### PR TITLE
Fix nil pointer dereference in NPL iptables Init

### DIFF
--- a/pkg/agent/nodeportlocal/rules/iptable_rule.go
+++ b/pkg/agent/nodeportlocal/rules/iptable_rule.go
@@ -62,15 +62,17 @@ func NewIPTableRules(isIPv6 bool) *iptablesRules {
 
 // Init initializes IPTABLES rules for NPL. Currently it deletes existing rules to ensure that no stale entries are present.
 func (ipt *iptablesRules) Init() error {
-	iptInstance, err := iptables.New(!ipt.isIPv6, ipt.isIPv6)
-	if err != nil {
-		return fmt.Errorf("error creating IPTables instance for NPL: %v", err)
-	}
-	ipt.table = iptInstance
-	if err := ipt.initRules(); err != nil {
-		return fmt.Errorf("initialization of NPL iptables rules failed: %v", err)
-	}
-	return nil
+    if ipt.table == nil {
+        iptInstance, err := iptables.New(!ipt.isIPv6, ipt.isIPv6)
+        if err != nil {
+            return fmt.Errorf("error creating IPTables instance for NPL: %w", err)
+        }
+        ipt.table = iptInstance
+    }
+    if err := ipt.initRules(); err != nil {
+        return fmt.Errorf("initialization of NPL iptables rules failed: %w", err)
+    }
+    return nil
 }
 
 // initRules creates the NPL chain and links it to the PREROUTING (for incoming

--- a/pkg/agent/nodeportlocal/rules/iptable_rule.go
+++ b/pkg/agent/nodeportlocal/rules/iptable_rule.go
@@ -62,6 +62,11 @@ func NewIPTableRules(isIPv6 bool) *iptablesRules {
 
 // Init initializes IPTABLES rules for NPL. Currently it deletes existing rules to ensure that no stale entries are present.
 func (ipt *iptablesRules) Init() error {
+	iptInstance, err := iptables.New(!ipt.isIPv6, ipt.isIPv6)
+	if err != nil {
+		return fmt.Errorf("error creating IPTables instance for NPL: %v", err)
+	}
+	ipt.table = iptInstance
 	if err := ipt.initRules(); err != nil {
 		return fmt.Errorf("initialization of NPL iptables rules failed: %v", err)
 	}


### PR DESCRIPTION
In [iptable_rule.go](https://github.com/TechNomad04/antrea/blob/main/pkg/agent/nodeportlocal/rules/iptable_rule.go),  NewIPTableRules constructs an iptablesRules struct without ever initializing the table field (type iptables.Interface):

```go
func NewIPTableRules(isIPv6 bool) *iptablesRules {
    protocol := iptables.ProtocolIPv4
    if isIPv6 {
        protocol = iptables.ProtocolIPv6
    }
    return &iptablesRules{
        isIPv6:   isIPv6,
        protocol: protocol,
        // table is never set — remains nil
    }
}
```

The table field is never subsequently assigned. When NewPortTable calls ptable.PodPortRules.Init() at agent startup, execution reaches initRules() which immediately calls ipt.table.EnsureChain(...) on the nil table — causing a nil pointer dereference panic.

- **Expected**
NewIPTableRules (or Init) should call iptables.New(ipv4Enabled, ipv6Enabled) and propagate any error, so NPL setup either succeeds with a valid iptables client or fails with a clear error message.

- **Actual behavior**
The agent panics with a nil pointer dereference at startup when NodePortLocal is enabled on Linux.

- **Proposed fix**
Move the iptables.New() call into Init() (since that method already returns an error) so that error propagation is straightforward and no change to the InitRules/NewIPTableRules signatures is needed

```go
func (ipt *iptablesRules) Init() error {
    if ipt.table == nil {
        iptInstance, err := iptables.New(!ipt.isIPv6, ipt.isIPv6)
        if err != nil {
            return fmt.Errorf("error creating IPTables instance for NPL: %w", err)
        }
        ipt.table = iptInstance
    }
    if err := ipt.initRules(); err != nil {
        return fmt.Errorf("initialization of NPL iptables rules failed: %w", err)
    }
    return nil
}
```
