### PR TITLE
Use klog.ErrorS instead of klog.V(2).InfoS for decode failures in tombstone handlers

### DIFF
--- a/pkg/controller/egress/controller.go
+++ b/pkg/controller/egress/controller.go
@@ -463,12 +463,12 @@ func (c *EgressController) deleteEgress(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object when deleting Egress, invalid type", "object", obj)
+			klog.ErrorS(nil, "Error decoding object when deleting Egress, invalid type", "object", obj)
 			return
 		}
 		egress, ok = tombstone.Obj.(*egressv1beta1.Egress)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object tombstone when deleting Egress, invalid type", "object", tombstone.Obj)
+			klog.ErrorS(nil, "Error decoding object tombstone when deleting Egress, invalid type", "object", tombstone.Obj)
 			return
 		}
 	}

--- a/pkg/controller/externalippool/controller.go
+++ b/pkg/controller/externalippool/controller.go
@@ -420,12 +420,12 @@ func (c *ExternalIPPoolController) deleteExternalIPPool(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object when deleting ExternalIPPool, invalid type", "object", obj)
+			klog.ErrorS(nil, "Error decoding object when deleting ExternalIPPool, invalid type", "object", obj)
 			return
 		}
 		pool, ok = tombstone.Obj.(*antreacrds.ExternalIPPool)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object tombstone when deleting ExternalIPPool, invalid type", "object", tombstone.Obj)
+			klog.ErrorS(nil, "Error decoding object tombstone when deleting ExternalIPPool, invalid type", "object", tombstone.Obj)
 			return
 		}
 	}

--- a/pkg/controller/externalnode/controller.go
+++ b/pkg/controller/externalnode/controller.go
@@ -123,12 +123,12 @@ func (c *ExternalNodeController) enqueueExternalNodeDelete(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object when deleting ExternalNode, invalid type", "object", obj)
+			klog.ErrorS(nil, "Error decoding object when deleting ExternalNode, invalid type", "object", obj)
 			return
 		}
 		en, ok = tombstone.Obj.(*v1alpha1.ExternalNode)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object tombstone when deleting ExternalNode, invalid type", "object", tombstone.Obj)
+			klog.ErrorS(nil, "Error decoding object tombstone when deleting ExternalNode, invalid type", "object", tombstone.Obj)
 			return
 		}
 	}

--- a/pkg/controller/labelidentity/controller.go
+++ b/pkg/controller/labelidentity/controller.go
@@ -120,12 +120,12 @@ func (c *Controller) deleteLabelIdentity(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object when deleting LabelIdentity, invalid type", "object", obj)
+			klog.ErrorS(nil, "Error decoding object when deleting LabelIdentity, invalid type", "object", obj)
 			return
 		}
 		labelIdentity, ok = tombstone.Obj.(*mcv1alpha1.LabelIdentity)
 		if !ok {
-			klog.V(2).InfoS("Error decoding object tombstone when deleting LabelIdentity, invalid type", "object", tombstone.Obj)
+			klog.ErrorS(nil, "Error decoding object tombstone when deleting LabelIdentity, invalid type", "object", tombstone.Obj)
 			return
 		}
 	}

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -166,12 +166,12 @@ func (c *Controller) deleteTraceflow(old interface{}) {
 	if !ok {
 		tombstone, ok := old.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			klog.V(2).InfoS("Unexpected object type when deleting Traceflow", "object", old)
+			klog.ErrorS(nil, "Unexpected object type when deleting Traceflow", "object", old)
 			return
 		}
 		tf, ok = tombstone.Obj.(*crdv1beta1.Traceflow)
 		if !ok {
-			klog.V(2).InfoS("Unexpected object type in tombstone when deleting Traceflow", "object", tombstone.Obj)
+			klog.ErrorS(nil, "Unexpected object type in tombstone when deleting Traceflow", "object", tombstone.Obj)
 			return
 		}
 	}


### PR DESCRIPTION
Follow-up to #8161  antoninbas pointed out those handlers logged decode failures at `V(2).InfoS` where `ErrorS` reflects the behavior better. Same fix, applied to the other 5 files #7964 touched, which had the identical inconsistency.

No behavior change, just log level. Tests pass.
