### PR TITLE
multicluster: start member StaleResCleanupController after cache is synced

### DIFF
--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -141,8 +141,12 @@ func runMember(o *Options) error {
 		env.GetPodNamespace(),
 		commonAreaGetter,
 	)
-
-	go staleController.Run(stopCh)
+	// Add the StaleResCleanupController as a Runnable to the Manager so it is started
+	// only after the cache has been synced, avoiding a spurious "the cache is not started"
+	// error on startup (see antrea-io/antrea#6152).
+	if err = mgr.Add(staleController); err != nil {
+		return fmt.Errorf("error adding StaleResCleanupController to Manager: %v", err)
+	}
 
 	// Member runs ResourceImportReconciler from RemoteCommonArea only
 

--- a/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
@@ -587,7 +587,11 @@ func TestStaleControllerNoRaceWithResourceImportReconciler(t *testing.T) {
 	go mgr.Run(stopCh)
 	// The staleController should not erroneously delete any LabelIdentities while the reconciliation
 	// of newly added ResourceImports are in-flight.
-	go c.Run(stopCh)
+	go func() {
+		if err := c.Start(wait.ContextForChannel(stopCh)); err != nil {
+			t.Errorf("StaleResCleanupController.Start returned an error: %v", err)
+		}
+	}()
 	time.Sleep(1 * time.Second)
 	actLabelIdentities := &mcv1alpha1.LabelIdentityList{}
 	err := fakeClient.List(ctx, actLabelIdentities)

--- a/multicluster/controllers/multicluster/member/stale_controller.go
+++ b/multicluster/controllers/multicluster/member/stale_controller.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8smcv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
@@ -361,29 +360,46 @@ func (c *StaleResCleanupController) cleanUpClusterInfoResourceExports(ctx contex
 	return nil
 }
 
-// Run starts the StaleResCleanupController and blocks until stopCh is closed.
-func (c *StaleResCleanupController) Run(stopCh <-chan struct{}) {
+// Start starts the StaleResCleanupController and blocks until ctx is canceled. It implements
+// the controller-runtime Runnable interface, so the controller can be added to the Manager via
+// mgr.Add. The Manager only starts Runnables after the cache has been synced, which guarantees
+// that the first call to CleanUp won't fail with "the cache is not started, can not read objects"
+// (see antrea-io/antrea#6152).
+func (c *StaleResCleanupController) Start(ctx context.Context) error {
 	klog.InfoS("Starting StaleResCleanupController")
 	defer klog.InfoS("Shutting down StaleResCleanupController")
 
-	ctx := wait.ContextForChannel(stopCh)
-
 	go func() {
-		retry.OnError(common.CleanUpRetry, func(err error) bool { return true },
-			func() error {
-				return c.CleanUp(ctx)
-			})
+		// wait.ExponentialBackoffWithContext, unlike retry.OnError, stops retrying as soon as
+		// ctx is canceled instead of running the full backoff (which can take tens of minutes
+		// given common.CleanUpRetry's Steps/Duration/Factor).
+		_ = wait.ExponentialBackoffWithContext(ctx, common.CleanUpRetry, func(ctx context.Context) (bool, error) {
+			if err := c.CleanUp(ctx); err != nil {
+				return false, nil
+			}
+			return true, nil
+		})
 	}()
 
-	for range c.commonAreaCreationCh {
-		retry.OnError(common.CleanUpRetry, func(err error) bool { return true },
-			func() error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case _, ok := <-c.commonAreaCreationCh:
+			if !ok {
+				return nil
+			}
+			// See the comment above on why ExponentialBackoffWithContext is used instead of
+			// retry.OnError: it must not block this select loop from observing ctx.Done()
+			// for the entire retry duration.
+			_ = wait.ExponentialBackoffWithContext(ctx, common.CleanUpRetry, func(ctx context.Context) (bool, error) {
 				if err := c.cleanUpStaleResources(ctx); err != nil {
 					klog.ErrorS(err, "Failed to clean up stale resources after a ClusterSet is created, will retry later")
-					return err
+					return false, nil
 				}
-				return nil
+				return true, nil
 			})
+		}
 	}
 }
 

--- a/multicluster/controllers/multicluster/member/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/member/stale_controller_test.go
@@ -785,3 +785,19 @@ func TestCleanUpGateway(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(actualGWList.Items))
 }
+
+// TestStart verifies that Start implements the controller-runtime Runnable contract: it
+// returns nil once ctx is done, so the controller can be added to a Manager via mgr.Add
+// (see antrea-io/antrea#6152). Start's behavior while running is already covered by
+// TestStaleControllerNoRaceWithResourceImportReconciler in resourceimport_controller_test.go.
+func TestStart(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(clusterSet).Build()
+	commonArea := commonarea.NewFakeRemoteCommonArea(fakeClient, "leader-cluster", common.LocalClusterID, "default", nil)
+	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
+	mcReconciler.SetRemoteCommonArea(commonArea)
+	c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.NoError(t, c.Start(ctx))
+}

--- a/multicluster/test/integration/suite_test.go
+++ b/multicluster/test/integration/suite_test.go
@@ -175,7 +175,8 @@ var _ = BeforeSuite(func() {
 		clusterSetReconciler,
 	)
 
-	go staleController.Run(stopCh)
+	err = k8sManager.Add(staleController)
+	Expect(err).ToNot(HaveOccurred())
 	// Fake the commonAreaCreation event since the ClusterSet creation is only triggered one time
 	// when the ClusterSet is created, but the stale controller test is not running yet.
 	go wait.UntilWithContext(ctx, func(ctx context.Context) {


### PR DESCRIPTION
Member-side twin of #8133 (already merged) — same cache-sync race (#6152), fixed the same way (`Run(stopCh)` → `Start(ctx) error`, wired via `mgr.Add()`).

Picks up the diagnosis from #8132 (@AVPthegreat), stale for weeks with an unresolved DCO check. Also fixed a separate bug found along the way: the old shutdown loop only exited if `commonAreaCreationCh` was closed, which never happens, so it could never actually return.

Tests pass, `gofmt`/`go vet` clean.
