### PR TITLE
Retry Pod flow installation on reconcile failure

### DIFF
--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -514,7 +514,8 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 				containerConfig.VLANID,
 				nil,
 			); err != nil {
-				klog.ErrorS(err, "Error when re-installing flows for Pod", "Pod", klog.KRef(namespace, name))
+				klog.ErrorS(err, "Error when re-installing flows for Pod, will retry in the background", "Pod", klog.KRef(namespace, name))
+				pc.retryInstallPodFlows(containerID, name, namespace, containerAccess)
 			}
 		}(containerConfig.ContainerID, name, namespace)
 	}
@@ -533,6 +534,37 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 	}
 
 	return nil
+}
+
+// retryInstallPodFlows retries flow installation for a Pod until it succeeds or the Pod is removed.
+func (pc *podConfigurator) retryInstallPodFlows(containerID, podName, podNamespace string, containerAccess *containerAccessArbitrator) {
+	go func() {
+		for {
+			time.Sleep(retryInterval)
+			containerAccess.lockContainer(containerID)
+			containerConfig, exists := pc.ifaceStore.GetContainerInterface(containerID)
+			if !exists {
+				containerAccess.unlockContainer(containerID)
+				klog.InfoS("The container interface had been deleted, stop retrying Pod flow installation", "Pod", klog.KRef(podNamespace, podName), "containerID", containerID)
+				return
+			}
+			err := pc.ofClient.InstallPodFlows(
+				containerConfig.InterfaceName,
+				containerConfig.IPs,
+				containerConfig.MAC,
+				uint32(containerConfig.OFPort),
+				containerConfig.VLANID,
+				nil,
+			)
+			containerAccess.unlockContainer(containerID)
+
+			if err == nil {
+				klog.InfoS("Successfully re-installed flows for Pod after retry", "Pod", klog.KRef(podNamespace, podName))
+				return
+			}
+			klog.ErrorS(err, "Retry failed to re-install flows for Pod, will retry again", "Pod", klog.KRef(podNamespace, podName))
+		}
+	}()
 }
 
 // disconnectInterfaceFromOVS disconnects an existing interface from ovs br-int.

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	v1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/events"
@@ -69,7 +70,8 @@ const (
 )
 
 var (
-	getNSPath = util.GetNSPath
+	getNSPath  = util.GetNSPath
+	workerName = "podConfigurator"
 	// retryInterval is the interval to re-install Pod OpenFlow entries if any error happened.
 	// Note, using a variable rather than constant for retryInterval because we may use a shorter time in the
 	// test code.
@@ -132,6 +134,36 @@ func newPodConfigurator(
 	// Initiate the PortStatus message listener. This function is a no-op except on Windows.
 	pc.initPortStatusMonitor(podInformer)
 	return pc, nil
+}
+
+// initUnreadyPortQueue sets up the workqueue, Pod lister and event recorder shared by
+// updateUnreadyPod / processNextWorkItem, which (re)install a Pod's OpenFlow entries in the
+// background, retrying with rate limiting until it succeeds or the Pod is removed.
+// podInformer is nil for a podConfigurator instance that only configures Pod secondary network
+// interfaces; such an instance never reconciles and has nothing to feed into the queue.
+func (pc *podConfigurator) initUnreadyPortQueue(podInformer cache.SharedIndexInformer) {
+	if podInformer == nil {
+		return
+	}
+	pc.podLister = v1.NewPodLister(podInformer.GetIndexer())
+	pc.podListerSynced = podInformer.HasSynced
+	pc.unreadyPortQueue = workqueue.NewTypedDelayingQueueWithConfig[string](
+		workqueue.TypedDelayingQueueConfig[string]{
+			Name: workerName,
+		},
+	)
+	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{
+		Interface: pc.kubeClient.EventsV1(),
+	})
+	pc.eventBroadcaster = eventBroadcaster
+	pc.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, "AntreaPodConfigurator")
+}
+
+// worker is a long-running function that will continually call the processNextWorkItem function in
+// order to read and process a message on the workqueue.
+func (pc *podConfigurator) worker() {
+	for pc.processNextWorkItem() {
+	}
 }
 
 func parseContainerIPs(ipcs []*current.IPConfig) ([]net.IP, error) {
@@ -514,8 +546,8 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 				containerConfig.VLANID,
 				nil,
 			); err != nil {
-				klog.ErrorS(err, "Error when re-installing flows for Pod, will retry in the background", "Pod", klog.KRef(namespace, name))
-				pc.retryInstallPodFlows(containerID, name, namespace, containerAccess)
+				klog.ErrorS(err, "Error when re-installing flows for Pod, will retry", "Pod", klog.KRef(namespace, name))
+				pc.unreadyPortQueue.Add(containerConfig.InterfaceName)
 			}
 		}(containerConfig.ContainerID, name, namespace)
 	}
