### PR TITLE
Add AntreaNodeConfig validation webhook

### DIFF
--- a/build/charts/antrea/crds/antreanodeconfig.yaml
+++ b/build/charts/antrea/crds/antreanodeconfig.yaml
@@ -66,7 +66,6 @@ spec:
                         type: object
                         required:
                           - bridgeName
-                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
@@ -78,7 +77,6 @@ spec:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
-                            minItems: 1
                             maxItems: 8
                             x-kubernetes-list-type: map
                             x-kubernetes-list-map-keys:

--- a/build/charts/antrea/crds/antreanodeconfig.yaml
+++ b/build/charts/antrea/crds/antreanodeconfig.yaml
@@ -66,17 +66,23 @@ spec:
                         type: object
                         required:
                           - bridgeName
+                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            minLength: 1
                             maxLength: 15
                             pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            minItems: 1
                             maxItems: 8
+                            x-kubernetes-list-type: map
+                            x-kubernetes-list-map-keys:
+                              - name
                             items:
                               type: object
                               required:
@@ -94,6 +100,7 @@ spec:
                                     "200-300") allowed on this interface.
                                     If not specified, all VLANs are allowed.
                                   type: array
+                                  x-kubernetes-list-type: set
                                   items:
                                     type: string
                                     pattern: '^((?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])|(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])-(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4]))$'

--- a/build/charts/antrea/templates/webhooks/validating/crdvalidator.yaml
+++ b/build/charts/antrea/templates/webhooks/validating/crdvalidator.yaml
@@ -171,3 +171,18 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
     timeoutSeconds: 5
+  - name: "antreanodeconfigvalidator.antrea.io"
+    clientConfig:
+      service:
+        name: "antrea"
+        namespace: {{ .Release.Namespace }}
+        path: "/validate/antreanodeconfig"
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["crd.antrea.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["antreanodeconfigs"]
+        scope: "Cluster"
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -393,17 +393,23 @@ spec:
                         type: object
                         required:
                           - bridgeName
+                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            minLength: 1
                             maxLength: 15
                             pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            minItems: 1
                             maxItems: 8
+                            x-kubernetes-list-type: map
+                            x-kubernetes-list-map-keys:
+                              - name
                             items:
                               type: object
                               required:
@@ -421,6 +427,7 @@ spec:
                                     "200-300") allowed on this interface.
                                     If not specified, all VLANs are allowed.
                                   type: array
+                                  x-kubernetes-list-type: set
                                   items:
                                     type: string
                                     pattern: '^((?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])|(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])-(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4]))$'
@@ -6522,6 +6529,21 @@ webhooks:
         apiGroups: ["policy.networking.k8s.io"]
         apiVersions: ["v1alpha2"]
         resources: ["clusternetworkpolicies"]
+        scope: "Cluster"
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
+  - name: "antreanodeconfigvalidator.antrea.io"
+    clientConfig:
+      service:
+        name: "antrea"
+        namespace: kube-system
+        path: "/validate/antreanodeconfig"
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["crd.antrea.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["antreanodeconfigs"]
         scope: "Cluster"
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -393,7 +393,6 @@ spec:
                         type: object
                         required:
                           - bridgeName
-                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
@@ -405,7 +404,6 @@ spec:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
-                            minItems: 1
                             maxItems: 8
                             x-kubernetes-list-type: map
                             x-kubernetes-list-map-keys:

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -384,17 +384,23 @@ spec:
                         type: object
                         required:
                           - bridgeName
+                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            minLength: 1
                             maxLength: 15
                             pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            minItems: 1
                             maxItems: 8
+                            x-kubernetes-list-type: map
+                            x-kubernetes-list-map-keys:
+                              - name
                             items:
                               type: object
                               required:
@@ -412,6 +418,7 @@ spec:
                                     "200-300") allowed on this interface.
                                     If not specified, all VLANs are allowed.
                                   type: array
