### PR TITLE
antreanodeconfig: reject VLAN ID 0 in AllowedVLANs

### DIFF
--- a/pkg/controller/antreanodeconfig/validate.go
+++ b/pkg/controller/antreanodeconfig/validate.go
@@ -27,7 +27,10 @@ import (
 	crdv1alpha1 "antrea.io/antrea/v2/pkg/apis/crd/v1alpha1"
 )
 
-const maxVLANID = 4094
+const (
+	minVLANID = 1
+	maxVLANID = 4094
+)
 
 type vlanIDRange struct {
 	start uint16
@@ -119,6 +122,9 @@ func validateVLANSpecs(specs []string) error {
 		}
 		if r.start > r.end {
 			return fmt.Errorf("VLAN range start %d is greater than end %d", r.start, r.end)
+		}
+		if r.start < minVLANID {
+			return fmt.Errorf("VLAN ID %d is less than the minimum VLAN ID %d", r.start, minVLANID)
 		}
 		if r.end > maxVLANID {
 			return fmt.Errorf("VLAN ID %d is greater than the maximum VLAN ID %d", r.end, maxVLANID)

--- a/pkg/controller/antreanodeconfig/validate_test.go
+++ b/pkg/controller/antreanodeconfig/validate_test.go
@@ -91,6 +91,17 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			name:      "single VLAN below minimum",
+			operation: admv1.Create,
+			anc:       newAntreaNodeConfig([]string{"0"}),
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "spec.secondaryNetwork.ovsBridges[0].physicalInterfaces[0].allowedVLANs is invalid: VLAN ID 0 is less than the minimum VLAN ID 1",
+				},
+			},
+		},
+		{
 			name:      "range end above maximum",
 			operation: admv1.Create,
 			anc:       newAntreaNodeConfig([]string{"4094-4095"}),


### PR DESCRIPTION
`validateVLANSpecs` checks that a VLAN ID/range doesn't exceed the maximum (4094), but never checks a lower bound, so `"0"` or a range like `"0-100"` passes validation today. OVS itself treats VLAN 0 as synonymous with an untagged packet (no VLAN header) — per IEEE 802.1Q, it's reserved to mean "priority-tagged frame, no VLAN membership" — so it doesn't look like a real, taggable VLAN ID that belongs in an allow-list.

That said, I'm inferring this from the field's general shape (the existing upper-bound check already assumes a bounded range of "real" VLAN IDs) rather than from any stated intent — `AllowedVLANs` isn't consumed by any agent code yet, so there's no downstream behavior to confirm against either way. Happy to adjust if `0` was meant to have some other meaning here.

Added one test case proving `"0"` is now rejected; confirmed it fails without the fix and passes with it. Existing tests unaffected.
