### PR TITLE
Fix assert object usage in secondary network e2e test

### DIFF
--- a/test/e2e-secondary-network/secondary_network_test.go
+++ b/test/e2e-secondary-network/secondary_network_test.go
@@ -97,6 +97,7 @@ func (data *testData) formAnnotationStringOfPod(pod *testPodInfo) string {
 			annotationString = annotationString + ", " + podNetworkSpec
 		}
 	}
+
 	annotationString += "]"
 	return annotationString
 }
@@ -162,7 +163,7 @@ func (data *testData) assertPodNetworkStatus(t *testing.T, clientset *kubernetes
 			}
 			if secondaryNetworkList == nil {
 				_, ok := podItem.Annotations[nadv1.NetworkStatusAnnot]
-				assert.False(t, ok, "Pod network status annotation should be deleted")
+				assert.False(collect, ok, "Pod network status annotation should be deleted")
 				return
 			}
 
@@ -181,9 +182,9 @@ func (data *testData) assertPodNetworkStatus(t *testing.T, clientset *kubernetes
 			var secondaryNetworkStatus []nadv1.NetworkStatus
 			for i, network := range networkStatus {
 				if network.Interface == "eth0" {
-					assert.Equal(t, macMap[network.Interface], network.Mac, "The primary network status `Mac` is not as expected")
-					assert.Equal(t, cniserver.AntreaCNIType, network.Name, "The primary network status `Name` is not as expected")
-					assert.Equal(t, true, network.Default, "The primary network status `Default` is not as expected")
+					assert.Equal(collect, macMap[network.Interface], network.Mac, "The primary network status `Mac` is not as expected")
+					assert.Equal(collect, cniserver.AntreaCNIType, network.Name, "The primary network status `Name` is not as expected")
+					assert.Equal(collect, true, network.Default, "The primary network status `Default` is not as expected")
 				} else {
 					secondaryNetworkStatus = append(secondaryNetworkStatus, networkStatus[i])
 				}


### PR DESCRIPTION
The `assertPodNetworkStatus` function incorrectly used the outer `t` (*testing.T) instead of `collect` (*assert.CollectT) within the `assert.EventuallyWithT` closure. This caused the test to fail immediately on the first polling attempt if the condition was not met, bypassing the intended asynchronous waiting mechanism and leading to flaky test failures.

This commit replaces `t` with `collect` for all assertions inside the `EventuallyWithT` block to ensure correct polling behavior.