### PR TITLE
fix: prevent nil pointer dereference in filestore and clickhouse client

### DIFF
--- a/pkg/agent/controller/networkpolicy/filestore.go
+++ b/pkg/agent/controller/networkpolicy/filestore.go
@@ -102,6 +102,9 @@ func (s fileStore) replaceAll(items []runtime.Object) error {
 func (s fileStore) loadAll() ([]runtime.Object, error) {
 	var objects []runtime.Object
 	err := afero.Walk(s.fs, s.dir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
 		if info.IsDir() {
 			return nil
 		}

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
@@ -259,9 +259,11 @@ func (ch *ClickHouseExportProcess) batchCommitAll(ctx context.Context) (int, err
 
 	// start new connection
 	tx, err := ch.db.BeginTx(ctx, nil)
-	if err == nil {
-		stmt, err = tx.PrepareContext(ctx, insertQuery)
+	if err != nil {
+		klog.ErrorS(err, "Error when starting transaction")
+		return 0, err
 	}
+	stmt, err = tx.PrepareContext(ctx, insertQuery)
 	if err != nil {
 		klog.ErrorS(err, "Error when preparing insert statement")
 		_ = tx.Rollback()


### PR DESCRIPTION
## Summary
- Add error check in filestore Walk callback to prevent nil pointer dereference
- Fix nil transaction rollback in clickhouse client

## Motivation
### Bug 1: filestore Walk callback
The `afero.Walk` callback receives an `err` parameter that can be non-nil when `info` is nil. The code accessed `info.IsDir()` without first checking whether `err != nil`. If the Walk function encounters an error (e.g., permission denied reading a directory), `info` will be nil, and calling `info.IsDir()` will panic with a nil pointer dereference. The analogous code in `pkg/support/dump.go` correctly handles this case.

### Bug 2: clickhouse transaction rollback
When `ch.db.BeginTx()` fails, `tx` is nil. The error check caught this, but then called `tx.Rollback()` unconditionally, which would panic on a nil transaction.

## Changes
| File | Change |
|------|--------|
| `pkg/agent/controller/networkpolicy/filestore.go:104` | Add `if err != nil { return nil }` before `info.IsDir()` |
| `pkg/flowaggregator/clickhouseclient/clickhouseclient.go:261-267` | Check `BeginTx` error separately before `PrepareContext` |

## Testing
- [x] Existing tests pass

Signed-off-by: Akanksha Trehun <magic-peach@users.noreply.github.com>