### PR TITLE
Fix data race on Node IPs in NPLController.Run()

### DIFF
--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -184,6 +184,14 @@ func (c *NPLController) getNodeIPForFamily(ipFamily corev1.IPFamily) string {
 	return c.nodeIPv4
 }
 
+// getNodeIPs returns both cached Node IPs under the read lock so callers
+// receive a consistent snapshot without two separate lock acquisitions.
+func (c *NPLController) getNodeIPs() (string, string) {
+	c.nodeIPMutex.RLock()
+	defer c.nodeIPMutex.RUnlock()
+	return c.nodeIPv4, c.nodeIPv6
+}
+
 func (c *NPLController) getPortTableForFamily(ipFamily corev1.IPFamily) *portcache.PortTable {
 	if ipFamily == corev1.IPv6Protocol {
 		return c.portTableIPv6
@@ -264,7 +272,8 @@ func (c *NPLController) Run(stopCh <-chan struct{}) {
 		klog.ErrorS(err, "Failed to determine Node IPs")
 		return
 	}
-	klog.InfoS("Node IPs are ready", "IPv4", c.nodeIPv4, "IPv6", c.nodeIPv6)
+	nodeIPv4, nodeIPv6 := c.getNodeIPs()
+	klog.InfoS("Node IPs are ready", "IPv4", nodeIPv4, "IPv6", nodeIPv6)
 
 	if err := c.waitForRulesInitialization(wait.ContextForChannel(stopCh)); err != nil {
 		klog.ErrorS(err, "Failed to initialize NodePortLocal rules")

--- a/pkg/agent/nodeportlocal/k8s/npl_controller_test.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller_test.go
@@ -1336,3 +1336,42 @@ func TestDualStack(t *testing.T) {
 		assert.True(t, testData.portTableIPv6.RuleExists(defaultPodKey, defaultPort, protocolTCP))
 	})
 }
+
+// TestNodeIPsReadyNoDataRace verifies that reading Node IPs after the poll loop in Run()
+// does not race with concurrent writes from the node informer.
+//
+// Before the fix, Run() accessed c.nodeIPv4 and c.nodeIPv6 directly at the log line
+// after PollUntilContextCancel, without holding nodeIPMutex. The node informer goroutine
+// can concurrently call updateNodeIPs() which writes those fields under a write lock.
+// This test, when run with "go test -race", will detect that race in unpatched code.
+//
+// After the fix, Run() calls getNodeIPs() which acquires the read lock, eliminating the race.
+func TestNodeIPsReadyNoDataRace(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		testSvc := getTestSvc()
+		testPod := getTestPod()
+		// setUp starts Run() and the node informer concurrently; with -race this exercises
+		// the previously-unprotected read of nodeIPv4/nodeIPv6 right after the poll loop.
+		testData := setUp(t, newTestConfig(), testSvc, testPod)
+
+		synctest.Wait()
+
+		// Trigger a Node IP update to exercise concurrent writes to nodeIPv4/nodeIPv6
+		// while Run() may be logging them.
+		newNodeIP := "10.10.10.99"
+		node, err := testData.k8sClient.CoreV1().Nodes().Get(t.Context(), defaultNodeName, metav1.GetOptions{})
+		require.NoError(t, err)
+		node.Status.Addresses = []corev1.NodeAddress{
+			{Type: corev1.NodeExternalIP, Address: newNodeIP},
+			{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+		}
+		_, err = testData.k8sClient.CoreV1().Nodes().UpdateStatus(t.Context(), node, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		synctest.Wait()
+
+		// Verify the annotation is updated — this also confirms the controller is still healthy.
+		expectedAnnotations := newExpectedNPLAnnotations().Add(types.IPFamilyIPv4, &newNodeIP, nil, defaultPort, protocolTCP)
+		testData.assertExpectedNPLAnnotations(testPod.Name, expectedAnnotations)
+	})
+}

--- a/pkg/agent/nodeportlocal/k8s/npl_controller_test.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller_test.go
@@ -1341,9 +1341,9 @@ func TestDualStack(t *testing.T) {
 // does not race with concurrent writes from the node informer.
 //
 // Before the fix, Run() accessed c.nodeIPv4 and c.nodeIPv6 directly at the log line
-// after PollUntilContextCancel, without holding nodeIPMutex. The node informer goroutine
-// can concurrently call updateNodeIPs() which writes those fields under a write lock.
-// This test, when run with "go test -race", will detect that race in unpatched code.
+// after PollUntilContextCancel, without holding nodeIPMutex, which could race with
+// concurrent updateNodeIPs() writes from the Node informer.
+// Running this test with "go test -race" is intended to help catch regressions of that issue.
 //
 // After the fix, Run() calls getNodeIPs() which acquires the read lock, eliminating the race.
 func TestNodeIPsReadyNoDataRace(t *testing.T) {


### PR DESCRIPTION
## Description

This PR fixes a data race on `nodeIPv4` and `nodeIPv6` in `NPLController.Run()` that is detectable by `go test -race`.

### Background
In the NodePortLocal architecture, the `NPLController` needs to know the Node's IP addresses to properly annotate Pods and handle local traffic. During controller startup in `Run()`, the controller polls `c.nodeIPsReady()` (which safely acquires `c.nodeIPMutex.RLock()`) until the Node's IP addresses are populated by the Node informer.

### The Bug
Once `PollUntilContextCancel` exits successfully, the controller logs that the Node IPs are ready. The previous code executed this log line:
```go
klog.InfoS("Node IPs are ready", "IPv4", c.nodeIPv4, "IPv6", c.nodeIPv6)
