### PR TITLE
Fix bridge-scoped OVS ofport lookup

### DIFF
--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -836,32 +836,6 @@ func (br *OVSBridge) GetOFPort(ifName string) (int32, error) {
 	return 0, fmt.Errorf("failed to parse a valid ofport from OVSDB result for interface %s", ifName)
 }
 
-func findBridgeInterfaceByName(bridge *Bridge, ports []Port, intfs []Interface, ifName string) (*Interface, error) {
-	portUUIDs := sets.New(bridge.Ports...)
-	ifUUIDs := sets.New[string]()
-	for i := range ports {
-		if !portUUIDs.Has(ports[i].UUID) {
-			continue
-		}
-		ifUUIDs.Insert(ports[i].Interfaces...)
-	}
-
-	var matched *Interface
-	for i := range intfs {
-		if intfs[i].Name != ifName || !ifUUIDs.Has(intfs[i].UUID) {
-			continue
-		}
-		if matched != nil {
-			return nil, fmt.Errorf("found multiple interfaces named %s on bridge %s", ifName, bridge.Name)
-		}
-		matched = &intfs[i]
-	}
-	if matched == nil {
-		return nil, fmt.Errorf("interface %s not found on bridge %s: %w", ifName, bridge.Name, client.ErrNotFound)
-	}
-	return matched, nil
-}
-
 func buildPortDataCommon(port *Port, intf *Interface, portData *OVSPortData) {
 	portData.Name = port.Name
 	portData.ExternalIDs = maps.Clone(port.ExternalIDs)
@@ -1308,38 +1282,35 @@ func (br *OVSBridge) getInterface(ctx context.Context, name string) (*Interface,
 
 // getInterfaceOnBridge fetches the Interface record with the given name only when
 // it is attached to the specified bridge.
+// In antrea-agent, OVS Port and its Interface share the same name, so we can look
+// them up directly by name instead of scanning all ports and interfaces on the bridge.
 func (br *OVSBridge) getInterfaceOnBridge(ctx context.Context, ifName string) (*Interface, error) {
 	bridge, err := br.getBridge(ctx)
 	if err != nil {
 		return nil, err
 	}
-	portUUIDs := sets.New[string](bridge.Ports...)
 
-	var ports []Port
-	if err := br.ovsdb.WhereCache(func(p *Port) bool {
-		return portUUIDs.Has(p.UUID)
-	}).List(ctx, &ports); err != nil {
-		if !errors.Is(err, client.ErrNotFound) {
-			klog.ErrorS(err, "Failed to list Port table", "bridge", br.name)
-		}
+	port, err := br.getPort(ctx, ifName, "")
+	if err != nil {
 		return nil, err
 	}
 
-	ifUUIDs := sets.New[string]()
-	for i := range ports {
-		ifUUIDs.Insert(ports[i].Interfaces...)
+	portUUIDs := sets.New(bridge.Ports...)
+	if !portUUIDs.Has(port.UUID) {
+		return nil, fmt.Errorf("port %s not found on bridge %s", ifName, bridge.Name)
 	}
-	var intfs []Interface
-	if err := br.ovsdb.WhereCache(func(i *Interface) bool {
-		return i.Name == ifName && ifUUIDs.Has(i.UUID)
-	}).List(ctx, &intfs); err != nil {
-		if !errors.Is(err, client.ErrNotFound) {
-			klog.ErrorS(err, "Failed to list Interface table", "bridge", br.name, "interface", ifName)
-		}
+
+	intf, err := br.getInterface(ctx, ifName)
+	if err != nil {
 		return nil, err
 	}
 
-	return findBridgeInterfaceByName(bridge, ports, intfs, ifName)
+	ifUUIDs := sets.New(port.Interfaces...)
+	if !ifUUIDs.Has(intf.UUID) {
+		return nil, fmt.Errorf("interface %s not attached to port %s on bridge %s", ifName, port.Name, bridge.Name)
+	}
+
+	return intf, nil
 }
 
 // transact is a helper function to execute an OVSDB transaction and log any error

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -770,7 +770,7 @@ func (br *OVSBridge) GetOFPort(ifName string) (int32, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultGetPortTimeout)
 	defer cancel()
 
-	intf, err := br.getInterface(ctx, ifName)
+	intf, err := br.getBridgeInterface(ctx, ifName)
 	if err != nil {
 		return 0, err
 	}
@@ -794,14 +794,14 @@ func (br *OVSBridge) GetOFPort(ifName string) (int32, error) {
 	// We use WaitConditionNotEqual to wait for the ofport to be assigned by OVS (including invalid value -1).
 	// We wait for the ofport to become NotEqual to empty set (nil). This guarantees the wait completes immediately when
 	// OVS assigns a valid port number (>0), or fails the port creation and assigns an error value (<0, e.g., -1).
-	ops, err := br.ovsdb.Where(interfaceWithName(ifName)).Wait(ovsdb.WaitConditionNotEqual, &timeoutMs, mIntf, &mIntf.OFPort)
+	ops, err := br.ovsdb.Where(interfaceWithUUID(intf.UUID)).Wait(ovsdb.WaitConditionNotEqual, &timeoutMs, mIntf, &mIntf.OFPort)
 	if err != nil {
 		return 0, err
 	}
 
 	// Append a select operation to return the updated row atomically.
 	// This prevents cache synchronization race conditions (RAW: read-after-write) and ensures consistency.
-	ops = append(ops, newSelectOperation(interfaceTable, "name", ifName, "ofport"))
+	ops = append(ops, newSelectOperation(interfaceTable, "_uuid", ovsdb.UUID{GoUUID: intf.UUID}, "ofport"))
 
 	results, err := br.transact(ctx, ops, "wait for ofport")
 	if err != nil {
@@ -834,6 +834,32 @@ func (br *OVSBridge) GetOFPort(ifName string) (int32, error) {
 	}
 
 	return 0, fmt.Errorf("failed to parse a valid ofport from OVSDB result for interface %s", ifName)
+}
+
+func findBridgeInterfaceByName(bridge *Bridge, ports []Port, intfs []Interface, ifName string) (*Interface, error) {
+	portUUIDs := sets.New(bridge.Ports...)
+	ifUUIDs := sets.New[string]()
+	for i := range ports {
+		if !portUUIDs.Has(ports[i].UUID) {
+			continue
+		}
+		ifUUIDs.Insert(ports[i].Interfaces...)
+	}
+
+	var matched *Interface
+	for i := range intfs {
+		if intfs[i].Name != ifName || !ifUUIDs.Has(intfs[i].UUID) {
+			continue
+		}
+		if matched != nil {
+			return nil, fmt.Errorf("found multiple interfaces named %s on bridge %s", ifName, bridge.Name)
+		}
+		matched = &intfs[i]
+	}
+	if matched == nil {
+		return nil, fmt.Errorf("interface %s not found on bridge %s", ifName, bridge.Name)
+	}
+	return matched, nil
 }
 
 func buildPortDataCommon(port *Port, intf *Interface, portData *OVSPortData) {
@@ -1277,6 +1303,38 @@ func (br *OVSBridge) getInterface(ctx context.Context, name string) (*Interface,
 	return intf, nil
 }
 
+// getBridgeInterface fetches the Interface record with the given name only when
+// it is attached to one of this bridge's ports.
+func (br *OVSBridge) getBridgeInterface(ctx context.Context, ifName string) (*Interface, error) {
+	bridge, err := br.getBridge(ctx)
+	if err != nil {
+		return nil, err
+	}
+	portUUIDs := sets.New[string](bridge.Ports...)
+
+	var ports []Port
+	if err := br.ovsdb.WhereCache(func(p *Port) bool {
+		return portUUIDs.Has(p.UUID)
+	}).List(ctx, &ports); err != nil {
+		klog.ErrorS(err, "Failed to list Port table", "bridge", br.name)
+		return nil, err
+	}
+
+	ifUUIDs := sets.New[string]()
+	for i := range ports {
+		ifUUIDs.Insert(ports[i].Interfaces...)
+	}
+	var intfs []Interface
+	if err := br.ovsdb.WhereCache(func(i *Interface) bool {
+		return i.Name == ifName && ifUUIDs.Has(i.UUID)
+	}).List(ctx, &intfs); err != nil {
+		klog.ErrorS(err, "Failed to list Interface table", "bridge", br.name, "interface", ifName)
+		return nil, err
+	}
+
+	return findBridgeInterfaceByName(bridge, ports, intfs, ifName)
+}
+
 // transact is a helper function to execute an OVSDB transaction and log any error
 // with the provided action description.
 func (br *OVSBridge) transact(ctx context.Context, ops []ovsdb.Operation, action string) ([]ovsdb.OperationResult, error) {
@@ -1332,4 +1390,5 @@ func newSelectOperation(table, column string, value interface{}, returnColumns .
 
 func bridgeWithUUID(uuid string) *Bridge       { return &Bridge{UUID: uuid} }
 func interfaceWithName(name string) *Interface { return &Interface{Name: name} }
+func interfaceWithUUID(uuid string) *Interface { return &Interface{UUID: uuid} }
 func OVSWithUUID(uuid string) *OpenvSwitch     { return &OpenvSwitch{UUID: uuid} }

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -857,7 +857,7 @@ func findBridgeInterfaceByName(bridge *Bridge, ports []Port, intfs []Interface, 
 		matched = &intfs[i]
 	}
 	if matched == nil {
-		return nil, fmt.Errorf("interface %s not found on bridge %s", ifName, bridge.Name)
+		return nil, fmt.Errorf("interface %s not found on bridge %s: %w", ifName, bridge.Name, client.ErrNotFound)
 	}
 	return matched, nil
 }
@@ -1265,10 +1265,13 @@ func (br *OVSBridge) getOpenvSwitch(ctx context.Context) (*OpenvSwitch, error) {
 // It logs an error and returns it if the bridge cannot be found or another error occurs.
 func (br *OVSBridge) getBridge(ctx context.Context) (*Bridge, error) {
 	bridge := &Bridge{Name: br.name}
+	if br.uuid != "" {
+		bridge = &Bridge{UUID: br.uuid}
+	}
 	err := br.ovsdb.Get(ctx, bridge)
 	if err != nil {
 		if !errors.Is(err, client.ErrNotFound) {
-			klog.ErrorS(err, "Failed to get bridge", "bridge", br.name)
+			klog.ErrorS(err, "Failed to get bridge", "bridge", br.name, "uuid", br.uuid)
 		}
 		return nil, err
 	}

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -770,7 +770,7 @@ func (br *OVSBridge) GetOFPort(ifName string) (int32, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultGetPortTimeout)
 	defer cancel()
 
-	intf, err := br.getBridgeInterface(ctx, ifName)
+	intf, err := br.getInterfaceOnBridge(ctx, ifName)
 	if err != nil {
 		return 0, err
 	}
@@ -1306,9 +1306,9 @@ func (br *OVSBridge) getInterface(ctx context.Context, name string) (*Interface,
 	return intf, nil
 }
 
-// getBridgeInterface fetches the Interface record with the given name only when
-// it is attached to one of this bridge's ports.
-func (br *OVSBridge) getBridgeInterface(ctx context.Context, ifName string) (*Interface, error) {
+// getInterfaceOnBridge fetches the Interface record with the given name only when
+// it is attached to the specified bridge.
+func (br *OVSBridge) getInterfaceOnBridge(ctx context.Context, ifName string) (*Interface, error) {
 	bridge, err := br.getBridge(ctx)
 	if err != nil {
 		return nil, err
@@ -1319,7 +1319,9 @@ func (br *OVSBridge) getBridgeInterface(ctx context.Context, ifName string) (*In
 	if err := br.ovsdb.WhereCache(func(p *Port) bool {
 		return portUUIDs.Has(p.UUID)
 	}).List(ctx, &ports); err != nil {
-		klog.ErrorS(err, "Failed to list Port table", "bridge", br.name)
+		if !errors.Is(err, client.ErrNotFound) {
+			klog.ErrorS(err, "Failed to list Port table", "bridge", br.name)
+		}
 		return nil, err
 	}
 
@@ -1331,7 +1333,9 @@ func (br *OVSBridge) getBridgeInterface(ctx context.Context, ifName string) (*In
 	if err := br.ovsdb.WhereCache(func(i *Interface) bool {
 		return i.Name == ifName && ifUUIDs.Has(i.UUID)
 	}).List(ctx, &intfs); err != nil {
-		klog.ErrorS(err, "Failed to list Interface table", "bridge", br.name, "interface", ifName)
+		if !errors.Is(err, client.ErrNotFound) {
+			klog.ErrorS(err, "Failed to list Interface table", "bridge", br.name, "interface", ifName)
+		}
 		return nil, err
 	}
 

--- a/pkg/ovs/ovsconfig/ovs_client_test.go
+++ b/pkg/ovs/ovsconfig/ovs_client_test.go
@@ -15,11 +15,9 @@
 package ovsconfig
 
 import (
-	"errors"
 	"net"
 	"testing"
 
-	"github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/ptr"
 )
@@ -102,73 +100,4 @@ func TestBuildPortDataCommon(t *testing.T) {
 		})
 	}
 
-}
-
-func TestFindBridgeInterfaceByName(t *testing.T) {
-	tests := []struct {
-		name           string
-		bridge         *Bridge
-		ports          []Port
-		intfs          []Interface
-		ifName         string
-		wantUUID       string
-		wantError      string
-		wantIsNotFound bool
-	}{
-		{
-			bridge: &Bridge{Name: "br-test", Ports: []string{"port-on-bridge"}},
-			ports: []Port{
-				{UUID: "port-on-bridge", Interfaces: []string{"if-on-bridge"}},
-				{UUID: "stale-port", Interfaces: []string{"stale-if"}},
-			},
-			name: "interface attached to bridge",
-			intfs: []Interface{
-				{UUID: "if-on-bridge", Name: "eth1", OFPort: ptr.To(1)},
-				{UUID: "stale-if", Name: "eth1", OFPort: ptr.To(2)},
-			},
-			ifName:   "eth1",
-			wantUUID: "if-on-bridge",
-		},
-		{
-			bridge: &Bridge{Name: "br-test", Ports: []string{"port-on-bridge"}},
-			ports: []Port{
-				{UUID: "port-on-bridge", Interfaces: []string{"if-on-bridge"}},
-				{UUID: "stale-port", Interfaces: []string{"stale-if"}},
-			},
-			name: "same-name interface not attached to bridge ignored",
-			intfs: []Interface{
-				{UUID: "stale-if", Name: "eth1", OFPort: ptr.To(2)},
-			},
-			ifName:         "eth1",
-			wantError:      "interface eth1 not found on bridge br-test",
-			wantIsNotFound: true,
-		},
-		{
-			bridge: &Bridge{Name: "br-test", Ports: []string{"port-on-bridge", "port-on-bridge-2"}},
-			ports: []Port{
-				{UUID: "port-on-bridge", Interfaces: []string{"if-on-bridge"}},
-				{UUID: "port-on-bridge-2", Interfaces: []string{"if-on-bridge-2"}},
-			},
-			name: "duplicate interfaces attached to bridge",
-			intfs: []Interface{
-				{UUID: "if-on-bridge", Name: "eth1", OFPort: ptr.To(1)},
-				{UUID: "if-on-bridge-2", Name: "eth1", OFPort: ptr.To(2)},
-			},
-			ifName:    "eth1",
-			wantError: "found multiple interfaces named eth1 on bridge br-test",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			intf, err := findBridgeInterfaceByName(tc.bridge, tc.ports, tc.intfs, tc.ifName)
-			if tc.wantError != "" {
-				assert.ErrorContains(t, err, tc.wantError)
-				assert.Equal(t, tc.wantIsNotFound, errors.Is(err, client.ErrNotFound))
-				return
-			}
-			assert.NoError(t, err)
-			assert.Equal(t, tc.wantUUID, intf.UUID)
-		})
-	}
 }

--- a/pkg/ovs/ovsconfig/ovs_client_test.go
+++ b/pkg/ovs/ovsconfig/ovs_client_test.go
@@ -101,3 +101,69 @@ func TestBuildPortDataCommon(t *testing.T) {
 	}
 
 }
+
+func TestFindBridgeInterfaceByName(t *testing.T) {
+	tests := []struct {
+		name      string
+		bridge    *Bridge
+		ports     []Port
+		intfs     []Interface
+		ifName    string
+		wantUUID  string
+		wantError string
+	}{
+		{
+			bridge: &Bridge{Name: "br-test", Ports: []string{"port-on-bridge"}},
+			ports: []Port{
+				{UUID: "port-on-bridge", Interfaces: []string{"if-on-bridge"}},
+				{UUID: "stale-port", Interfaces: []string{"stale-if"}},
+			},
+			name: "interface attached to bridge",
+			intfs: []Interface{
+				{UUID: "if-on-bridge", Name: "eth1", OFPort: ptr.To(1)},
+				{UUID: "stale-if", Name: "eth1", OFPort: ptr.To(2)},
+			},
+			ifName:   "eth1",
+			wantUUID: "if-on-bridge",
+		},
+		{
+			bridge: &Bridge{Name: "br-test", Ports: []string{"port-on-bridge"}},
+			ports: []Port{
+				{UUID: "port-on-bridge", Interfaces: []string{"if-on-bridge"}},
+				{UUID: "stale-port", Interfaces: []string{"stale-if"}},
+			},
+			name: "same-name interface not attached to bridge ignored",
+			intfs: []Interface{
+				{UUID: "stale-if", Name: "eth1", OFPort: ptr.To(2)},
+			},
+			ifName:    "eth1",
+			wantError: "interface eth1 not found on bridge br-test",
+		},
+		{
+			bridge: &Bridge{Name: "br-test", Ports: []string{"port-on-bridge", "port-on-bridge-2"}},
+			ports: []Port{
+				{UUID: "port-on-bridge", Interfaces: []string{"if-on-bridge"}},
+				{UUID: "port-on-bridge-2", Interfaces: []string{"if-on-bridge-2"}},
+			},
+			name: "duplicate interfaces attached to bridge",
+			intfs: []Interface{
+				{UUID: "if-on-bridge", Name: "eth1", OFPort: ptr.To(1)},
+				{UUID: "if-on-bridge-2", Name: "eth1", OFPort: ptr.To(2)},
+			},
+			ifName:    "eth1",
+			wantError: "found multiple interfaces named eth1 on bridge br-test",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			intf, err := findBridgeInterfaceByName(tc.bridge, tc.ports, tc.intfs, tc.ifName)
+			if tc.wantError != "" {
+				assert.EqualError(t, err, tc.wantError)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantUUID, intf.UUID)
+		})
+	}
+}

--- a/pkg/ovs/ovsconfig/ovs_client_test.go
+++ b/pkg/ovs/ovsconfig/ovs_client_test.go
@@ -15,9 +15,11 @@
 package ovsconfig
 
 import (
+	"errors"
 	"net"
 	"testing"
 
+	"github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/ptr"
 )
@@ -104,13 +106,14 @@ func TestBuildPortDataCommon(t *testing.T) {
 
 func TestFindBridgeInterfaceByName(t *testing.T) {
 	tests := []struct {
-		name      string
-		bridge    *Bridge
-		ports     []Port
-		intfs     []Interface
-		ifName    string
-		wantUUID  string
-		wantError string
+		name           string
+		bridge         *Bridge
+		ports          []Port
+		intfs          []Interface
+		ifName         string
+		wantUUID       string
+		wantError      string
+		wantIsNotFound bool
 	}{
 		{
 			bridge: &Bridge{Name: "br-test", Ports: []string{"port-on-bridge"}},
@@ -136,8 +139,9 @@ func TestFindBridgeInterfaceByName(t *testing.T) {
 			intfs: []Interface{
 				{UUID: "stale-if", Name: "eth1", OFPort: ptr.To(2)},
 			},
-			ifName:    "eth1",
-			wantError: "interface eth1 not found on bridge br-test",
+			ifName:         "eth1",
+			wantError:      "interface eth1 not found on bridge br-test",
+			wantIsNotFound: true,
 		},
 		{
 			bridge: &Bridge{Name: "br-test", Ports: []string{"port-on-bridge", "port-on-bridge-2"}},
@@ -159,7 +163,8 @@ func TestFindBridgeInterfaceByName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			intf, err := findBridgeInterfaceByName(tc.bridge, tc.ports, tc.intfs, tc.ifName)
 			if tc.wantError != "" {
-				assert.EqualError(t, err, tc.wantError)
+				assert.ErrorContains(t, err, tc.wantError)
+				assert.Equal(t, tc.wantIsNotFound, errors.Is(err, client.ErrNotFound))
 				return
 			}
 			assert.NoError(t, err)


### PR DESCRIPTION
After the libovsdb migration, GetOFPort started reading the Interface row from the local OVSDB cache by interface name before falling back to a server-side wait. This can return a stale Interface row when a bridge is deleted and recreated quickly, because Interface records are global in OVSDB and cache updates are asynchronous.

For secondary network bridge reconciliation, this can make a newly created bridge appear to already have an uplink port when the matching Interface actually belonged to the old bridge. The controller then skips creating the uplink port, leaving the new bridge incomplete.

Scope GetOFPort to the current bridge by resolving the Interface through the bridge's Port records first, then wait/select the ofport by Interface UUID instead of by name.