### PR TITLE
docs: fix typos in multicluster documentation

### DIFF
--- a/docs/multicluster/api.md
+++ b/docs/multicluster/api.md
@@ -1,6 +1,6 @@
 # Antrea Multi-cluster API
 
-This document lists all the API resource versions currently supported by Antrea Mulit-cluster.
+This document lists all the API resource versions currently supported by Antrea Multi-cluster.
 
 Antrea Multi-cluster is supported since v1.5.0. Most Custom Resource Definitions (CRDs)
 used by Antrea Multi-cluster are in the API group `multicluster.crd.antrea.io`, and

--- a/docs/multicluster/architecture.md
+++ b/docs/multicluster/architecture.md
@@ -27,7 +27,7 @@ including the leader and member clusters information.
 
 The MemberClusterAnnounce CRD declares a member cluster configuration to the leader cluster.
 
-The Common Area is an abstraction in the Antrea Multi-cluster implementation provides a storage
+The Common Area is an abstraction in the Antrea Multi-cluster implementation that provides a storage
 interface for resource export/import that can be read/written by all member and leader clusters
 in the ClusterSet. The Common Area is implemented with a Namespace in the leader cluster for a
 given ClusterSet.
@@ -137,7 +137,7 @@ The Multi-cluster Gateway implementation introduces two new CRDs `Gateway` and
 information including: `internalIP` for tunnels to local Nodes, and `gatewayIP`
 for tunnels to remote cluster Gateways. `ClusterInfoImport` includes Gateway
 and network information of member clusters, including Gateway IPs and Service
-CIDRs. The existing esource export/import pipeline is leveraged to exchange
+CIDRs. The existing resource export/import pipeline is leveraged to exchange
 the cluster network information among member clusters, generating
 ClusterInfoImports in each member cluster.
 

--- a/docs/multicluster/upgrade.md
+++ b/docs/multicluster/upgrade.md
@@ -22,7 +22,7 @@ Multi-cluster feature is still in Alpha version, and the API is not stable yet. 
 is always to upgrade Antrea Multi-cluster to the same version for a ClusterSet.
 
 - **Antrea Leader Controller**: must be upgraded first
-- **Antrea Member Controller**: must the same version as the **Antrea Leader Controller**.
+- **Antrea Member Controller**: must be the same version as the **Antrea Leader Controller**.
 - **Antctl**: must not be newer than the **Antrea Leader/Member Controller**. Please
   notice Antctl for Multi-cluster is added since v1.6.0.
 

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -468,7 +468,7 @@ For example, once you export the `default/nginx` Service in member cluster
 `test-cluster-west`, it will be automatically imported in member cluster
 `test-cluster-east`. A Service and an Endpoints with name
 `default/antrea-mc-nginx` will be created in `test-cluster-east`, as well as
-a ServcieImport CR with name `default/nginx`. Now, Pods in `test-cluster-east`
+a ServiceImport CR with name `default/nginx`. Now, Pods in `test-cluster-east`
 can access the imported Service using its ClusterIP, and the requests will be
 routed to the backend `nginx` Pods in `test-cluster-west`. You can check the
 imported Service and ServiceImport with commands:
@@ -618,7 +618,7 @@ data:
     featureGates:
       Multicluster: true
     multicluster:
-      enableStretchedNetworkPolicy: true # required by both egress and ingres rules
+      enableStretchedNetworkPolicy: true # required by both egress and ingress rules
   antrea-agent.conf: |
     featureGates:
       Multicluster: true


### PR DESCRIPTION
Fixes 6 typos/grammar errors in the multicluster docs found while working on related modules: a misspelling in `api.md`, a missing word and a misspelling in `architecture.md`, a missing word in `upgrade.md`, and a misspelling plus a typo in a config comment in `user-guide.md`. No content changes beyond fixing the prose.
