### PR TITLE
Warn when protocolFilter matches no supported protocols

### DIFF
--- a/pkg/agent/flowexporter/filter/protocol_filter.go
+++ b/pkg/agent/flowexporter/filter/protocol_filter.go
@@ -60,8 +60,8 @@ func NewProtocolFilter(protocols []string) ProtocolFilter {
 		klog.InfoS("Found unsupported protocol(s) in protocolFilter, refer to the docs for supported protocols", "unsupportedProtocols", strings.Join(invalidProtocols, ","))
 	}
 
-	if len(protocols) == 0 {
-		klog.InfoS("protocolFilter is empty and nothing will be exported")
+	if len(validatedProtocols) == 0 {
+		klog.InfoS("protocolFilter matches no supported protocols, so no flows will be exported")
 	}
 
 	return ProtocolFilter{

--- a/pkg/agent/flowexporter/filter/protocol_filter_test.go
+++ b/pkg/agent/flowexporter/filter/protocol_filter_test.go
@@ -54,6 +54,13 @@ func TestNewProtocolFilter(t *testing.T) {
 			[]string{"TCP", "udp", "sctp"},
 			sets.New(tcp, udp, sctp),
 		},
+		{
+			// A non-empty list of only invalid protocols results in an empty
+			// (but non-nil) set, which denies all protocols.
+			"Only invalid protocols",
+			[]string{"tpc", "icmp"},
+			sets.New[uint8](),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -98,6 +105,14 @@ func TestProtocolFilter_Allow(t *testing.T) {
 			"sctp not filtered out",
 			[]string{"tcp", "udp"},
 			sctp,
+			false,
+		},
+		{
+			// When every configured protocol is invalid, the filter denies all
+			// protocols rather than allowing all.
+			"only invalid protocols deny everything",
+			[]string{"tpc"},
+			tcp,
 			false,
 		},
 	}


### PR DESCRIPTION
NewProtocolFilter logged the "nothing will be exported" warning only when the configured protocolFilter list was literally empty. When the list contained only invalid/unsupported protocol names (which the static agent config does not validate, unlike the CRD enum), the effective filter denied all protocols and dropped every flow, but the warning was not logged.

Check the number of validated protocols instead of the raw input length, so the warning is emitted whenever the filter matches no supported protocols.

Fixes #8158