### PR TITLE
test: add coverage for bundleStream download path

### DIFF
--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -366,7 +366,7 @@ func (b *bundleStream) GetObjectKind() schema.ObjectKind {
 }
 
 func (b *bundleStream) DeepCopyObject() runtime.Object {
-	panic("bundleStream does not have DeepCopyObject")
+	return &bundleStream{cache: b.cache}
 }
 
 func (b *bundleStream) InputStream(_ context.Context, _, _ string) (stream io.ReadCloser, flush bool, mimeType string, err error) {

--- a/pkg/apiserver/registry/system/supportbundle/rest_test.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest_test.go
@@ -205,6 +205,59 @@ func TestControllerStorage(t *testing.T) {
 	}, time.Second*2, time.Millisecond*100, "Supportbundle file %s was not deleted after deleting the Supportbundle object", filePath)
 }
 
+func TestDownloadREST(t *testing.T) {
+	bundle := &supportBundleREST{
+		mode: modeController,
+		cache: &system.SupportBundle{
+			ObjectMeta: metav1.ObjectMeta{Name: modeController},
+			Status:     system.SupportBundleStatusCollected,
+		},
+	}
+	d := &downloadREST{supportBundle: bundle}
+	assert.Equal(t, &system.SupportBundle{}, d.New())
+	assert.Equal(t, []string{"application/tar+gz"}, d.ProducesMIMETypes(""))
+	assert.Equal(t, "", d.ProducesObject(""))
+	d.Destroy()
+
+	obj, err := d.Get(context.TODO(), "", nil)
+	require.NoError(t, err)
+	stream, ok := obj.(*bundleStream)
+	require.True(t, ok)
+	assert.Same(t, bundle.cache, stream.cache)
+}
+
+func TestBundleStreamDeepCopyObject(t *testing.T) {
+	stream := &bundleStream{cache: &system.SupportBundle{ObjectMeta: metav1.ObjectMeta{Name: modeController}}}
+	assert.NotPanics(t, func() {
+		copied := stream.DeepCopyObject()
+		copiedStream, ok := copied.(*bundleStream)
+		require.True(t, ok)
+		assert.Equal(t, stream.cache, copiedStream.cache)
+	})
+}
+
+func TestBundleStreamInputStream(t *testing.T) {
+	defaultFS = afero.NewMemMapFs()
+	defer func() {
+		defaultFS = afero.NewOsFs()
+	}()
+	f, err := defaultFS.Create("bundle.tar.gz")
+	require.NoError(t, err)
+	_, err = f.WriteString("bundle content")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	stream := &bundleStream{cache: &system.SupportBundle{Filepath: "bundle.tar.gz"}}
+	rc, flush, mimeType, err := stream.InputStream(context.TODO(), "", "")
+	require.NoError(t, err)
+	defer rc.Close()
+	assert.True(t, flush)
+	assert.Equal(t, "application/tar+gz", mimeType)
+
+	_, err = (&bundleStream{cache: &system.SupportBundle{Filepath: "missing.tar.gz"}}).InputStream(context.TODO(), "", "")
+	assert.Error(t, err)
+}
+
 type fakeAgentDumper struct {
 	returnErr error
 }

--- a/pkg/apiserver/registry/system/supportbundle/rest_test.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest_test.go
@@ -214,10 +214,10 @@ func TestDownloadREST(t *testing.T) {
 		},
 	}
 	d := &downloadREST{supportBundle: bundle}
+	defer d.Destroy()
 	assert.Equal(t, &system.SupportBundle{}, d.New())
 	assert.Equal(t, []string{"application/tar+gz"}, d.ProducesMIMETypes(""))
 	assert.Equal(t, "", d.ProducesObject(""))
-	d.Destroy()
 
 	obj, err := d.Get(context.TODO(), "", nil)
 	require.NoError(t, err)
@@ -254,7 +254,7 @@ func TestBundleStreamInputStream(t *testing.T) {
 	assert.True(t, flush)
 	assert.Equal(t, "application/tar+gz", mimeType)
 
-	_, err = (&bundleStream{cache: &system.SupportBundle{Filepath: "missing.tar.gz"}}).InputStream(context.TODO(), "", "")
+	_, _, _, err = (&bundleStream{cache: &system.SupportBundle{Filepath: "missing.tar.gz"}}).InputStream(context.TODO(), "", "")
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a potential panic in the support bundle download path by replacing the `bundleStream.DeepCopyObject()` panic with a safe implementation and adds test coverage for the download-related functionality.

## Changes

- Replace the `bundleStream.DeepCopyObject()` panic with a safe shallow-copy implementation.
- Add unit tests for `downloadREST`, including:
  - `New`
  - `Destroy`
  - `ProducesMIMETypes`
  - `ProducesObject`
  - `Get`
- Add unit tests for `bundleStream.DeepCopyObject()`.
- Add unit tests for `bundleStream.InputStream()`, covering both:
  - Successful file streaming
  - Missing file/error path

## Why

`bundleStream` is returned as a `runtime.Object` by the support bundle download endpoint. Its previous `DeepCopyObject()` implementation unconditionally panicked, which could cause request handling to fail if the apiserver or serializers invoked a deep copy. This change provides a safe implementation while improving test coverage for the download path.

Fixes #8160