+                                  x-kubernetes-list-type: set
                                   items:
                                     type: string
                                     pattern: '^((?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])|(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])-(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4]))$'

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -384,7 +384,6 @@ spec:
                         type: object
                         required:
                           - bridgeName
-                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
@@ -396,7 +395,6 @@ spec:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
-                            minItems: 1
                             maxItems: 8
                             x-kubernetes-list-type: map
                             x-kubernetes-list-map-keys:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -389,17 +389,23 @@ spec:
                         type: object
                         required:
                           - bridgeName
+                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            minLength: 1
                             maxLength: 15
                             pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            minItems: 1
                             maxItems: 8
+                            x-kubernetes-list-type: map
+                            x-kubernetes-list-map-keys:
+                              - name
                             items:
                               type: object
                               required:
@@ -417,6 +423,7 @@ spec:
                                     "200-300") allowed on this interface.
                                     If not specified, all VLANs are allowed.
                                   type: array
+                                  x-kubernetes-list-type: set
                                   items:
                                     type: string
                                     pattern: '^((?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])|(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])-(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4]))$'
@@ -6519,6 +6526,21 @@ webhooks:
         apiGroups: ["policy.networking.k8s.io"]
         apiVersions: ["v1alpha2"]
         resources: ["clusternetworkpolicies"]
+        scope: "Cluster"
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
+  - name: "antreanodeconfigvalidator.antrea.io"
+    clientConfig:
+      service:
+        name: "antrea"
+        namespace: kube-system
+        path: "/validate/antreanodeconfig"
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["crd.antrea.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["antreanodeconfigs"]
         scope: "Cluster"
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -389,7 +389,6 @@ spec:
                         type: object
                         required:
                           - bridgeName
-                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
@@ -401,7 +400,6 @@ spec:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
-                            minItems: 1
                             maxItems: 8
                             x-kubernetes-list-type: map
                             x-kubernetes-list-map-keys:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -389,17 +389,23 @@ spec:
                         type: object
                         required:
                           - bridgeName
+                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            minLength: 1
                             maxLength: 15
                             pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            minItems: 1
                             maxItems: 8
+                            x-kubernetes-list-type: map
+                            x-kubernetes-list-map-keys:
+                              - name
                             items:
                               type: object
                               required:
@@ -417,6 +423,7 @@ spec:
                                     "200-300") allowed on this interface.
                                     If not specified, all VLANs are allowed.
                                   type: array
+                                  x-kubernetes-list-type: set
                                   items:
                                     type: string
                                     pattern: '^((?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])|(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])-(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4]))$'
@@ -6507,6 +6514,21 @@ webhooks:
         apiGroups: ["policy.networking.k8s.io"]
         apiVersions: ["v1alpha2"]
         resources: ["clusternetworkpolicies"]
+        scope: "Cluster"
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
+  - name: "antreanodeconfigvalidator.antrea.io"
+    clientConfig:
+      service:
+        name: "antrea"
+        namespace: kube-system
+        path: "/validate/antreanodeconfig"
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["crd.antrea.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["antreanodeconfigs"]
         scope: "Cluster"
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -389,7 +389,6 @@ spec:
                         type: object
                         required:
                           - bridgeName
-                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
@@ -401,7 +400,6 @@ spec:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
-                            minItems: 1
                             maxItems: 8
                             x-kubernetes-list-type: map
                             x-kubernetes-list-map-keys:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -389,7 +389,6 @@ spec:
                         type: object
                         required:
                           - bridgeName
-                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
@@ -401,7 +400,6 @@ spec:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
-                            minItems: 1
                             maxItems: 8
                             x-kubernetes-list-type: map
                             x-kubernetes-list-map-keys:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -389,17 +389,23 @@ spec:
                         type: object
                         required:
                           - bridgeName
+                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            minLength: 1
                             maxLength: 15
                             pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            minItems: 1
                             maxItems: 8
+                            x-kubernetes-list-type: map
+                            x-kubernetes-list-map-keys:
+                              - name
                             items:
                               type: object
                               required:
@@ -417,6 +423,7 @@ spec:
                                     "200-300") allowed on this interface.
                                     If not specified, all VLANs are allowed.
                                   type: array
