### PR TITLE
fix: close ClickHouse connection on ping failure during retry

### DIFF
--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
@@ -457,6 +457,7 @@ func ConnectClickHouse(config *ClickHouseConfig) (*sql.DB, error) {
 		}
 		connect = clickhouse.OpenDB(&opt)
 		if err := connect.Ping(); err != nil {
+			connect.Close()
 			if exception, ok := err.(*clickhouse.Exception); ok {
 				connErr = fmt.Errorf("failed to ping ClickHouse: %v", exception.Message)
 			} else {


### PR DESCRIPTION
## Summary
Close ClickHouse connection on ping failure during retry to prevent resource leaks.

## Motivation
In `ConnectClickHouse`, within the retry loop, `clickhouse.OpenDB(&opt)` creates a new database connection on every iteration. When `connect.Ping()` fails, the connection was not closed before retrying. Each failed retry leaked a `*sql.DB` object holding underlying TCP sockets and associated goroutines.

During startup, if ClickHouse is temporarily unavailable (common during rolling upgrades), the agent would leak one connection per retry attempt (up to ~10 connections over 10 seconds).

## Changes
| File | Change |
|------|--------|
| `pkg/flowaggregator/clickhouseclient/clickhouseclient.go:459` | Add `connect.Close()` before returning on ping failure |

## Testing
- [x] Existing tests pass

Signed-off-by: Akanksha Trehun <magic-peach@users.noreply.github.com>