### PR TITLE
Deprecate the 'destinationClusterIP' IE for 'destinationServiceIP'

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,12 @@ linters:
         text: "SA1019: (v1|corev1).EndpointSubset is deprecated"
       - linters:
           - staticcheck
+        # DestinationClusterIp is deprecated in favor of DestinationServiceIp,
+        # but we still need to populate it for backward compatibility until it
+        # is removed.
+        text: "SA1019: .*\\.DestinationClusterIp is deprecated"
+      - linters:
+          - staticcheck
         # NewSimpleClientset is marked as deprecated, with the documentation
         # suggesting NewClientset as a direct replacement. However, NewClientset
         # is only available when apply configurations are generated (e.g. via

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -314,7 +314,7 @@ COMMON_IMAGES_LIST=("registry.k8s.io/e2e-test-images/agnhost:2.40" \
                     "antrea/nginx:1.21.6-alpine" \
                     "antrea/toolbox:1.5-1")
 
-FLOW_VISIBILITY_IMAGE_LIST=("antrea/ipfix-collector:v0.16.0" \
+FLOW_VISIBILITY_IMAGE_LIST=("antrea/ipfix-collector:v0.17.0" \
                             "antrea/clickhouse-operator:0.21.0" \
                             "antrea/metrics-exporter:0.21.0" \
                             "antrea/clickhouse-server:23.4")

--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -732,6 +732,7 @@ $ antctl get flowrecords --srcip 10.10.0.1 --srcport 50497 -o json
     "destinationNodeName": "k8s-node-worker-1",
     "destinationPodName": "coredns-78fcd69978-x2twv",
     "destinationPodNamespace": "kube-system",
+    "destinationServiceIPv4": "0.0.0.0",
     "destinationServicePort": 0,
     "destinationServicePortName": "",
     "destinationTransportPort": 53,

--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -188,30 +188,32 @@ Flow Exporter are listed below:
 
 #### IEs from Antrea IE Registry
 
-| IPFIX Information Element        | Field ID | Type        | Description |
-|----------------------------------|----------|-------------|-------------|
-| sourcePodNamespace               | 100      | string      |             |
-| sourcePodName                    | 101      | string      |             |
-| destinationPodNamespace          | 102      | string      |             |
-| destinationPodName               | 103      | string      |             |
-| sourceNodeName                   | 104      | string      |             |
-| destinationNodeName              | 105      | string      |             |
-| destinationClusterIPv4           | 106      | ipv4Address |             |
-| destinationClusterIPv6           | 107      | ipv6Address |             |
-| destinationServicePort           | 108      | unsigned16  |             |
-| destinationServicePortName       | 109      | string      |             |
-| ingressNetworkPolicyName         | 110      | string      | Name of the ingress network policy applied to the destination Pod for this flow. |
-| ingressNetworkPolicyNamespace    | 111      | string      | Namespace of the ingress network policy applied to the destination Pod for this flow. |
-| ingressNetworkPolicyType         | 115      | unsigned8   | 1 stands for Kubernetes Network Policy. 2 stands for Antrea Network Policy. 3 stands for Antrea Cluster Network Policy. |
-| ingressNetworkPolicyRuleName     | 141      | string      | Name of the ingress network policy Rule applied to the destination Pod for this flow. |
-| egressNetworkPolicyName          | 112      | string      | Name of the egress network policy applied to the source Pod for this flow. |
-| egressNetworkPolicyNamespace     | 113      | string      | Namespace of the egress network policy applied to the source Pod for this flow. |
-| egressNetworkPolicyType          | 118      | unsigned8   |             |
-| egressNetworkPolicyRuleName      | 142      | string      | Name of the egress network policy rule applied to the source Pod for this flow. |
-| ingressNetworkPolicyRuleAction   | 139      | unsigned8   | 1 stands for Allow. 2 stands for Drop. 3 stands for Reject. |
-| egressNetworkPolicyRuleAction    | 140      | unsigned8   |             |
-| tcpState                         | 136      | string      | The state of the TCP connection. The states are: LISTEN, SYN-SENT, SYN-RECEIVED, ESTABLISHED, FIN-WAIT-1, FIN-WAIT-2, CLOSE-WAIT, CLOSING, LAST-ACK, TIME-WAIT, and CLOSED. |
-| flowType                         | 137      | unsigned8   | 1 stands for Intra-Node. 2 stands for Inter-Node. 3 stands for To External. 4 stands for From External. |
+| IPFIX Information Element      | Field ID | Type        | Description                                                                                                                                                                 |
+|--------------------------------|----------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| sourcePodNamespace             | 100      | string      |                                                                                                                                                                             |
+| sourcePodName                  | 101      | string      |                                                                                                                                                                             |
+| destinationPodNamespace        | 102      | string      |                                                                                                                                                                             |
+| destinationPodName             | 103      | string      |                                                                                                                                                                             |
+| sourceNodeName                 | 104      | string      |                                                                                                                                                                             |
+| destinationNodeName            | 105      | string      |                                                                                                                                                                             |
+| destinationClusterIPv4         | 106      | ipv4Address | DEPRECATED in favor of destinationServiceIPv4.                                                                                                                              |
+| destinationClusterIPv6         | 107      | ipv6Address | DEPRECATED in favor of destinationServiceIPv6.                                                                                                                              |
+| destinationServiceIPv4         | 168      | ipv4Address |                                                                                                                                                                             |
+| destinationServiceIPv6         | 169      | ipv6Address |                                                                                                                                                                             |
+| destinationServicePort         | 108      | unsigned16  |                                                                                                                                                                             |
+| destinationServicePortName     | 109      | string      |                                                                                                                                                                             |
+| ingressNetworkPolicyName       | 110      | string      | Name of the ingress network policy applied to the destination Pod for this flow.                                                                                            |
+| ingressNetworkPolicyNamespace  | 111      | string      | Namespace of the ingress network policy applied to the destination Pod for this flow.                                                                                       |
+| ingressNetworkPolicyType       | 115      | unsigned8   | 1 stands for Kubernetes Network Policy. 2 stands for Antrea Network Policy. 3 stands for Antrea Cluster Network Policy.                                                     |
+| ingressNetworkPolicyRuleName   | 141      | string      | Name of the ingress network policy Rule applied to the destination Pod for this flow.                                                                                       |
+| egressNetworkPolicyName        | 112      | string      | Name of the egress network policy applied to the source Pod for this flow.                                                                                                  |
+| egressNetworkPolicyNamespace   | 113      | string      | Namespace of the egress network policy applied to the source Pod for this flow.                                                                                             |
+| egressNetworkPolicyType        | 118      | unsigned8   |                                                                                                                                                                             |
+| egressNetworkPolicyRuleName    | 142      | string      | Name of the egress network policy rule applied to the source Pod for this flow.                                                                                             |
+| ingressNetworkPolicyRuleAction | 139      | unsigned8   | 1 stands for Allow. 2 stands for Drop. 3 stands for Reject.                                                                                                                 |
+| egressNetworkPolicyRuleAction  | 140      | unsigned8   |                                                                                                                                                                             |
+| tcpState                       | 136      | string      | The state of the TCP connection. The states are: LISTEN, SYN-SENT, SYN-RECEIVED, ESTABLISHED, FIN-WAIT-1, FIN-WAIT-2, CLOSE-WAIT, CLOSING, LAST-ACK, TIME-WAIT, and CLOSED. |
+| flowType                       | 137      | unsigned8   | 1 stands for Intra-Node. 2 stands for Inter-Node. 3 stands for To External. 4 stands for From External.                                                                     |
 
 ### Supported Capabilities
 

--- a/pkg/agent/flowexporter/exporter/ipfix.go
+++ b/pkg/agent/flowexporter/exporter/ipfix.go
@@ -344,7 +344,7 @@ func (e *ipfixExporter) addConnToSet(conn *connection.Connection) error {
 			} else {
 				ie.SetStringValue("")
 			}
-		case "destinationClusterIPv4":
+		case "destinationClusterIPv4", "destinationServiceIPv4":
 			if conn.DestinationServicePortName != "" {
 				ie.SetIPAddressValue(conn.OriginalDestinationAddress.AsSlice())
 			} else {
@@ -353,7 +353,7 @@ func (e *ipfixExporter) addConnToSet(conn *connection.Connection) error {
 				// this dummy IP address.
 				ie.SetIPAddressValue(net.IPv4zero)
 			}
-		case "destinationClusterIPv6":
+		case "destinationClusterIPv6", "destinationServiceIPv6":
 			if conn.DestinationServicePortName != "" {
 				ie.SetIPAddressValue(conn.OriginalDestinationAddress.AsSlice())
 			} else {
@@ -398,18 +398,6 @@ func (e *ipfixExporter) addConnToSet(conn *connection.Connection) error {
 			ie.SetStringValue(conn.EgressIP)
 		case "egressNodeName":
 			ie.SetStringValue(conn.EgressNodeName)
-		case "destinationServiceIPv4":
-			if conn.DestinationServicePortName != "" {
-				ie.SetIPAddressValue(conn.OriginalDestinationAddress.AsSlice())
-			} else {
-				ie.SetIPAddressValue(net.IPv4zero)
-			}
-		case "destinationServiceIPv6":
-			if conn.DestinationServicePortName != "" {
-				ie.SetIPAddressValue(conn.OriginalDestinationAddress.AsSlice())
-			} else {
-				ie.SetIPAddressValue(net.IPv6zero)
-			}
 		case "proxySnatIPv4":
 			if conn.ProxySnatIP.IsValid() {
 				ie.SetIPAddressValue(conn.ProxySnatIP.AsSlice())

--- a/pkg/agent/flowexporter/exporter/ipfix_test.go
+++ b/pkg/agent/flowexporter/exporter/ipfix_test.go
@@ -337,9 +337,9 @@ func getElemList(ianaIE []string, antreaIE []string) []ipfixentities.InfoElement
 			ie.SetUnsigned8Value(uint8(0))
 		case "sourceIPv4Address", "destinationIPv4Address", "sourceIPv6Address", "destinationIPv6Address":
 			ie.SetIPAddressValue(net.ParseIP(""))
-		case "destinationClusterIPv4":
+		case "destinationClusterIPv4", "destinationServiceIPv4":
 			ie.SetIPAddressValue(net.IP{0, 0, 0, 0})
-		case "destinationClusterIPv6":
+		case "destinationClusterIPv6", "destinationServiceIPv6":
 			ie.SetIPAddressValue(net.ParseIP("::"))
 		case "sourceTransportPort", "destinationTransportPort", "destinationServicePort":
 			ie.SetUnsigned16Value(uint16(0))

--- a/pkg/apis/flow/v1alpha1/flow.pb.go
+++ b/pkg/apis/flow/v1alpha1/flow.pb.go
@@ -730,20 +730,21 @@ func (x *Labels) GetLabels() map[string]string {
 }
 
 type Kubernetes struct {
-	state                          protoimpl.MessageState  `protogen:"open.v1"`
-	FlowType                       FlowType                `protobuf:"varint,1,opt,name=flow_type,json=flowType,proto3,enum=antrea_io.antrea.pkg.apis.flow.v1alpha1.FlowType" json:"flow_type,omitempty"`
-	SourcePodNamespace             string                  `protobuf:"bytes,2,opt,name=source_pod_namespace,json=sourcePodNamespace,proto3" json:"source_pod_namespace,omitempty"`
-	SourcePodName                  string                  `protobuf:"bytes,3,opt,name=source_pod_name,json=sourcePodName,proto3" json:"source_pod_name,omitempty"`
-	SourcePodUid                   string                  `protobuf:"bytes,4,opt,name=source_pod_uid,json=sourcePodUid,proto3" json:"source_pod_uid,omitempty"`
-	SourcePodLabels                *Labels                 `protobuf:"bytes,5,opt,name=source_pod_labels,json=sourcePodLabels,proto3" json:"source_pod_labels,omitempty"`
-	SourceNodeName                 string                  `protobuf:"bytes,6,opt,name=source_node_name,json=sourceNodeName,proto3" json:"source_node_name,omitempty"`
-	SourceNodeUid                  string                  `protobuf:"bytes,7,opt,name=source_node_uid,json=sourceNodeUid,proto3" json:"source_node_uid,omitempty"`
-	DestinationPodNamespace        string                  `protobuf:"bytes,8,opt,name=destination_pod_namespace,json=destinationPodNamespace,proto3" json:"destination_pod_namespace,omitempty"`
-	DestinationPodName             string                  `protobuf:"bytes,9,opt,name=destination_pod_name,json=destinationPodName,proto3" json:"destination_pod_name,omitempty"`
-	DestinationPodUid              string                  `protobuf:"bytes,10,opt,name=destination_pod_uid,json=destinationPodUid,proto3" json:"destination_pod_uid,omitempty"`
-	DestinationPodLabels           *Labels                 `protobuf:"bytes,11,opt,name=destination_pod_labels,json=destinationPodLabels,proto3" json:"destination_pod_labels,omitempty"`
-	DestinationNodeName            string                  `protobuf:"bytes,12,opt,name=destination_node_name,json=destinationNodeName,proto3" json:"destination_node_name,omitempty"`
-	DestinationNodeUid             string                  `protobuf:"bytes,13,opt,name=destination_node_uid,json=destinationNodeUid,proto3" json:"destination_node_uid,omitempty"`
+	state                   protoimpl.MessageState `protogen:"open.v1"`
+	FlowType                FlowType               `protobuf:"varint,1,opt,name=flow_type,json=flowType,proto3,enum=antrea_io.antrea.pkg.apis.flow.v1alpha1.FlowType" json:"flow_type,omitempty"`
+	SourcePodNamespace      string                 `protobuf:"bytes,2,opt,name=source_pod_namespace,json=sourcePodNamespace,proto3" json:"source_pod_namespace,omitempty"`
+	SourcePodName           string                 `protobuf:"bytes,3,opt,name=source_pod_name,json=sourcePodName,proto3" json:"source_pod_name,omitempty"`
+	SourcePodUid            string                 `protobuf:"bytes,4,opt,name=source_pod_uid,json=sourcePodUid,proto3" json:"source_pod_uid,omitempty"`
+	SourcePodLabels         *Labels                `protobuf:"bytes,5,opt,name=source_pod_labels,json=sourcePodLabels,proto3" json:"source_pod_labels,omitempty"`
+	SourceNodeName          string                 `protobuf:"bytes,6,opt,name=source_node_name,json=sourceNodeName,proto3" json:"source_node_name,omitempty"`
+	SourceNodeUid           string                 `protobuf:"bytes,7,opt,name=source_node_uid,json=sourceNodeUid,proto3" json:"source_node_uid,omitempty"`
+	DestinationPodNamespace string                 `protobuf:"bytes,8,opt,name=destination_pod_namespace,json=destinationPodNamespace,proto3" json:"destination_pod_namespace,omitempty"`
+	DestinationPodName      string                 `protobuf:"bytes,9,opt,name=destination_pod_name,json=destinationPodName,proto3" json:"destination_pod_name,omitempty"`
+	DestinationPodUid       string                 `protobuf:"bytes,10,opt,name=destination_pod_uid,json=destinationPodUid,proto3" json:"destination_pod_uid,omitempty"`
+	DestinationPodLabels    *Labels                `protobuf:"bytes,11,opt,name=destination_pod_labels,json=destinationPodLabels,proto3" json:"destination_pod_labels,omitempty"`
+	DestinationNodeName     string                 `protobuf:"bytes,12,opt,name=destination_node_name,json=destinationNodeName,proto3" json:"destination_node_name,omitempty"`
+	DestinationNodeUid      string                 `protobuf:"bytes,13,opt,name=destination_node_uid,json=destinationNodeUid,proto3" json:"destination_node_uid,omitempty"`
+	// Deprecated: Marked as deprecated in pkg/apis/flow/v1alpha1/flow.proto.
 	DestinationClusterIp           []byte                  `protobuf:"bytes,14,opt,name=destination_cluster_ip,json=destinationClusterIp,proto3" json:"destination_cluster_ip,omitempty"`
 	DestinationServicePort         uint32                  `protobuf:"varint,15,opt,name=destination_service_port,json=destinationServicePort,proto3" json:"destination_service_port,omitempty"`
 	DestinationServicePortName     string                  `protobuf:"bytes,16,opt,name=destination_service_port_name,json=destinationServicePortName,proto3" json:"destination_service_port_name,omitempty"`
@@ -891,6 +892,7 @@ func (x *Kubernetes) GetDestinationNodeUid() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in pkg/apis/flow/v1alpha1/flow.proto.
 func (x *Kubernetes) GetDestinationClusterIp() []byte {
 	if x != nil {
 		return x.DestinationClusterIp
@@ -1426,7 +1428,7 @@ const file_pkg_apis_flow_v1alpha1_flow_proto_rawDesc = "" +
 	"\x06labels\x18\x01 \x03(\v2;.antrea_io.antrea.pkg.apis.flow.v1alpha1.Labels.LabelsEntryR\x06labels\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe8\x11\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xec\x11\n" +
 	"\n" +
 	"Kubernetes\x12N\n" +
 	"\tflow_type\x18\x01 \x01(\x0e21.antrea_io.antrea.pkg.apis.flow.v1alpha1.FlowTypeR\bflowType\x120\n" +
@@ -1442,8 +1444,8 @@ const file_pkg_apis_flow_v1alpha1_flow_proto_rawDesc = "" +
 	" \x01(\tR\x11destinationPodUid\x12e\n" +
 	"\x16destination_pod_labels\x18\v \x01(\v2/.antrea_io.antrea.pkg.apis.flow.v1alpha1.LabelsR\x14destinationPodLabels\x122\n" +
 	"\x15destination_node_name\x18\f \x01(\tR\x13destinationNodeName\x120\n" +
-	"\x14destination_node_uid\x18\r \x01(\tR\x12destinationNodeUid\x124\n" +
-	"\x16destination_cluster_ip\x18\x0e \x01(\fR\x14destinationClusterIp\x128\n" +
+	"\x14destination_node_uid\x18\r \x01(\tR\x12destinationNodeUid\x128\n" +
+	"\x16destination_cluster_ip\x18\x0e \x01(\fB\x02\x18\x01R\x14destinationClusterIp\x128\n" +
 	"\x18destination_service_port\x18\x0f \x01(\rR\x16destinationServicePort\x12A\n" +
 	"\x1ddestination_service_port_name\x18\x10 \x01(\tR\x1adestinationServicePortName\x126\n" +
 	"\x17destination_service_uid\x18\x11 \x01(\tR\x15destinationServiceUid\x12y\n" +

--- a/pkg/apis/flow/v1alpha1/flow.proto
+++ b/pkg/apis/flow/v1alpha1/flow.proto
@@ -117,7 +117,7 @@ message Kubernetes {
   string destination_node_name = 12;
   string destination_node_uid = 13;
 
-  bytes destination_cluster_ip = 14;
+  bytes destination_cluster_ip = 14 [deprecated = true];
   uint32 destination_service_port = 15;
   string destination_service_port_name = 16;
   string destination_service_uid = 17;

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
@@ -63,6 +63,7 @@ const (
                    destinationPodNamespace,
                    destinationNodeName,
                    destinationClusterIP,
+                   destinationServiceIP,
                    destinationServicePort,
                    destinationServicePortName,
                    ingressNetworkPolicyName,
@@ -89,9 +90,9 @@ const (
                    egressName,
                    egressIP,
                    egressNodeName)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                           ?, ?, ?, ?, ?)`
+                           ?, ?, ?, ?)`
 )
 
 // PrepareClickHouseConnection is used for unit testing
@@ -306,6 +307,7 @@ func (ch *ClickHouseExportProcess) batchCommitAll(ctx context.Context) (int, err
 			record.DestinationPodNamespace,
 			record.DestinationNodeName,
 			record.DestinationClusterIP,
+			record.DestinationServiceIP,
 			record.DestinationServicePort,
 			record.DestinationServicePortName,
 			record.IngressNetworkPolicyName,

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
@@ -63,7 +63,6 @@ const (
                    destinationPodNamespace,
                    destinationNodeName,
                    destinationClusterIP,
-                   destinationServiceIP,
                    destinationServicePort,
                    destinationServicePortName,
                    ingressNetworkPolicyName,
@@ -90,9 +89,9 @@ const (
                    egressName,
                    egressIP,
                    egressNodeName)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 
                            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                           ?, ?, ?, ?)`
+                           ?, ?, ?, ?, ?)`
 )
 
 // PrepareClickHouseConnection is used for unit testing
@@ -307,7 +306,6 @@ func (ch *ClickHouseExportProcess) batchCommitAll(ctx context.Context) (int, err
 			record.DestinationPodNamespace,
 			record.DestinationNodeName,
 			record.DestinationClusterIP,
-			record.DestinationServiceIP,
 			record.DestinationServicePort,
 			record.DestinationServicePortName,
 			record.IngressNetworkPolicyName,

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
@@ -95,6 +95,7 @@ func TestBatchCommitAll(t *testing.T) {
 			"antrea-test-b",
 			"k8s-node-control-plane-b",
 			"10.10.1.10",
+			"10.10.1.10",
 			5202,
 			"perftest",
 			"test-flow-aggregator-networkpolicy-ingress-allow",

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
@@ -17,7 +17,6 @@ package clickhouseclient
 import (
 	"database/sql/driver"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -33,6 +32,10 @@ import (
 )
 
 var fakeClusterUUID = uuid.Must(uuid.NewV4()).String()
+
+// clickhouseFieldCount is the number of columns in the "flows" table INSERT query in
+// clickhouseclient.go. Refer to `insertQuery` in clickhouseclient.go.
+const clickhouseFieldCount = 51
 
 func TestCacheRecord(t *testing.T) {
 	chExportProc := &ClickHouseExportProcess{
@@ -95,7 +98,6 @@ func TestBatchCommitAll(t *testing.T) {
 			"antrea-test-b",
 			"k8s-node-control-plane-b",
 			"10.10.1.10",
-			"10.10.1.10",
 			5202,
 			"perftest",
 			"test-flow-aggregator-networkpolicy-ingress-allow",
@@ -142,8 +144,7 @@ func TestBatchCommitAllMultiRecord(t *testing.T) {
 		queueSize: maxQueueSize,
 	}
 	recordRow := flowrecord.FlowRecord{}
-	fieldCount := reflect.TypeOf(recordRow).NumField() + 1
-	argList := make([]driver.Value, fieldCount)
+	argList := make([]driver.Value, clickhouseFieldCount)
 	for i := 0; i < len(argList); i++ {
 		argList[i] = sqlmock.AnyArg()
 	}
@@ -174,8 +175,7 @@ func TestBatchCommitAllError(t *testing.T) {
 	}
 	recordRow := flowrecord.FlowRecord{}
 	chExportProc.deque.PushBack(&recordRow)
-	fieldCount := reflect.TypeOf(recordRow).NumField() + 1
-	argList := make([]driver.Value, fieldCount)
+	argList := make([]driver.Value, clickhouseFieldCount)
 	for i := 0; i < len(argList); i++ {
 		argList[i] = sqlmock.AnyArg()
 	}

--- a/pkg/flowaggregator/collector/preprocessor_test.go
+++ b/pkg/flowaggregator/collector/preprocessor_test.go
@@ -202,6 +202,10 @@ func createTestElements(isIPv4 bool) []ipfixentities.InfoElementWithValue {
 		destinationClusterIPv4Elem.SetIPAddressValue(netip.MustParseAddr("10.10.1.10").AsSlice())
 		elements = append(elements, destinationClusterIPv4Elem)
 
+		destinationServiceIPv4Elem := createTestElement("destinationServiceIPv4", ipfixregistry.AntreaEnterpriseID)
+		destinationServiceIPv4Elem.SetIPAddressValue(netip.MustParseAddr("10.10.1.10").AsSlice())
+		elements = append(elements, destinationServiceIPv4Elem)
+
 		egressIPElem := createTestElement("egressIP", ipfixregistry.AntreaEnterpriseID)
 		egressIPElem.SetStringValue("172.18.0.1")
 		elements = append(elements, egressIPElem)
@@ -218,6 +222,10 @@ func createTestElements(isIPv4 bool) []ipfixentities.InfoElementWithValue {
 		destinationClusterIPv6Elem.SetIPAddressValue(netip.MustParseAddr("2001:0:3238:dfe1:64::a").AsSlice())
 		elements = append(elements, destinationClusterIPv6Elem)
 
+		destinationServiceIPv6Elem := createTestElement("destinationServiceIPv6", ipfixregistry.AntreaEnterpriseID)
+		destinationServiceIPv6Elem.SetIPAddressValue(netip.MustParseAddr("2001:0:3238:dfe1:64::a").AsSlice())
+		elements = append(elements, destinationServiceIPv6Elem)
+
 		egressIPElem := createTestElement("egressIP", ipfixregistry.AntreaEnterpriseID)
 		egressIPElem.SetStringValue("2001:0:3238:dfe1::ac12:1")
 		elements = append(elements, egressIPElem)
@@ -230,13 +238,13 @@ func createExpectedFlowRecord(isIPv4 bool) *flowpb.Flow {
 	ipVersion := flowpb.IPVersion_IP_VERSION_4
 	source := netip.MustParseAddr("10.10.0.79")
 	destination := netip.MustParseAddr("10.10.0.80")
-	destinationClusterIP := netip.MustParseAddr("10.10.1.10")
+	destinationServiceIP := netip.MustParseAddr("10.10.1.10")
 	egressIP := netip.MustParseAddr("172.18.0.1")
 	if !isIPv4 {
 		ipVersion = flowpb.IPVersion_IP_VERSION_6
 		source = netip.MustParseAddr("2001:0:3238:dfe1:63::fefb")
 		destination = netip.MustParseAddr("2001:0:3238:dfe1:63::fefc")
-		destinationClusterIP = netip.MustParseAddr("2001:0:3238:dfe1:64::a")
+		destinationServiceIP = netip.MustParseAddr("2001:0:3238:dfe1:64::a")
 		egressIP = netip.MustParseAddr("2001:0:3238:dfe1::ac12:1")
 	}
 	return &flowpb.Flow{
@@ -270,7 +278,8 @@ func createExpectedFlowRecord(isIPv4 bool) *flowpb.Flow {
 			DestinationPodName:             "perftest-b",
 			DestinationPodNamespace:        "antrea-test-b",
 			DestinationNodeName:            "k8s-node-control-plane-b",
-			DestinationClusterIp:           destinationClusterIP.AsSlice(),
+			DestinationClusterIp:           destinationServiceIP.AsSlice(),
+			DestinationServiceIp:           destinationServiceIP.AsSlice(),
 			DestinationServicePort:         5202,
 			DestinationServicePortName:     "perftest",
 			IngressNetworkPolicyName:       "test-flow-aggregator-networkpolicy-ingress-allow",

--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -414,6 +414,7 @@ func (e *IPFIXExporter) makeIPFIXRecord(flow *flowpb.Flow, isIPv6 bool) ipfixent
 		setUUID(flow.K8S.EgressNodeUid)
 	}
 	setIPAddress(flow.K8S.DestinationClusterIp)
+	setIPAddress(flow.K8S.DestinationServiceIp)
 	if e.aggregatorMode == flowaggregatorconfig.AggregatorModeAggregate {
 		// Add Antrea source stats fields
 		next().SetUnsigned64Value(flow.Aggregation.StatsFromSource.PacketTotalCount)

--- a/pkg/flowaggregator/flowlogger/logger.go
+++ b/pkg/flowaggregator/flowlogger/logger.go
@@ -102,6 +102,7 @@ func (fl *FlowLogger) WriteRecord(r *flowrecord.FlowRecord, prettyPrint bool) er
 		r.DestinationPodNamespace,
 		r.DestinationNodeName,
 		r.DestinationClusterIP,
+		r.DestinationServiceIP,
 		fmt.Sprintf("%d", r.DestinationServicePort),
 		r.DestinationServicePortName,
 		r.IngressNetworkPolicyName,

--- a/pkg/flowaggregator/flowlogger/logger_test.go
+++ b/pkg/flowaggregator/flowlogger/logger_test.go
@@ -70,11 +70,11 @@ func TestWriteRecord(t *testing.T) {
 	}{
 		{
 			prettyPrint: true,
-			expected:    "1637706961,1637706973,10.10.0.79,10.10.0.80,44752,5201,TCP,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,10.10.1.10,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,Drop,K8sNetworkPolicy,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,Invalid,Invalid,test-egress,172.18.0.1,test-egress-node",
+			expected:    "1637706961,1637706973,10.10.0.79,10.10.0.80,44752,5201,TCP,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,10.10.1.10,10.10.1.10,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,Drop,K8sNetworkPolicy,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,Invalid,Invalid,test-egress,172.18.0.1,test-egress-node",
 		},
 		{
 			prettyPrint: false,
-			expected:    "1637706961,1637706973,10.10.0.79,10.10.0.80,44752,5201,6,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,10.10.1.10,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,2,1,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,5,4,test-egress,172.18.0.1,test-egress-node",
+			expected:    "1637706961,1637706973,10.10.0.79,10.10.0.80,44752,5201,6,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,10.10.1.10,10.10.1.10,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,2,1,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,5,4,test-egress,172.18.0.1,test-egress-node",
 		},
 	}
 

--- a/pkg/flowaggregator/flowrecord/record.go
+++ b/pkg/flowaggregator/flowrecord/record.go
@@ -49,6 +49,7 @@ type FlowRecord struct {
 	DestinationPodNamespace              string
 	DestinationNodeName                  string
 	DestinationClusterIP                 string
+	DestinationServiceIP                 string
 	DestinationServicePort               uint16
 	DestinationServicePortName           string
 	IngressNetworkPolicyName             string
@@ -147,6 +148,7 @@ func GetFlowRecord(record *flowpb.Flow) (*FlowRecord, error) {
 		DestinationPodNamespace:           record.K8S.DestinationPodNamespace,
 		DestinationNodeName:               record.K8S.DestinationNodeName,
 		DestinationClusterIP:              IpAddressAsString(record.K8S.DestinationClusterIp),
+		DestinationServiceIP:              IpAddressAsString(record.K8S.DestinationServiceIp),
 		DestinationServicePort:            uint16(record.K8S.DestinationServicePort),
 		DestinationServicePortName:        record.K8S.DestinationServicePortName,
 		IngressNetworkPolicyName:          record.K8S.IngressNetworkPolicyName,

--- a/pkg/flowaggregator/flowrecord/record_test.go
+++ b/pkg/flowaggregator/flowrecord/record_test.go
@@ -81,11 +81,13 @@ func TestGetFlowRecord(t *testing.T) {
 			assert.Equal(t, "10.10.0.79", flowRecord.SourceIP)
 			assert.Equal(t, "10.10.0.80", flowRecord.DestinationIP)
 			assert.Equal(t, "10.10.1.10", flowRecord.DestinationClusterIP)
+			assert.Equal(t, "10.10.2.10", flowRecord.DestinationServiceIP)
 			assert.Equal(t, "172.18.0.1", flowRecord.EgressIP)
 		} else {
 			assert.Equal(t, "2001:0:3238:dfe1:63::fefb", flowRecord.SourceIP)
 			assert.Equal(t, "2001:0:3238:dfe1:63::fefc", flowRecord.DestinationIP)
 			assert.Equal(t, "2001:0:3238:dfe1:64::a", flowRecord.DestinationClusterIP)
+			assert.Equal(t, "2001:0:3238:dfe1:65::a", flowRecord.DestinationServiceIP)
 			assert.Equal(t, "2001:0:3238:dfe1::ac12:1", flowRecord.EgressIP)
 		}
 	}

--- a/pkg/flowaggregator/flowrecord/testing/util.go
+++ b/pkg/flowaggregator/flowrecord/testing/util.go
@@ -48,6 +48,7 @@ func PrepareTestFlowRecord() *flowrecord.FlowRecord {
 		DestinationPodNamespace:              "antrea-test-b",
 		DestinationNodeName:                  "k8s-node-control-plane-b",
 		DestinationClusterIP:                 "10.10.1.10",
+		DestinationServiceIP:                 "10.10.1.10",
 		DestinationServicePort:               5202,
 		DestinationServicePortName:           "perftest",
 		IngressNetworkPolicyName:             "test-flow-aggregator-networkpolicy-ingress-allow",

--- a/pkg/flowaggregator/infoelements/elements.go
+++ b/pkg/flowaggregator/infoelements/elements.go
@@ -177,8 +177,10 @@ func AntreaInfoElements(includeK8sNames, includeK8sUIDs, isIPv6 bool) []string {
 	}
 	if isIPv6 {
 		ies = append(ies, "destinationClusterIPv6")
+		ies = append(ies, "destinationServiceIPv6")
 	} else {
 		ies = append(ies, "destinationClusterIPv4")
+		ies = append(ies, "destinationServiceIPv4")
 	}
 	return ies
 }

--- a/pkg/flowaggregator/infoelements/elements_test.go
+++ b/pkg/flowaggregator/infoelements/elements_test.go
@@ -150,11 +150,11 @@ func TestAntreaInfoElements(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("ipv4", func(t *testing.T) {
-				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv4")
+				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv4", "destinationServiceIPv4")
 				assert.Equal(t, expectedIEs, AntreaInfoElements(tc.includeK8sNames, tc.includeK8sUIDs, false))
 			})
 			t.Run("ipv6", func(t *testing.T) {
-				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv6")
+				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv6", "destinationServiceIPv6")
 				assert.Equal(t, expectedIEs, AntreaInfoElements(tc.includeK8sNames, tc.includeK8sUIDs, true))
 			})
 		})

--- a/pkg/flowaggregator/intermediate/aggregate.go
+++ b/pkg/flowaggregator/intermediate/aggregate.go
@@ -205,10 +205,12 @@ func (a *aggregationProcess) GetRecords(flowKey *FlowKey) []map[string]interface
 			m["sourceIPv4Address"] = net.IP(f.Ip.Source)
 			m["destinationIPv4Address"] = net.IP(f.Ip.Destination)
 			m["destinationClusterIPv4"] = net.IP(f.K8S.DestinationClusterIp)
+			m["destinationServiceIPv4"] = net.IP(f.K8S.DestinationServiceIp)
 		} else {
 			m["sourceIPv6Address"] = net.IP(f.Ip.Source)
 			m["destinationIPv6Address"] = net.IP(f.Ip.Destination)
 			m["destinationClusterIPv6"] = net.IP(f.K8S.DestinationClusterIp)
+			m["destinationServiceIPv6"] = net.IP(f.K8S.DestinationServiceIp)
 		}
 		return m
 	}

--- a/pkg/flowaggregator/intermediate/aggregate_test.go
+++ b/pkg/flowaggregator/intermediate/aggregate_test.go
@@ -100,8 +100,10 @@ func createFlowRecordForSrc(isIPv6 bool, flowType flowpb.FlowType, isUpdatedReco
 	record.K8S.DestinationServicePort = 4739
 	if isIPv6 {
 		record.K8S.DestinationClusterIp = netip.MustParseAddr("2001:0:3238:BBBB:63::AAAA").AsSlice()
+		record.K8S.DestinationServiceIp = netip.MustParseAddr("2001:0:3238:BBBB:63::AAAA").AsSlice()
 	} else {
 		record.K8S.DestinationClusterIp = netip.MustParseAddr("192.168.0.1").AsSlice()
+		record.K8S.DestinationServiceIp = netip.MustParseAddr("192.168.0.1").AsSlice()
 	}
 	record.K8S.EgressNetworkPolicyRuleAction = egressNetworkPolicyRuleAction
 	if !isUpdatedRecord {
@@ -132,8 +134,10 @@ func createFlowRecordForDst(isIPv6 bool, flowType flowpb.FlowType, isUpdatedReco
 		record.K8S.DestinationServicePort = 4739
 		if isIPv6 {
 			record.K8S.DestinationClusterIp = netip.MustParseAddr("2001:0:3238:BBBB:63::AAAA").AsSlice()
+			record.K8S.DestinationServiceIp = netip.MustParseAddr("2001:0:3238:BBBB:63::AAAA").AsSlice()
 		} else {
 			record.K8S.DestinationClusterIp = netip.MustParseAddr("192.168.0.1").AsSlice()
+			record.K8S.DestinationServiceIp = netip.MustParseAddr("192.168.0.1").AsSlice()
 		}
 	}
 	record.K8S.IngressNetworkPolicyRuleAction = ingressNetworkPolicyRuleAction
@@ -664,10 +668,12 @@ func assertElementMap(t *testing.T, record map[string]interface{}, ipv6 bool) {
 		assert.Equal(t, net.ParseIP("2001:0:3238:dfe1:63::fefb"), record["sourceIPv6Address"])
 		assert.Equal(t, net.ParseIP("2001:0:3238:dfe1:63::fefc"), record["destinationIPv6Address"])
 		assert.Equal(t, net.ParseIP("2001:0:3238:bbbb:63::aaaa"), record["destinationClusterIPv6"])
+		assert.Equal(t, net.ParseIP("2001:0:3238:bbbb:63::aaaa"), record["destinationServiceIPv6"])
 	} else {
 		assert.Equal(t, net.ParseIP("10.0.0.1").To4(), record["sourceIPv4Address"])
 		assert.Equal(t, net.ParseIP("10.0.0.2").To4(), record["destinationIPv4Address"])
 		assert.Equal(t, net.ParseIP("192.168.0.1").To4(), record["destinationClusterIPv4"])
+		assert.Equal(t, net.ParseIP("192.168.0.1").To4(), record["destinationServiceIPv4"])
 	}
 	assert.Equal(t, uint16(1234), record["sourceTransportPort"])
 	assert.Equal(t, uint16(5678), record["destinationTransportPort"])
@@ -898,8 +904,10 @@ func runCorrelationAndCheckResult(t *testing.T, ap *aggregationProcess, clock *c
 		assert.Equal(t, "pod2", aggRecord.Record.K8S.DestinationPodName)
 		if !isIPv6 {
 			assert.Equal(t, netip.MustParseAddr("192.168.0.1").AsSlice(), aggRecord.Record.K8S.DestinationClusterIp)
+			assert.Equal(t, netip.MustParseAddr("192.168.0.1").AsSlice(), aggRecord.Record.K8S.DestinationServiceIp)
 		} else {
 			assert.Equal(t, netip.MustParseAddr("2001:0:3238:BBBB:63::AAAA").AsSlice(), aggRecord.Record.K8S.DestinationClusterIp)
+			assert.Equal(t, netip.MustParseAddr("2001:0:3238:BBBB:63::AAAA").AsSlice(), aggRecord.Record.K8S.DestinationServiceIp)
 		}
 		assert.EqualValues(t, 4739, aggRecord.Record.K8S.DestinationServicePort)
 		assert.True(t, ap.AreCorrelatedFieldsFilled(*aggRecord))
@@ -948,6 +956,7 @@ func runAggregationAndCheckResult(t *testing.T, ap *aggregationProcess, clock *c
 	assert.Equal(t, "pod1", aggRecord.Record.K8S.SourcePodName)
 	assert.Equal(t, "pod2", aggRecord.Record.K8S.DestinationPodName)
 	assert.Equal(t, netip.MustParseAddr("192.168.0.1").AsSlice(), aggRecord.Record.K8S.DestinationClusterIp)
+	assert.Equal(t, netip.MustParseAddr("192.168.0.1").AsSlice(), aggRecord.Record.K8S.DestinationServiceIp)
 	assert.EqualValues(t, 4739, aggRecord.Record.K8S.DestinationServicePort)
 	assert.Equal(t, flowpb.NetworkPolicyRuleAction_NETWORK_POLICY_RULE_ACTION_NO_ACTION, aggRecord.Record.K8S.IngressNetworkPolicyRuleAction)
 

--- a/pkg/flowaggregator/s3uploader/s3uploader.go
+++ b/pkg/flowaggregator/s3uploader/s3uploader.go
@@ -432,6 +432,8 @@ func writeRecord(w io.Writer, r *flowrecord.FlowRecord, clusterUUID string) {
 	io.WriteString(w, ",")
 	io.WriteString(w, r.DestinationClusterIP)
 	io.WriteString(w, ",")
+	io.WriteString(w, r.DestinationServiceIP)
+	io.WriteString(w, ",")
 	io.WriteString(w, fmt.Sprintf("%d", r.DestinationServicePort))
 	io.WriteString(w, ",")
 	io.WriteString(w, r.DestinationServicePortName)

--- a/pkg/flowaggregator/s3uploader/s3uploader_test.go
+++ b/pkg/flowaggregator/s3uploader/s3uploader_test.go
@@ -34,8 +34,8 @@ import (
 var (
 	timestampStr    = fmt.Sprint(time.Now().Unix())
 	fakeClusterUUID = uuid.Must(uuid.NewV4()).String()
-	recordStrIPv4   = "1637706961,1637706973,1637706974,1637706975,3,10.10.0.79,10.10.0.80,44752,5201,6,823188,30472817041,241333,8982624938,471111,24500996,136211,7083284,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,10.10.1.10,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,2,1,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,1,3,TIME_WAIT,2,'{\"antrea-e2e\":\"perftest-a\",\"app\":\"iperf\"}','{\"antrea-e2e\":\"perftest-b\",\"app\":\"iperf\"}',15902813472,12381344,15902813473,15902813474,12381345,12381346," + fakeClusterUUID + "," + timestampStr + ",test-egress,172.18.0.1,test-egress-node"
-	recordStrIPv6   = "1637706961,1637706973,1637706974,1637706975,3,2001:0:3238:dfe1:63::fefb,2001:0:3238:dfe1:63::fefc,44752,5201,6,823188,30472817041,241333,8982624938,471111,24500996,136211,7083284,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,2001:0:3238:dfe1:64::a,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,2,1,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,1,3,TIME_WAIT,2,'{\"antrea-e2e\":\"perftest-a\",\"app\":\"iperf\"}','{\"antrea-e2e\":\"perftest-b\",\"app\":\"iperf\"}',15902813472,12381344,15902813473,15902813474,12381345,12381346," + fakeClusterUUID + "," + timestampStr + ",test-egress,2001:0:3238:dfe1::ac12:1,test-egress-node"
+	recordStrIPv4   = "1637706961,1637706973,1637706974,1637706975,3,10.10.0.79,10.10.0.80,44752,5201,6,823188,30472817041,241333,8982624938,471111,24500996,136211,7083284,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,10.10.1.10,10.10.2.10,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,2,1,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,1,3,TIME_WAIT,2,'{\"antrea-e2e\":\"perftest-a\",\"app\":\"iperf\"}','{\"antrea-e2e\":\"perftest-b\",\"app\":\"iperf\"}',15902813472,12381344,15902813473,15902813474,12381345,12381346," + fakeClusterUUID + "," + timestampStr + ",test-egress,172.18.0.1,test-egress-node"
+	recordStrIPv6   = "1637706961,1637706973,1637706974,1637706975,3,2001:0:3238:dfe1:63::fefb,2001:0:3238:dfe1:63::fefc,44752,5201,6,823188,30472817041,241333,8982624938,471111,24500996,136211,7083284,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,2001:0:3238:dfe1:64::a,2001:0:3238:dfe1:65::a,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,2,1,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,1,3,TIME_WAIT,2,'{\"antrea-e2e\":\"perftest-a\",\"app\":\"iperf\"}','{\"antrea-e2e\":\"perftest-b\",\"app\":\"iperf\"}',15902813472,12381344,15902813473,15902813474,12381345,12381346," + fakeClusterUUID + "," + timestampStr + ",test-egress,2001:0:3238:dfe1::ac12:1,test-egress-node"
 )
 
 func TestUpdateS3Uploader(t *testing.T) {
@@ -75,7 +75,7 @@ func TestCacheRecord(t *testing.T) {
 	require.Equal(t, int32(1), s3UploadProc.cachedRecordCount)
 	currentBuffer := s3UploadProc.currentBuffer.String()
 	fields := getFields(currentBuffer)
-	fields[50] = timestampStr // Overwrite timestamp with fixed value used for test flow record.
+	fields[51] = timestampStr // Overwrite timestamp with fixed value used for test flow record.
 	assert.Equal(t, getFields(recordStrIPv4), fields)
 
 	// Second call, reach currentBuffer max size, add the currentBuffer to bufferQueue.
@@ -86,7 +86,7 @@ func TestCacheRecord(t *testing.T) {
 	records := strings.Fields(buf.String())
 	require.Len(t, records, 2)
 	fields = getFields(records[1])
-	fields[50] = timestampStr
+	fields[51] = timestampStr
 	assert.Equal(t, getFields(recordStrIPv6), fields)
 	assert.EqualValues(t, 0, s3UploadProc.cachedRecordCount)
 	assert.Equal(t, 0, s3UploadProc.currentBuffer.Len())

--- a/pkg/flowaggregator/testing/util.go
+++ b/pkg/flowaggregator/testing/util.go
@@ -28,12 +28,14 @@ func PrepareTestFlowRecord(isIPv4 bool) *flowpb.Flow {
 	source := netip.MustParseAddr("10.10.0.79")
 	destination := netip.MustParseAddr("10.10.0.80")
 	destinationClusterIP := netip.MustParseAddr("10.10.1.10")
+	destinationServiceIP := netip.MustParseAddr("10.10.2.10")
 	egressIP := netip.MustParseAddr("172.18.0.1")
 	if !isIPv4 {
 		ipVersion = flowpb.IPVersion_IP_VERSION_6
 		source = netip.MustParseAddr("2001:0:3238:dfe1:63::fefb")
 		destination = netip.MustParseAddr("2001:0:3238:dfe1:63::fefc")
 		destinationClusterIP = netip.MustParseAddr("2001:0:3238:dfe1:64::a")
+		destinationServiceIP = netip.MustParseAddr("2001:0:3238:dfe1:65::a")
 		egressIP = netip.MustParseAddr("2001:0:3238:dfe1::ac12:1")
 	}
 	return &flowpb.Flow{
@@ -81,6 +83,7 @@ func PrepareTestFlowRecord(isIPv4 bool) *flowpb.Flow {
 			},
 			DestinationNodeName:            "k8s-node-control-plane-b",
 			DestinationClusterIp:           destinationClusterIP.AsSlice(),
+			DestinationServiceIp:           destinationServiceIP.AsSlice(),
 			DestinationServicePort:         5202,
 			DestinationServicePortName:     "perftest",
 			IngressNetworkPolicyName:       "test-flow-aggregator-networkpolicy-ingress-allow",

--- a/test/e2e/charts/flow-visibility/templates/configmap.yaml
+++ b/test/e2e/charts/flow-visibility/templates/configmap.yaml
@@ -51,6 +51,7 @@ data:
             destinationPodNamespace String,
             destinationNodeName String,
             destinationClusterIP String,
+            destinationServiceIP String,
             destinationServicePort UInt16,
             destinationServicePortName String,
             ingressNetworkPolicyName String,

--- a/test/e2e/charts/flow-visibility/templates/configmap.yaml
+++ b/test/e2e/charts/flow-visibility/templates/configmap.yaml
@@ -51,7 +51,6 @@ data:
             destinationPodNamespace String,
             destinationNodeName String,
             destinationClusterIP String,
-            destinationServiceIP String,
             destinationServicePort UInt16,
             destinationServicePortName String,
             ingressNetworkPolicyName String,

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -1314,12 +1314,12 @@ func checkRecordsForDenyFlowsClickHouse(t *testing.T, data *TestData, testFlow1,
 		var srcPodName, dstPodName string
 		var svcIP string
 		var checkSrcNodeInfo bool
-		if record.SourceIP == testFlow1.srcIP && (record.DestinationIP == testFlow1.dstIP || record.DestinationClusterIP == testFlow1.dstIP) {
+		if record.SourceIP == testFlow1.srcIP && (record.DestinationIP == testFlow1.dstIP || record.DestinationServiceIP == testFlow1.dstIP) {
 			srcPodName = testFlow1.srcPodName
 			dstPodName = testFlow1.dstPodName
 			svcIP = testFlow1.svcIP
 			checkSrcNodeInfo = !testFlow1.srcNodeInfoNotAvailable
-		} else if record.SourceIP == testFlow2.srcIP && (record.DestinationIP == testFlow2.dstIP || record.DestinationClusterIP == testFlow2.dstIP) {
+		} else if record.SourceIP == testFlow2.srcIP && (record.DestinationIP == testFlow2.dstIP || record.DestinationServiceIP == testFlow2.dstIP) {
 			srcPodName = testFlow2.srcPodName
 			dstPodName = testFlow2.dstPodName
 			svcIP = testFlow2.svcIP
@@ -1562,7 +1562,7 @@ func getClickHouseOutput(t *testing.T, data *TestData, srcIP, dstIP, srcPort str
 
 	query := fmt.Sprintf("SELECT * FROM flows WHERE (sourceIP = '%s') AND (destinationIP = '%s') AND (octetDeltaCount != 0)", srcIP, dstIP)
 	if isDstService {
-		query = fmt.Sprintf("SELECT * FROM flows WHERE (sourceIP = '%s') AND (destinationClusterIP = '%s') AND (octetDeltaCount != 0)", srcIP, dstIP)
+		query = fmt.Sprintf("SELECT * FROM flows WHERE (sourceIP = '%s') AND (destinationServiceIP = '%s') AND (octetDeltaCount != 0)", srcIP, dstIP)
 	}
 	if len(srcPort) > 0 {
 		query = fmt.Sprintf("%s AND (sourceTransportPort = %s)", query, srcPort)
@@ -1940,13 +1940,13 @@ func matchSrcAndDstAddress(srcIP string, dstIP string, isDstService bool, isIPv6
 	srcField := fmt.Sprintf("sourceIPv4Address: %s", srcIP)
 	dstField := fmt.Sprintf("destinationIPv4Address: %s", dstIP)
 	if isDstService {
-		dstField = fmt.Sprintf("destinationClusterIPv4: %s", dstIP)
+		dstField = fmt.Sprintf("destinationServiceIPv4: %s", dstIP)
 	}
 	if isIPv6 {
 		srcField = fmt.Sprintf("sourceIPv6Address: %s", srcIP)
 		dstField = fmt.Sprintf("destinationIPv6Address: %s", dstIP)
 		if isDstService {
-			dstField = fmt.Sprintf("destinationClusterIPv6: %s", dstIP)
+			dstField = fmt.Sprintf("destinationServiceIPv6: %s", dstIP)
 		}
 	}
 	return srcField, dstField
@@ -2200,6 +2200,7 @@ type ClickHouseFullRow struct {
 	DestinationPodNamespace              string    `json:"destinationPodNamespace"`
 	DestinationNodeName                  string    `json:"destinationNodeName"`
 	DestinationClusterIP                 string    `json:"destinationClusterIP"`
+	DestinationServiceIP                 string    `json:"destinationServiceIP"`
 	DestinationServicePort               uint16    `json:"destinationServicePort"`
 	DestinationServicePortName           string    `json:"destinationServicePortName"`
 	IngressNetworkPolicyName             string    `json:"ingressNetworkPolicyName"`

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -1314,12 +1314,13 @@ func checkRecordsForDenyFlowsClickHouse(t *testing.T, data *TestData, testFlow1,
 		var srcPodName, dstPodName string
 		var svcIP string
 		var checkSrcNodeInfo bool
-		if record.SourceIP == testFlow1.srcIP && (record.DestinationIP == testFlow1.dstIP || record.DestinationServiceIP == testFlow1.dstIP) {
+		// TODO(yang) use DestinationServiceIP once the ClickHouse schema is updated
+		if record.SourceIP == testFlow1.srcIP && (record.DestinationIP == testFlow1.dstIP || record.DestinationClusterIP == testFlow1.dstIP) {
 			srcPodName = testFlow1.srcPodName
 			dstPodName = testFlow1.dstPodName
 			svcIP = testFlow1.svcIP
 			checkSrcNodeInfo = !testFlow1.srcNodeInfoNotAvailable
-		} else if record.SourceIP == testFlow2.srcIP && (record.DestinationIP == testFlow2.dstIP || record.DestinationServiceIP == testFlow2.dstIP) {
+		} else if record.SourceIP == testFlow2.srcIP && (record.DestinationIP == testFlow2.dstIP || record.DestinationClusterIP == testFlow2.dstIP) {
 			srcPodName = testFlow2.srcPodName
 			dstPodName = testFlow2.dstPodName
 			svcIP = testFlow2.svcIP
@@ -1562,7 +1563,8 @@ func getClickHouseOutput(t *testing.T, data *TestData, srcIP, dstIP, srcPort str
 
 	query := fmt.Sprintf("SELECT * FROM flows WHERE (sourceIP = '%s') AND (destinationIP = '%s') AND (octetDeltaCount != 0)", srcIP, dstIP)
 	if isDstService {
-		query = fmt.Sprintf("SELECT * FROM flows WHERE (sourceIP = '%s') AND (destinationServiceIP = '%s') AND (octetDeltaCount != 0)", srcIP, dstIP)
+		// TODO(yang) use DestinationServiceIP once the ClickHouse schema is updated
+		query = fmt.Sprintf("SELECT * FROM flows WHERE (sourceIP = '%s') AND (destinationClusterIP = '%s') AND (octetDeltaCount != 0)", srcIP, dstIP)
 	}
 	if len(srcPort) > 0 {
 		query = fmt.Sprintf("%s AND (sourceTransportPort = %s)", query, srcPort)
@@ -2200,7 +2202,6 @@ type ClickHouseFullRow struct {
 	DestinationPodNamespace              string    `json:"destinationPodNamespace"`
 	DestinationNodeName                  string    `json:"destinationNodeName"`
 	DestinationClusterIP                 string    `json:"destinationClusterIP"`
-	DestinationServiceIP                 string    `json:"destinationServiceIP"`
 	DestinationServicePort               uint16    `json:"destinationServicePort"`
 	DestinationServicePortName           string    `json:"destinationServicePortName"`
 	IngressNetworkPolicyName             string    `json:"ingressNetworkPolicyName"`

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -139,7 +139,7 @@ const (
 	mcjoinImage         = "antrea/mcjoin:v2.9"
 	nginxImage          = "antrea/nginx:1.21.6-alpine"
 	iisImage            = "mcr.microsoft.com/windows/servercore/iis"
-	ipfixCollectorImage = "antrea/ipfix-collector:v0.16.0"
+	ipfixCollectorImage = "antrea/ipfix-collector:v0.17.0"
 
 	nginxLBService = "nginx-loadbalancer"
 


### PR DESCRIPTION
Fixes #7610 
- Updated the field destinationClusterIP as deprecated in flow-visibility doc.
- Marked the same field as deprecated in flow.proto.
- Ensured all occurrences of destinationClusterIP usage is migrated to using the new destinationServiceIP field instead.