+                                  x-kubernetes-list-type: set
                                   items:
                                     type: string
                                     pattern: '^((?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])|(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])-(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4]))$'
@@ -6566,6 +6573,21 @@ webhooks:
         apiGroups: ["policy.networking.k8s.io"]
         apiVersions: ["v1alpha2"]
         resources: ["clusternetworkpolicies"]
+        scope: "Cluster"
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
+  - name: "antreanodeconfigvalidator.antrea.io"
+    clientConfig:
+      service:
+        name: "antrea"
+        namespace: kube-system
+        path: "/validate/antreanodeconfig"
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["crd.antrea.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["antreanodeconfigs"]
         scope: "Cluster"
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -389,17 +389,23 @@ spec:
                         type: object
                         required:
                           - bridgeName
+                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            minLength: 1
                             maxLength: 15
                             pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            minItems: 1
                             maxItems: 8
+                            x-kubernetes-list-type: map
+                            x-kubernetes-list-map-keys:
+                              - name
                             items:
                               type: object
                               required:
@@ -417,6 +423,7 @@ spec:
                                     "200-300") allowed on this interface.
                                     If not specified, all VLANs are allowed.
                                   type: array
+                                  x-kubernetes-list-type: set
                                   items:
                                     type: string
                                     pattern: '^((?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])|(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4])-(?:[0-9]{1,3}|[1-3][0-9]{3}|40[0-8][0-9]|409[0-4]))$'
@@ -6507,6 +6514,21 @@ webhooks:
         apiGroups: ["policy.networking.k8s.io"]
         apiVersions: ["v1alpha2"]
         resources: ["clusternetworkpolicies"]