@@ -534,41 +566,6 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 	}
 
 	return nil
-}
-
-// retryInstallPodFlows retries flow installation for a Pod until it succeeds or the Pod is removed.
-func (pc *podConfigurator) retryInstallPodFlows(containerID, podName, podNamespace string, containerAccess *containerAccessArbitrator) {
-	go func() {
-		for {
-			sleepDuration := retryInterval
-			if sleepDuration <= 0 {
-				sleepDuration = time.Second
-			}
-			time.Sleep(sleepDuration)
-			containerAccess.lockContainer(containerID)
-			containerConfig, exists := pc.ifaceStore.GetContainerInterface(containerID)
-			if !exists {
-				containerAccess.unlockContainer(containerID)
-				klog.InfoS("The container interface has been deleted, stop retrying Pod flow installation", "Pod", klog.KRef(podNamespace, podName), "containerID", containerID)
-				return
-			}
-			err := pc.ofClient.InstallPodFlows(
-				containerConfig.InterfaceName,
-				containerConfig.IPs,
-				containerConfig.MAC,
-				uint32(containerConfig.OFPort),
-				containerConfig.VLANID,
-				nil,
-			)
-			containerAccess.unlockContainer(containerID)
-
-			if err == nil {
-				klog.InfoS("Successfully re-installed flows for Pod after retry", "Pod", klog.KRef(podNamespace, podName))
-				return
-			}
-			klog.ErrorS(err, "Retry failed to re-install flows for Pod, will retry again", "Pod", klog.KRef(podNamespace, podName))
-		}
-	}()
 }
 
 // disconnectInterfaceFromOVS disconnects an existing interface from ovs br-int.

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -540,12 +540,16 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 func (pc *podConfigurator) retryInstallPodFlows(containerID, podName, podNamespace string, containerAccess *containerAccessArbitrator) {
 	go func() {
 		for {
-			time.Sleep(retryInterval)
+			sleepDuration := retryInterval
+			if sleepDuration <= 0 {
+				sleepDuration = time.Second
+			}
+			time.Sleep(sleepDuration)
 			containerAccess.lockContainer(containerID)
 			containerConfig, exists := pc.ifaceStore.GetContainerInterface(containerID)
 			if !exists {
 				containerAccess.unlockContainer(containerID)
-				klog.InfoS("The container interface had been deleted, stop retrying Pod flow installation", "Pod", klog.KRef(podNamespace, podName), "containerID", containerID)
+				klog.InfoS("The container interface has been deleted, stop retrying Pod flow installation", "Pod", klog.KRef(podNamespace, podName), "containerID", containerID)
 				return
 			}
 			err := pc.ofClient.InstallPodFlows(

--- a/pkg/agent/cniserver/pod_configuration_linux.go
+++ b/pkg/agent/cniserver/pod_configuration_linux.go
@@ -20,8 +20,10 @@ package cniserver
 import (
 	"fmt"
 	"net"
+	"time"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -106,10 +108,30 @@ func (pc *podConfigurator) isInterfaceInvalid(ifaceConfig *interfacestore.Interf
 	return ifaceConfig.OFPort == -1
 }
 
-func (pc *podConfigurator) initPortStatusMonitor(_ cache.SharedIndexInformer) {
-
+func (pc *podConfigurator) initPortStatusMonitor(podInformer cache.SharedIndexInformer) {
+	pc.initUnreadyPortQueue(podInformer)
 }
 
 func (pc *podConfigurator) Run(stopCh <-chan struct{}) {
+	// unreadyPortQueue is nil for a podConfigurator instance that only configures Pod secondary
+	// network interfaces; there is nothing to run for it.
+	if pc.unreadyPortQueue == nil {
+		<-stopCh
+		return
+	}
+	defer pc.unreadyPortQueue.ShutDown()
+
+	klog.InfoS("Starting", "worker", workerName)
+	defer klog.InfoS("Shutting down", "worker", workerName)
+
+	if !cache.WaitForNamedCacheSync(workerName, stopCh, pc.podListerSynced) {
+		return
+	}
+	pc.eventBroadcaster.StartStructuredLogging(0)
+	pc.eventBroadcaster.StartRecordingToSink(stopCh)
+	defer pc.eventBroadcaster.Shutdown()
+
+	go wait.Until(pc.worker, time.Second, stopCh)
+
 	<-stopCh
 }

--- a/pkg/agent/cniserver/pod_configuration_windows.go
+++ b/pkg/agent/cniserver/pod_configuration_windows.go
@@ -24,19 +24,11 @@ import (
 	"antrea.io/libOpenflow/openflow15"
 	current "github.com/containernetworking/cni/pkg/types/100"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/scheme"
-	v1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/events"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/v2/pkg/agent/cniserver/ipam"
 	"antrea.io/antrea/v2/pkg/agent/interfacestore"
-)
-
-var (
-	workerName = "podConfigurator"
 )
 
 const (
@@ -148,21 +140,7 @@ func (pc *podConfigurator) reconcileMissingPods(ifConfigs []*interfacestore.Inte
 // initPortStatusMonitor has subscribed a channel to listen for the OpenFlow PortStatus message, and it also
 // initiates the Pod recorder.
 func (pc *podConfigurator) initPortStatusMonitor(podInformer cache.SharedIndexInformer) {
-	pc.podLister = v1.NewPodLister(podInformer.GetIndexer())
-	pc.podListerSynced = podInformer.HasSynced
-	pc.unreadyPortQueue = workqueue.NewTypedDelayingQueueWithConfig[string](
-		workqueue.TypedDelayingQueueConfig[string]{
-			Name: workerName,
-		},
-	)
-	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{
-		Interface: pc.kubeClient.EventsV1(),
-	})
-	pc.eventBroadcaster = eventBroadcaster
-	pc.recorder = eventBroadcaster.NewRecorder(
-		scheme.Scheme,
-		"AntreaPodConfigurator",
-	)
+	pc.initUnreadyPortQueue(podInformer)
 	pc.statusCh = make(chan *openflow15.PortStatus, 100)
 	pc.ofClient.SubscribeOFPortStatusMessage(pc.statusCh)
 }
@@ -170,10 +148,10 @@ func (pc *podConfigurator) initPortStatusMonitor(podInformer cache.SharedIndexIn
 func (pc *podConfigurator) Run(stopCh <-chan struct{}) {
 	defer pc.unreadyPortQueue.ShutDown()
 
-	klog.Infof("Starting %s", workerName)
-	defer klog.Infof("Shutting down %s", workerName)
+	klog.InfoS("Starting", "worker", workerName)
+	defer klog.InfoS("Shutting down", "worker", workerName)
 
-	if !cache.WaitForNamedCacheSync("podConfigurator", stopCh, pc.podListerSynced) {
+	if !cache.WaitForNamedCacheSync(workerName, stopCh, pc.podListerSynced) {
 		return
 	}
 	pc.eventBroadcaster.StartStructuredLogging(0)
@@ -191,12 +169,5 @@ func (pc *podConfigurator) Run(stopCh <-chan struct{}) {
 		case <-stopCh:
 			return
 		}
-	}
-}
-
-// worker is a long-running function that will continually call the processNextWorkItem function in
-// order to read and process a message on the workqueue.
-func (pc *podConfigurator) worker() {
-	for pc.processNextWorkItem() {
 	}
 }

--- a/pkg/agent/cniserver/server_linux_test.go
+++ b/pkg/agent/cniserver/server_linux_test.go
@@ -677,29 +677,34 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-// TestReconcileRetriesOnInstallPodFlowsFailure verifies flows are retried in the background
-// when InstallPodFlows fails during reconcile.
+// TestReconcileRetriesOnInstallPodFlowsFailure verifies that when InstallPodFlows fails during
+// reconcile, the Pod's interface is fed into unreadyPortQueue and the existing queue worker
+// (processNextWorkItem / updateUnreadyPod) retries and succeeds, instead of the Pod being left
+// without a working dataplane.
 func TestReconcileRetriesOnInstallPodFlowsFailure(t *testing.T) {
-	oriRetryInterval := retryInterval
-	retryInterval = 10 * time.Millisecond
-	defer func() {
-		retryInterval = oriRetryInterval
-	}()
-
 	controller := gomock.NewController(t)
-	kubeClient := fakeclientset.NewClientset(pod1)
 	mockOVSBridgeClient = ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient = openflowtest.NewMockClient(controller)
 	ifaceStore = interfacestore.NewInterfaceStore()
 	mockRoute = routetest.NewMockInterface(controller)
 	cniServer := newCNIServer(t)
 	cniServer.routeClient = mockRoute
-	cniServer.podConfigurator, _ = newPodConfigurator(nil, mockOVSBridgeClient, mockOFClient, mockRoute, ifaceStore, gwMAC, "system", false, false, channel.NewSubscribableChannel("PodUpdate", 100), nil, nil)
+
+	clients := newMockClients(controller, nodeName, pod1)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	clients.startInformers(stopCh)
+	cniServer.kubeClient = clients.kubeClient
+
+	cniServer.podConfigurator, _ = newPodConfigurator(
+		clients.kubeClient, mockOVSBridgeClient, mockOFClient, mockRoute, ifaceStore, gwMAC, "system", false, false,
+		channel.NewSubscribableChannel("PodUpdate", 100), clients.localPodInformer, cniServer.containerAccess)
 	cniServer.podConfigurator.ifConfigurator = newTestInterfaceConfigurator()
+	go cniServer.podConfigurator.Run(stopCh)
+
 	cniServer.nodeConfig = &config.NodeConfig{
 		Name: nodeName,
 	}
-	cniServer.kubeClient = kubeClient
 	ifaceStore.AddInterface(normalInterface)
 
 	podFlowsInstalled := make(chan struct{})
@@ -717,6 +722,6 @@ func TestReconcileRetriesOnInstallPodFlowsFailure(t *testing.T) {
 	select {
 	case <-podFlowsInstalled:
 	case <-time.After(2 * time.Second):
-		t.Errorf("InstallPodFlows for %s should have been retried and succeeded but was not", normalInterface.InterfaceName)
+		t.Errorf("InstallPodFlows for %s should have been retried via unreadyPortQueue but was not", normalInterface.InterfaceName)
 	}
 }

--- a/pkg/agent/cniserver/server_linux_test.go
+++ b/pkg/agent/cniserver/server_linux_test.go
@@ -676,3 +676,47 @@ func TestReconcile(t *testing.T) {
 		t.Errorf("InstallPodFlows for %s should be called but was not", normalInterface.InterfaceName)
 	}
 }
+
+// TestReconcileRetriesOnInstallPodFlowsFailure verifies flows are retried in the background
+// when InstallPodFlows fails during reconcile.
+func TestReconcileRetriesOnInstallPodFlowsFailure(t *testing.T) {
+	oriRetryInterval := retryInterval
+	retryInterval = 10 * time.Millisecond
+	defer func() {
+		retryInterval = oriRetryInterval
+	}()
+
+	controller := gomock.NewController(t)
+	kubeClient := fakeclientset.NewClientset(pod1)
+	mockOVSBridgeClient = ovsconfigtest.NewMockOVSBridgeClient(controller)
+	mockOFClient = openflowtest.NewMockClient(controller)
+	ifaceStore = interfacestore.NewInterfaceStore()
+	mockRoute = routetest.NewMockInterface(controller)
+	cniServer := newCNIServer(t)
+	cniServer.routeClient = mockRoute
+	cniServer.podConfigurator, _ = newPodConfigurator(nil, mockOVSBridgeClient, mockOFClient, mockRoute, ifaceStore, gwMAC, "system", false, false, channel.NewSubscribableChannel("PodUpdate", 100), nil, nil)
+	cniServer.podConfigurator.ifConfigurator = newTestInterfaceConfigurator()
+	cniServer.nodeConfig = &config.NodeConfig{
+		Name: nodeName,
+	}
+	cniServer.kubeClient = kubeClient
+	ifaceStore.AddInterface(normalInterface)
+
+	podFlowsInstalled := make(chan struct{})
+	gomock.InOrder(
+		mockOFClient.EXPECT().InstallPodFlows(normalInterface.InterfaceName, normalInterface.IPs, normalInterface.MAC, uint32(normalInterface.OFPort), uint16(0), nil).
+			Return(fmt.Errorf("transient OVS error")).Times(1),
+		mockOFClient.EXPECT().InstallPodFlows(normalInterface.InterfaceName, normalInterface.IPs, normalInterface.MAC, uint32(normalInterface.OFPort), uint16(0), nil).
+			Do(func(_ string, _ []net.IP, _ net.HardwareAddr, _ uint32, _ uint16, _ *uint32) {
+				close(podFlowsInstalled)
+			}).Return(nil).Times(1),
+	)
+	err := cniServer.reconcile()
+	assert.NoError(t, err)
+
+	select {
+	case <-podFlowsInstalled:
+	case <-time.After(2 * time.Second):
+		t.Errorf("InstallPodFlows for %s should have been retried and succeeded but was not", normalInterface.InterfaceName)
+	}
+}


### PR DESCRIPTION
Fixes a reconciliation gap in the antrea-agent CNI server where a Pod's OpenFlow entries could be permanently lost if flow installation failed during agent-startup reconciliation, leaving the Pod unable to reach ClusterIP Services until it was manually deleted and recreated.
Fixes #8178 

Change:

When `InstallPodFlows` fails inside `reconcile()`, the Pod's containerID is now handed to a new `retryInstallPodFlows` goroutine that keeps retrying (using the existing `containerAccess` per-container lock to stay safe against concurrent CNI events) until the flows install successfully or the interface is removed from the store (e.g. because the Pod was deleted). This runs independently of reconcile's own completion, so a transient failure at startup no longer permanently strands a Pod without a working dataplane.

Testing:

Added `TestReconcileRetriesOnInstallPodFlowsFailure` in `pkg/agent/cniserver/server_linux_test.go`, which makes the mocked `InstallPodFlows` fail once during `reconcile()` and verifies it is automatically retried and succeeds shortly after, without needing a new CNI event. Verified with `go test -race` and `go vet` on the `cniserver` package; all existing tests continue to pass.

The underlying race is inherently timing-dependent: the original report reproduced it only 2 out of 12 runs, so a deterministic end-to-end repro isn't practical; the unit test isolates and exercises the exact failure path deterministically instead.
