### PR TITLE
Fix panics and nil dereferences on tombstone deletes in remaining handlers

### DIFF
--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -213,7 +213,19 @@ func (c *Controller) updateTraceflow(_, curObj interface{}) {
 }
 
 func (c *Controller) deleteTraceflow(old interface{}) {
-	tf := old.(*crdv1beta1.Traceflow)
+	tf, ok := old.(*crdv1beta1.Traceflow)
+	if !ok {
+		tombstone, ok := old.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.V(2).InfoS("Error decoding object when deleting Traceflow, invalid type", "object", old)
+			return
+		}
+		tf, ok = tombstone.Obj.(*crdv1beta1.Traceflow)
+		if !ok {
+			klog.V(2).InfoS("Error decoding object tombstone when deleting Traceflow, invalid type", "object", tombstone.Obj)
+			return
+		}
+	}
 	klog.Infof("Processing Traceflow %s DELETE event", tf.Name)
 	c.enqueueTraceflow(tf)
 }

--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -217,12 +217,12 @@ func (c *Controller) deleteTraceflow(old interface{}) {
 	if !ok {
 		tombstone, ok := old.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object when deleting Traceflow, invalid type", "object", old)
+			klog.ErrorS(nil, "Error decoding object when deleting Traceflow, invalid type", "object", old)
 			return
 		}
 		tf, ok = tombstone.Obj.(*crdv1beta1.Traceflow)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object tombstone when deleting Traceflow, invalid type", "object", tombstone.Obj)
+			klog.ErrorS(nil, "Error decoding object tombstone when deleting Traceflow, invalid type", "object", tombstone.Obj)
 			return
 		}
 	}

--- a/pkg/agent/controller/traceflow/traceflow_controller_test.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -967,6 +968,23 @@ func TestProcessTraceflowItem(t *testing.T) {
 	tfc.enqueueTraceflow(tc.tf)
 	got := tfc.processTraceflowItem()
 	assert.Equal(t, tc.expected, got)
+}
+
+func TestDeleteTraceflow_Tombstone(t *testing.T) {
+	tf := &crdv1beta1.Traceflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "tf1", UID: "uid1"},
+	}
+	tfc := newFakeTraceflowController(t, []runtime.Object{tf}, nil, nil)
+
+	// Deliver the delete as a tombstone, as the informer does after a watch reconnect.
+	tfc.deleteTraceflow(cache.DeletedFinalStateUnknown{
+		Key: tf.Name,
+		Obj: tf,
+	})
+
+	require.Equal(t, 1, tfc.queue.Len(), "expected Traceflow to be enqueued from the tombstone delete")
+	key, _ := tfc.queue.Get()
+	assert.Equal(t, tf.Name, key)
 }
 
 func TestValidateTraceflow(t *testing.T) {

--- a/pkg/agent/externalnode/external_node_controller.go
+++ b/pkg/agent/externalnode/external_node_controller.go
@@ -173,7 +173,19 @@ func (c *ExternalNodeController) enqueueExternalNodeUpdate(oldObj interface{}, n
 }
 
 func (c *ExternalNodeController) enqueueExternalNodeDelete(obj interface{}) {
-	en := obj.(*v1alpha1.ExternalNode)
+	en, ok := obj.(*v1alpha1.ExternalNode)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.V(2).InfoS("Error decoding object when deleting ExternalNode, invalid type", "object", obj)
+			return
+		}
+		en, ok = tombstone.Obj.(*v1alpha1.ExternalNode)
+		if !ok {
+			klog.V(2).InfoS("Error decoding object tombstone when deleting ExternalNode, invalid type", "object", tombstone.Obj)
+			return
+		}
+	}
 	key, _ := keyFunc(en)
 	c.queue.Add(key)
 	klog.InfoS("Enqueued ExternalNode DELETE event", "ExternalNode", klog.KObj(en))