+        scope: "Cluster"
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
+  - name: "antreanodeconfigvalidator.antrea.io"
+    clientConfig:
+      service:
+        name: "antrea"
+        namespace: kube-system
+        path: "/validate/antreanodeconfig"
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["crd.antrea.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["antreanodeconfigs"]
         scope: "Cluster"
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -389,7 +389,6 @@ spec:
                         type: object
                         required:
                           - bridgeName
-                          - physicalInterfaces
                         properties:
                           bridgeName:
                             description: Name of the OVS bridge.
@@ -401,7 +400,6 @@ spec:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
-                            minItems: 1
                             maxItems: 8
                             x-kubernetes-list-type: map
                             x-kubernetes-list-map-keys:

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -117,6 +117,7 @@ var allowedPaths = []string{
 	"/validate/ippool",
 	"/validate/supportbundlecollection",
 	"/validate/traceflow",
+	"/validate/antreanodeconfig",
 	"/convert/clustergroup",
 	"/convert/ippool",
 }

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -619,9 +619,8 @@ type OVSBridgeConfig struct {
 	// +required
 	BridgeName string `json:"bridgeName"`
 	// PhysicalInterfaces is a list of physical interfaces to be connected to this bridge.
-	// At least one interface must be specified.
-	// +required
-	PhysicalInterfaces []OVSPhysicalInterfaceConfig `json:"physicalInterfaces"`
+	// +optional
+	PhysicalInterfaces []OVSPhysicalInterfaceConfig `json:"physicalInterfaces,omitempty"`
 	// EnableMulticastSnooping enables multicast snooping on the bridge, allowing the bridge
 	// to learn about multicast group memberships and forward multicast traffic only to ports
 	// that have interested receivers. When disabled, multicast traffic is flooded to all ports

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -619,8 +619,9 @@ type OVSBridgeConfig struct {
 	// +required
 	BridgeName string `json:"bridgeName"`
 	// PhysicalInterfaces is a list of physical interfaces to be connected to this bridge.
-	// +optional
-	PhysicalInterfaces []OVSPhysicalInterfaceConfig `json:"physicalInterfaces,omitempty"`
+	// At least one interface must be specified.
+	// +required
+	PhysicalInterfaces []OVSPhysicalInterfaceConfig `json:"physicalInterfaces"`
 	// EnableMulticastSnooping enables multicast snooping on the bridge, allowing the bridge
 	// to learn about multicast group memberships and forward multicast traffic only to ports
 	// that have interested receivers. When disabled, multicast traffic is flooded to all ports

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -63,6 +63,7 @@ import (
 	"antrea.io/antrea/v2/pkg/apiserver/registry/system/supportbundle"
 	"antrea.io/antrea/v2/pkg/apiserver/storage"
 	crdv1a2informers "antrea.io/antrea/v2/pkg/client/informers/externalversions/crd/v1alpha2"
+	"antrea.io/antrea/v2/pkg/controller/antreanodeconfig"
 	"antrea.io/antrea/v2/pkg/controller/egress"
 	"antrea.io/antrea/v2/pkg/controller/externalippool"
 	"antrea.io/antrea/v2/pkg/controller/ipam"
@@ -355,6 +356,8 @@ func installHandlers(c *ExtraConfig, s *genericapiserver.GenericAPIServer) {
 	if features.DefaultFeatureGate.Enabled(features.Traceflow) {
 		s.Handler.NonGoRestfulMux.HandleFunc("/validate/traceflow", webhook.HandlerForValidateFunc(c.traceflowController.Validate))
 	}
+
+	s.Handler.NonGoRestfulMux.HandleFunc("/validate/antreanodeconfig", webhook.HandlerForValidateFunc(antreanodeconfig.Validate))
 }
 
 func DefaultCAConfig() *certificate.CAConfig {

--- a/pkg/controller/antreanodeconfig/validate.go
+++ b/pkg/controller/antreanodeconfig/validate.go
@@ -92,42 +92,36 @@ func newAdmissionResponseForErr(err error) *admv1.AdmissionResponse {
 
 func parseVLANSpec(spec string) (vlanIDRange, error) {
 	spec = strings.TrimSpace(spec)
-	if idx := strings.IndexByte(spec, '-'); idx >= 0 {
-		startStr, endStr := spec[:idx], spec[idx+1:]
+	if startStr, endStr, ok := strings.Cut(spec, "-"); ok {
 		start, err := strconv.ParseUint(startStr, 10, 16)
 		if err != nil {
-			return vlanIDRange{}, fmt.Errorf("invalid VLAN range start %q: %v", startStr, err)
+			return vlanIDRange{}, fmt.Errorf("invalid VLAN range start %q: %w", startStr, err)
 		}
 		end, err := strconv.ParseUint(endStr, 10, 16)
 		if err != nil {
-			return vlanIDRange{}, fmt.Errorf("invalid VLAN range end %q: %v", endStr, err)
+			return vlanIDRange{}, fmt.Errorf("invalid VLAN range end %q: %w", endStr, err)
 		}
 		return vlanIDRange{start: uint16(start), end: uint16(end)}, nil
 	}
 
 	v, err := strconv.ParseUint(spec, 10, 16)
 	if err != nil {
-		return vlanIDRange{}, fmt.Errorf("invalid VLAN ID %q: %v", spec, err)
+		return vlanIDRange{}, fmt.Errorf("invalid VLAN ID %q: %w", spec, err)
 	}
 	return vlanIDRange{start: uint16(v), end: uint16(v)}, nil
 }
 
 func validateVLANSpecs(specs []string) error {
-	for _, rawSpec := range specs {
-		spec := strings.TrimSpace(rawSpec)
+	for _, spec := range specs {
 		r, err := parseVLANSpec(spec)
 		if err != nil {
 			return err
 		}
-		if strings.Contains(spec, "-") {
-			if r.start > r.end {
-				return fmt.Errorf("VLAN range start %d is greater than end %d", r.start, r.end)
-			}
-			if r.end > maxVLANID {
-				return fmt.Errorf("VLAN range end %d is greater than the maximum VLAN ID %d", r.end, maxVLANID)
-			}
-		} else if r.start > maxVLANID {
-			return fmt.Errorf("VLAN ID %d is greater than the maximum VLAN ID %d", r.start, maxVLANID)
+		if r.start > r.end {
+			return fmt.Errorf("VLAN range start %d is greater than end %d", r.start, r.end)
+		}
+		if r.end > maxVLANID {
+			return fmt.Errorf("VLAN ID %d is greater than the maximum VLAN ID %d", r.end, maxVLANID)
 		}
 	}
 	return nil

--- a/pkg/controller/antreanodeconfig/validate.go
+++ b/pkg/controller/antreanodeconfig/validate.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package antreanodeconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	admv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	crdv1alpha1 "antrea.io/antrea/v2/pkg/apis/crd/v1alpha1"
+)
+
+const maxVLANID = 4094
+
+type vlanIDRange struct {
+	start uint16
+	end   uint16
+}
+
+// Validate validates AntreaNodeConfig admission requests.
+func Validate(review *admv1.AdmissionReview) *admv1.AdmissionResponse {
+	var result *metav1.Status
+	var msg string
+	allowed := true
+
+	klog.V(2).InfoS("Validating AntreaNodeConfig", "request", review.Request)
+	var newObj crdv1alpha1.AntreaNodeConfig
+	if review.Request.Object.Raw != nil {
+		if err := json.Unmarshal(review.Request.Object.Raw, &newObj); err != nil {
+			klog.ErrorS(err, "Error de-serializing current AntreaNodeConfig")
+			return newAdmissionResponseForErr(err)
+		}
+	}
+
+	switch review.Request.Operation {
+	case admv1.Create:
+		klog.V(2).InfoS("Validating CREATE request for AntreaNodeConfig", "name", newObj.Name)
+		if err := validateAntreaNodeConfig(&newObj); err != nil {
+			msg = err.Error()
+			allowed = false
+		}
+	case admv1.Update:
+		klog.V(2).InfoS("Validating UPDATE request for AntreaNodeConfig", "name", newObj.Name)
+		if err := validateAntreaNodeConfig(&newObj); err != nil {
+			msg = err.Error()
+			allowed = false
+		}
+	case admv1.Delete:
+		// This should not happen with the webhook configuration included in Antrea manifests.
+		klog.V(2).InfoS("Validating DELETE request for AntreaNodeConfig", "name", newObj.Name)
+	}
+
+	if msg != "" {
+		result = &metav1.Status{Message: msg}
+	}
+	return &admv1.AdmissionResponse{
+		Allowed: allowed,
+		Result:  result,
+	}
+}
+
+func newAdmissionResponseForErr(err error) *admv1.AdmissionResponse {
+	return &admv1.AdmissionResponse{
+		Result: &metav1.Status{
+			Message: err.Error(),
+		},
+	}
+}
+
+func parseVLANSpec(spec string) (vlanIDRange, error) {
+	spec = strings.TrimSpace(spec)
+	if idx := strings.IndexByte(spec, '-'); idx >= 0 {
+		startStr, endStr := spec[:idx], spec[idx+1:]
+		start, err := strconv.ParseUint(startStr, 10, 16)
+		if err != nil {
+			return vlanIDRange{}, fmt.Errorf("invalid VLAN range start %q: %v", startStr, err)
+		}
+		end, err := strconv.ParseUint(endStr, 10, 16)
+		if err != nil {
+			return vlanIDRange{}, fmt.Errorf("invalid VLAN range end %q: %v", endStr, err)
+		}
+		return vlanIDRange{start: uint16(start), end: uint16(end)}, nil
+	}
+
+	v, err := strconv.ParseUint(spec, 10, 16)
+	if err != nil {
+		return vlanIDRange{}, fmt.Errorf("invalid VLAN ID %q: %v", spec, err)
+	}
+	return vlanIDRange{start: uint16(v), end: uint16(v)}, nil
+}
+
+func validateVLANSpecs(specs []string) error {
+	seen := make(map[uint16]string)
+	for _, rawSpec := range specs {
+		spec := strings.TrimSpace(rawSpec)
+		r, err := parseVLANSpec(spec)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(spec, "-") {
+			if r.start > r.end {
+				return fmt.Errorf("VLAN range start %d is greater than end %d", r.start, r.end)
+			}
+			if r.end > maxVLANID {
+				return fmt.Errorf("VLAN range end %d is greater than maximum VLAN ID %d", r.end, maxVLANID)
+			}
+		} else if r.start > maxVLANID {
+			return fmt.Errorf("VLAN ID %d is greater than maximum VLAN ID %d", r.start, maxVLANID)
+		}
+		for id := r.start; id <= r.end; id++ {
+			if prev, ok := seen[id]; ok {
+				return fmt.Errorf("VLAN ID %d is specified more than once in %q and %q", id, prev, spec)
+			}
+			seen[id] = spec
+		}
+	}
+	return nil
+}
+
+func validateAntreaNodeConfig(anc *crdv1alpha1.AntreaNodeConfig) error {
+	if anc.Spec.SecondaryNetwork == nil {
+		return nil
+	}
+	for bridgeIdx, bridge := range anc.Spec.SecondaryNetwork.OVSBridges {
+		for ifaceIdx, iface := range bridge.PhysicalInterfaces {
+			if len(iface.AllowedVLANs) == 0 {
+				continue
+			}
+			if err := validateVLANSpecs(iface.AllowedVLANs); err != nil {
+				return fmt.Errorf("spec.secondaryNetwork.ovsBridges[%d].physicalInterfaces[%d].allowedVLANs is invalid: %v",
+					bridgeIdx, ifaceIdx, err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/controller/antreanodeconfig/validate.go
+++ b/pkg/controller/antreanodeconfig/validate.go
@@ -36,6 +36,10 @@ type vlanIDRange struct {
 
 // Validate validates AntreaNodeConfig admission requests.
 func Validate(review *admv1.AdmissionReview) *admv1.AdmissionResponse {
+	if review == nil || review.Request == nil {
+		return newAdmissionResponseForErr(fmt.Errorf("invalid AdmissionReview: nil request"))
+	}
+
 	var result *metav1.Status
 	var msg string
 	allowed := true
@@ -47,6 +51,9 @@ func Validate(review *admv1.AdmissionReview) *admv1.AdmissionResponse {
 			klog.ErrorS(err, "Error de-serializing current AntreaNodeConfig")
 			return newAdmissionResponseForErr(err)
 		}
+	}
+	if review.Request.Operation != admv1.Delete && review.Request.Object.Raw == nil {
+		return newAdmissionResponseForErr(fmt.Errorf("missing object in AdmissionReview"))
 	}
 
 	switch review.Request.Operation {
@@ -64,7 +71,6 @@ func Validate(review *admv1.AdmissionReview) *admv1.AdmissionResponse {
 		}
 	case admv1.Delete:
 		// This should not happen with the webhook configuration included in Antrea manifests.
-		klog.V(2).InfoS("Validating DELETE request for AntreaNodeConfig", "name", newObj.Name)
 	}
 
 	if msg != "" {
@@ -107,7 +113,6 @@ func parseVLANSpec(spec string) (vlanIDRange, error) {
 }
 
 func validateVLANSpecs(specs []string) error {
-	seen := make(map[uint16]string)
 	for _, rawSpec := range specs {
 		spec := strings.TrimSpace(rawSpec)
 		r, err := parseVLANSpec(spec)
@@ -119,16 +124,10 @@ func validateVLANSpecs(specs []string) error {
 				return fmt.Errorf("VLAN range start %d is greater than end %d", r.start, r.end)
 			}
 			if r.end > maxVLANID {
-				return fmt.Errorf("VLAN range end %d is greater than maximum VLAN ID %d", r.end, maxVLANID)
+				return fmt.Errorf("VLAN range end %d is greater than the maximum VLAN ID %d", r.end, maxVLANID)
 			}
 		} else if r.start > maxVLANID {
-			return fmt.Errorf("VLAN ID %d is greater than maximum VLAN ID %d", r.start, maxVLANID)
-		}
-		for id := r.start; id <= r.end; id++ {
-			if prev, ok := seen[id]; ok {
-				return fmt.Errorf("VLAN ID %d is specified more than once in %q and %q", id, prev, spec)
-			}
-			seen[id] = spec
+			return fmt.Errorf("VLAN ID %d is greater than the maximum VLAN ID %d", r.start, maxVLANID)
 		}
 	}
 	return nil

--- a/pkg/controller/antreanodeconfig/validate_test.go
+++ b/pkg/controller/antreanodeconfig/validate_test.go
@@ -86,7 +86,7 @@ func TestValidate(t *testing.T) {
 			expectedResponse: &admv1.AdmissionResponse{
 				Allowed: false,
 				Result: &metav1.Status{
-					Message: "spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN ID 4095 is greater than maximum VLAN ID 4094",
+					Message: "spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN ID 4095 is greater than the maximum VLAN ID 4094",
 				},
 			},
 		},
@@ -97,30 +97,16 @@ func TestValidate(t *testing.T) {
 			expectedResponse: &admv1.AdmissionResponse{
 				Allowed: false,
 				Result: &metav1.Status{
-					Message: "spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN range end 4095 is greater than maximum VLAN ID 4094",
+					Message: "spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN range end 4095 is greater than the maximum VLAN ID 4094",
 				},
 			},
 		},
 		{
-			name:      "duplicate VLAN ID",
-			operation: admv1.Create,
-			anc:       newAntreaNodeConfig([]string{"100", "100"}),
-			expectedResponse: &admv1.AdmissionResponse{
-				Allowed: false,
-				Result: &metav1.Status{
-					Message: `spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN ID 100 is specified more than once in "100" and "100"`,
-				},
-			},
-		},
-		{
-			name:      "overlapping VLAN range",
+			name:      "overlapping VLAN ranges are allowed (OVSDB deduplicates)",
 			operation: admv1.Update,
 			anc:       newAntreaNodeConfig([]string{"100-200", "150"}),
 			expectedResponse: &admv1.AdmissionResponse{
-				Allowed: false,
-				Result: &metav1.Status{
-					Message: `spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN ID 150 is specified more than once in "100-200" and "150"`,
-				},
+				Allowed: true,
 			},
 		},
 		{
@@ -138,6 +124,24 @@ func TestValidate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "anc"},
 				Spec: crdv1alpha1.AntreaNodeConfigSpec{
 					NodeSelector: metav1.LabelSelector{MatchLabels: map[string]string{"role": "worker"}},
+				},
+			},
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		{
+			name:      "bridge without physical interfaces allowed",
+			operation: admv1.Create,
+			anc: &crdv1alpha1.AntreaNodeConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "anc"},
+				Spec: crdv1alpha1.AntreaNodeConfigSpec{
+					NodeSelector: metav1.LabelSelector{MatchLabels: map[string]string{"role": "worker"}},
+					SecondaryNetwork: &crdv1alpha1.SecondaryNetworkConfig{
+						OVSBridges: []crdv1alpha1.OVSBridgeConfig{
+							{BridgeName: "br-secondary"},
+						},
+					},
 				},
 			},
 			expectedResponse: &admv1.AdmissionResponse{

--- a/pkg/controller/antreanodeconfig/validate_test.go
+++ b/pkg/controller/antreanodeconfig/validate_test.go
@@ -97,7 +97,7 @@ func TestValidate(t *testing.T) {
 			expectedResponse: &admv1.AdmissionResponse{
 				Allowed: false,
 				Result: &metav1.Status{
-					Message: "spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN range end 4095 is greater than the maximum VLAN ID 4094",
+					Message: "spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN ID 4095 is greater than the maximum VLAN ID 4094",
 				},
 			},
 		},

--- a/pkg/controller/antreanodeconfig/validate_test.go
+++ b/pkg/controller/antreanodeconfig/validate_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package antreanodeconfig
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	crdv1alpha1 "antrea.io/antrea/v2/pkg/apis/crd/v1alpha1"
+)
+
+func marshal(t *testing.T, object runtime.Object) []byte {
+	t.Helper()
+	raw, err := json.Marshal(object)
+	require.NoError(t, err)
+	return raw
+}
+
+func newAntreaNodeConfig(allowedVLANs []string) *crdv1alpha1.AntreaNodeConfig {
+	return &crdv1alpha1.AntreaNodeConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "anc"},
+		Spec: crdv1alpha1.AntreaNodeConfigSpec{
+			NodeSelector: metav1.LabelSelector{MatchLabels: map[string]string{"role": "worker"}},
+			SecondaryNetwork: &crdv1alpha1.SecondaryNetworkConfig{
+				OVSBridges: []crdv1alpha1.OVSBridgeConfig{
+					{
+						BridgeName: "br-secondary",
+						PhysicalInterfaces: []crdv1alpha1.OVSPhysicalInterfaceConfig{
+							{Name: "eth1", AllowedVLANs: allowedVLANs},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name             string
+		operation        admv1.Operation
+		anc              *crdv1alpha1.AntreaNodeConfig
+		expectedResponse *admv1.AdmissionResponse
+	}{
+		{
+			name:      "valid VLAN range",
+			operation: admv1.Create,
+			anc:       newAntreaNodeConfig([]string{"100", "200-300"}),
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		{
+			name:      "inverted VLAN range",
+			operation: admv1.Create,
+			anc:       newAntreaNodeConfig([]string{"300-200"}),
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN range start 300 is greater than end 200",
+				},
+			},
+		},
+		{
+			name:      "single VLAN above maximum",
+			operation: admv1.Create,
+			anc:       newAntreaNodeConfig([]string{"4095"}),
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN ID 4095 is greater than maximum VLAN ID 4094",
+				},
+			},
+		},
+		{
+			name:      "range end above maximum",
+			operation: admv1.Create,
+			anc:       newAntreaNodeConfig([]string{"4094-4095"}),
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN range end 4095 is greater than maximum VLAN ID 4094",
+				},
+			},
+		},
+		{
+			name:      "duplicate VLAN ID",
+			operation: admv1.Create,
+			anc:       newAntreaNodeConfig([]string{"100", "100"}),
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: `spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN ID 100 is specified more than once in "100" and "100"`,
+				},
+			},
+		},
+		{
+			name:      "overlapping VLAN range",
+			operation: admv1.Update,
+			anc:       newAntreaNodeConfig([]string{"100-200", "150"}),
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: `spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN ID 150 is specified more than once in "100-200" and "150"`,
+				},
+			},
+		},
+		{
+			name:      "delete allowed",
+			operation: admv1.Delete,
+			anc:       newAntreaNodeConfig([]string{"300-200"}),
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		{
+			name:      "empty secondary network allowed",
+			operation: admv1.Create,
+			anc: &crdv1alpha1.AntreaNodeConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "anc"},
+				Spec: crdv1alpha1.AntreaNodeConfigSpec{
+					NodeSelector: metav1.LabelSelector{MatchLabels: map[string]string{"role": "worker"}},
+				},
+			},
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			review := &admv1.AdmissionReview{
+				Request: &admv1.AdmissionRequest{
+					Name:      tt.anc.Name,
+					Operation: tt.operation,
+					Object:    runtime.RawExtension{Raw: marshal(t, tt.anc)},
+				},
+			}
+			assert.Equal(t, tt.expectedResponse, Validate(review))
+		})
+	}
+}


### PR DESCRIPTION
Validate AntreaNodeConfig create and update requests with a new
controller webhook. Reject invalid VLAN ranges, and values above
the OVS-supported maximum.

Also tighten the CRD schema for secondary OVS bridge configuration
and publish the validating webhook in Helm and generated manifests.