--- a/pkg/agent/externalnode/external_node_controller.go
+++ b/pkg/agent/externalnode/external_node_controller.go
@@ -177,12 +177,12 @@ func (c *ExternalNodeController) enqueueExternalNodeDelete(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object when deleting ExternalNode, invalid type", "object", obj)
+			klog.ErrorS(nil, "Error decoding object when deleting ExternalNode, invalid type", "object", obj)
 			return
 		}
 		en, ok = tombstone.Obj.(*v1alpha1.ExternalNode)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object tombstone when deleting ExternalNode, invalid type", "object", tombstone.Obj)
+			klog.ErrorS(nil, "Error decoding object tombstone when deleting ExternalNode, invalid type", "object", tombstone.Obj)
 			return
 		}
 	}

--- a/pkg/agent/externalnode/external_node_controller_test.go
+++ b/pkg/agent/externalnode/external_node_controller_test.go
@@ -427,6 +427,28 @@ func TestEnqueueExternalNodeUpdate(t *testing.T) {
 	}
 }
 
+func TestEnqueueExternalNodeDelete_Tombstone(t *testing.T) {
+	controller := gomock.NewController(t)
+	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
+	mockOFClient := openflowtest.NewMockClient(controller)
+	mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)
+	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(controller)
+	c := newExternalNodeController(t, controller, mockOVSBridgeClient, mockOFClient, mockOVSCtlClient, mockIfaceStore)
+	externalNode := &v1alpha1.ExternalNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "vm1", Namespace: "ns1"},
+	}
+
+	// Deliver the delete as a tombstone, as the informer does after a watch reconnect.
+	c.enqueueExternalNodeDelete(cache.DeletedFinalStateUnknown{
+		Key: "ns1/vm1",
+		Obj: externalNode,
+	})
+
+	require.Equal(t, 1, c.queue.Len(), "expected ExternalNode to be enqueued from the tombstone delete")
+	key, _ := c.queue.Get()
+	assert.Equal(t, "ns1/vm1", key)
+}
+
 func newExternalNodeController(t *testing.T, controller *gomock.Controller, mockOVSBridgeClient *ovsconfigtest.MockOVSBridgeClient, mockOFClient *openflowtest.MockClient, mockOVSCtlClient *ovsctltest.MockOVSCtlClient, mockIfaceStore *interfacestoretest.MockInterfaceStore) *ExternalNodeController {
 	mockOVSBridgeClient.EXPECT().GetBridgeName().Times(1)
 	localExternalNodeInformer := crdv1alpha1informers.NewExternalNodeInformer(

--- a/pkg/agent/multicluster/stretched_networkpolicy_controller.go
+++ b/pkg/agent/multicluster/stretched_networkpolicy_controller.go
@@ -281,7 +281,19 @@ func (s *StretchedNetworkPolicyController) processPodUpdate(old, cur interface{}
 // be deleted by podConfigurator. So no need to enqueue this Pod to update its
 // classifier flow.
 func (s *StretchedNetworkPolicyController) processPodDelete(old interface{}) {
-	oldPod, _ := old.(*v1.Pod)
+	oldPod, ok := old.(*v1.Pod)
+	if !ok {
+		tombstone, ok := old.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.ErrorS(nil, "Error decoding object when deleting Pod, invalid type", "object", old)
+			return
+		}
+		oldPod, ok = tombstone.Obj.(*v1.Pod)
+		if !ok {
+			klog.ErrorS(nil, "Error decoding object tombstone when deleting Pod, invalid type", "object", tombstone.Obj)
+			return
+		}
+	}
 	oldPodRef := getPodReference(oldPod)
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -312,7 +324,19 @@ func (s *StretchedNetworkPolicyController) processNamespaceUpdate(old, cur inter
 // processLabelIdentityEvent handles labelIdentity add/update/delete event.
 // It will enqueue all Pods affected by this labelIdentity
 func (s *StretchedNetworkPolicyController) processLabelIdentityEvent(cur interface{}) {
-	labelIdentity, _ := cur.(*v1alpha1.LabelIdentity)
+	labelIdentity, ok := cur.(*v1alpha1.LabelIdentity)
+	if !ok {
+		tombstone, ok := cur.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.ErrorS(nil, "Error decoding object when processing LabelIdentity event, invalid type", "object", cur)
+			return
+		}
+		labelIdentity, ok = tombstone.Obj.(*v1alpha1.LabelIdentity)
+		if !ok {
+			klog.ErrorS(nil, "Error decoding object tombstone when processing LabelIdentity event, invalid type", "object", tombstone.Obj)
+			return
+		}
+	}
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	if podSet, ok := s.labelToPods[labelIdentity.Spec.Label]; ok {

--- a/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
+++ b/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -553,6 +554,52 @@ func TestStretchedNetworkPolicyControllerLabelIdentityEvent(t *testing.T) {
 		t.Errorf("Test didn't finish in time")
 	case <-finishCh:
 	}
+}
+
+func TestProcessPodDelete_Tombstone(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	mcClient := mcfake.NewSimpleClientset()
+	c := newStretchedNetworkPolicyController(t, clientset, mcClient)
+
+	podRef := types.NamespacedName{Name: "pod", Namespace: "ns"}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podRef.Name, Namespace: podRef.Namespace},
+	}
+	c.labelToPods["label1"] = podSet{podRef: struct{}{}}
+	c.podToLabel[podRef] = "label1"
+
+	// Deliver the delete as a tombstone, as the informer does after a watch reconnect.
+	c.processPodDelete(cache.DeletedFinalStateUnknown{
+		Key: podRef.String(),
+		Obj: pod,
+	})
+
+	assert.NotContains(t, c.podToLabel, podRef, "expected Pod to be removed from podToLabel after tombstone delete")
+	assert.NotContains(t, c.labelToPods["label1"], podRef, "expected Pod to be removed from labelToPods after tombstone delete")
+}
+
+func TestProcessLabelIdentityEvent_Tombstone(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	mcClient := mcfake.NewSimpleClientset()
+	c := newStretchedNetworkPolicyController(t, clientset, mcClient)
+	defer c.queue.ShutDown()
+
+	podRef := types.NamespacedName{Name: "pod", Namespace: "ns"}
+	labelIdentity := &v1alpha1.LabelIdentity{
+		ObjectMeta: metav1.ObjectMeta{Name: "labelIdentity1"},
+		Spec:       v1alpha1.LabelIdentitySpec{Label: "label1"},
+	}
+	c.labelToPods[labelIdentity.Spec.Label] = podSet{podRef: struct{}{}}
+
+	// Deliver the delete as a tombstone, as the informer does after a watch reconnect.
+	c.processLabelIdentityEvent(cache.DeletedFinalStateUnknown{
+		Key: labelIdentity.Name,
+		Obj: labelIdentity,
+	})
+
+	require.Equal(t, 1, c.queue.Len(), "expected affected Pod to be enqueued from the tombstone delete")
+	item, _ := c.queue.Get()
+	assert.Equal(t, podRef, item)
 }
 
 func toPodAddEvent(pod *corev1.Pod) antreatypes.PodUpdate {

--- a/pkg/controller/networkpolicy/clustergroup.go
+++ b/pkg/controller/networkpolicy/clustergroup.go
@@ -96,7 +96,6 @@ func (c *NetworkPolicyController) updateClusterGroup(oldObj, curObj interface{})
 // deleteClusterGroup is responsible for processing the DELETE event of a ClusterGroup resource.
 func (c *NetworkPolicyController) deleteClusterGroup(oldObj interface{}) {
 	og, ok := oldObj.(*crdv1beta1.ClusterGroup)
-	klog.V(2).Infof("Processing DELETE event for ClusterGroup %s", og.Name)
 	if !ok {
 		tombstone, ok := oldObj.(cache.DeletedFinalStateUnknown)
 		if !ok {
@@ -109,6 +108,7 @@ func (c *NetworkPolicyController) deleteClusterGroup(oldObj interface{}) {
 			return
 		}
 	}
+	klog.V(2).Infof("Processing DELETE event for ClusterGroup %s", og.Name)
 	key := internalGroupKeyFunc(og)
 	klog.V(2).Infof("Deleting internal Group %s", key)
 	err := c.internalGroupStore.Delete(key)

--- a/pkg/controller/networkpolicy/clustergroup_test.go
+++ b/pkg/controller/networkpolicy/clustergroup_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
@@ -557,6 +558,28 @@ func TestDeleteCG(t *testing.T) {
 	npc.deleteClusterGroup(&testCG)
 	_, found, _ := npc.internalGroupStore.Get(key)
 	assert.False(t, found, "expected internal Group to be deleted")
+}
+
+func TestDeleteCG_Tombstone(t *testing.T) {
+	selectorA := metav1.LabelSelector{MatchLabels: map[string]string{"foo1": "bar1"}}
+	testCG := crdv1beta1.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "cgA", UID: "uidA"},
+		Spec: crdv1beta1.GroupSpec{
+			NamespaceSelector: &selectorA,
+		},
+	}
+	key := testCG.Name
+	_, npc := newController(nil, nil)
+	npc.addClusterGroup(&testCG)
+
+	// Deliver the delete as a tombstone, as the informer does after a watch reconnect.
+	npc.deleteClusterGroup(cache.DeletedFinalStateUnknown{
+		Key: key,
+		Obj: &testCG,
+	})
+
+	_, found, _ := npc.internalGroupStore.Get(key)
+	assert.False(t, found, "expected internal Group to be deleted from a tombstone delete")
 }
 
 func TestClusterClusterGroupMembersComputedConditionEqual(t *testing.T) {

--- a/pkg/controller/networkpolicy/group.go
+++ b/pkg/controller/networkpolicy/group.go
@@ -92,7 +92,6 @@ func (n *NetworkPolicyController) updateGroup(oldObj, curObj interface{}) {
 // deleteGroup is responsible for processing the DELETE event of a Group resource.
 func (n *NetworkPolicyController) deleteGroup(oldObj interface{}) {
 	og, ok := oldObj.(*crdv1beta1.Group)
-	klog.V(2).InfoS("Processing DELETE event for Group", "Group", internalGroupKeyFunc(og))
 	if !ok {
 		tombstone, ok := oldObj.(cache.DeletedFinalStateUnknown)
 		if !ok {
@@ -105,6 +104,7 @@ func (n *NetworkPolicyController) deleteGroup(oldObj interface{}) {
 			return
 		}
 	}
+	klog.V(2).InfoS("Processing DELETE event for Group", "Group", internalGroupKeyFunc(og))
 	key := internalGroupKeyFunc(og)
 	klog.V(2).InfoS("Deleting internal Group", "Group", key)
 	err := n.internalGroupStore.Delete(key)

--- a/pkg/controller/networkpolicy/group.go
+++ b/pkg/controller/networkpolicy/group.go
@@ -104,8 +104,8 @@ func (n *NetworkPolicyController) deleteGroup(oldObj interface{}) {
 			return
 		}
 	}
-	klog.V(2).InfoS("Processing DELETE event for Group", "Group", internalGroupKeyFunc(og))
 	key := internalGroupKeyFunc(og)
+	klog.V(2).InfoS("Processing DELETE event for Group", "Group", key)
 	klog.V(2).InfoS("Deleting internal Group", "Group", key)
 	err := n.internalGroupStore.Delete(key)
 	if err != nil {

--- a/pkg/controller/networkpolicy/group_test.go
+++ b/pkg/controller/networkpolicy/group_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
 	crdv1beta1 "antrea.io/antrea/v2/pkg/apis/crd/v1beta1"
@@ -487,6 +488,28 @@ func TestDeleteG(t *testing.T) {
 	npc.deleteGroup(&testG)
 	_, found, _ := npc.internalGroupStore.Get(key)
 	assert.False(t, found, "expected internal Group to be deleted")
+}
+
+func TestDeleteG_Tombstone(t *testing.T) {
+	selectorA := metav1.LabelSelector{MatchLabels: map[string]string{"foo1": "bar1"}}
+	testG := crdv1beta1.Group{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "gA", UID: "uidA"},
+		Spec: crdv1beta1.GroupSpec{
+			NamespaceSelector: &selectorA,
+		},
+	}
+	key := fmt.Sprintf("%s/%s", testG.Namespace, testG.Name)
+	_, npc := newController(nil, nil)
+	npc.addGroup(&testG)
+
+	// Deliver the delete as a tombstone, as the informer does after a watch reconnect.
+	npc.deleteGroup(cache.DeletedFinalStateUnknown{
+		Key: key,
+		Obj: &testG,
+	})
+
+	_, found, _ := npc.internalGroupStore.Get(key)
+	assert.False(t, found, "expected internal Group to be deleted from a tombstone delete")
 }
 
 func TestGroupMembersComputedConditionEqual(t *testing.T) {


### PR DESCRIPTION
**Problem**

Commit 1ba8d6273 (#7964) fixed several controller-side delete handlers that
panicked when the informer delivered a `cache.DeletedFinalStateUnknown`
tombstone instead of the real object type. This happens whenever a watch
connection to the apiserver is interrupted — timeout, restart, network blip —
and the informer has to infer a delete from a relist instead of observing it
directly (see client-go's `delta_fifo.go` `Replace()`). It's routine in any
long-running cluster, not an edge case.

That sweep left several equivalent bugs unfixed:

- **`pkg/agent/controller/traceflow`** `deleteTraceflow` and
  **`pkg/agent/externalnode`** `enqueueExternalNodeDelete` — the agent-side
  counterparts of two handlers #7964 fixed on the controller side, with the
  identical unchecked type assertion (`obj.(*Type)`).
- **`pkg/agent/multicluster`** `processPodDelete` and
  `processLabelIdentityEvent` — discard the assertion's `ok` value entirely
  (`x, _ := obj.(*Type)`) and then dereference the result.
- **`pkg/controller/networkpolicy`** `deleteClusterGroup` and `deleteGroup` —
  already had correct tombstone-handling code, but logged a field of the
  asserted object *before* checking whether the assertion succeeded, which is
  a nil pointer dereference on the exact path meant to guard against it.

None of these are recovered by client-go — `util/runtime.HandleCrash` logs the
panic and then deliberately re-panics, crashing the whole `antrea-agent` or
`antrea-controller` process.

`trafficcontrol`'s `deleteTC`/`deletePod` have the same bug but already have
an open fix in #8028, so they're intentionally left out here.

**Solution**

Applied the two-step type assertion already used in this codebase
(`pkg/controller/networkpolicy/clustergroup.go`, `group.go`): try the real
type first, and on failure try `cache.DeletedFinalStateUnknown` and unwrap its
`Obj` field, logging and returning if that also fails. The two
`networkpolicy` handlers needed no new logic — just moved the existing log
statement to after the `ok` check.

**Testing**

Added one unit test per handler that delivers the delete as a
`cache.DeletedFinalStateUnknown`, matching what the informer does after a
watch reconnect, and asserts the real side effect (item enqueued, map entry
cleared, store entry removed) rather than just the absence of a panic.
Verified each test fails against the pre-fix code (panic or nil pointer
dereference) and passes after the fix. Full test suites for all four affected
packages pass.

**Files Changed**

| File | Change |
|---|---|
| `pkg/agent/controller/traceflow/traceflow_controller.go` | tombstone handling in `deleteTraceflow` |
| `pkg/agent/controller/traceflow/traceflow_controller_test.go` | +`TestDeleteTraceflow_Tombstone` |
| `pkg/agent/externalnode/external_node_controller.go` | tombstone handling in `enqueueExternalNodeDelete` |
| `pkg/agent/externalnode/external_node_controller_test.go` | +`TestEnqueueExternalNodeDelete_Tombstone` |
| `pkg/agent/multicluster/stretched_networkpolicy_controller.go` | tombstone handling in `processPodDelete`, `processLabelIdentityEvent` |
| `pkg/agent/multicluster/stretched_networkpolicy_controller_test.go` | +`TestProcessPodDelete_Tombstone`, +`TestProcessLabelIdentityEvent_Tombstone` |
| `pkg/controller/networkpolicy/clustergroup.go` | fix log-before-check ordering in `deleteClusterGroup` |
| `pkg/controller/networkpolicy/clustergroup_test.go` | +`TestDeleteCG_Tombstone` |
| `pkg/controller/networkpolicy/group.go` | fix log-before-check ordering in `deleteGroup` |
| `pkg/controller/networkpolicy/group_test.go` | +`TestDeleteG_Tombstone` |
