### PR TITLE
fix(antctl): check error before accessing response in deploy helper

### DIFF
--- a/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
+++ b/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
@@ -179,13 +179,15 @@ func deploy(cmd *cobra.Command, role string, version string, namespace string, f
 		for _, manifest := range manifests {
 			// #nosec G107
 			resp, err := httpGet(manifest)
-			if resp.StatusCode == 404 {
-				return fmt.Errorf("manifest %s not found", manifest)
-			}
 			if err != nil {
 				return err
 			}
+			if resp.StatusCode == 404 {
+				resp.Body.Close()
+				return fmt.Errorf("manifest %s not found", manifest)
+			}
 			b, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference when HTTP request fails in multicluster deploy helper
- Close HTTP response body to prevent resource leak

## Bug
In `deploy_helper.go`, `resp.StatusCode` is checked before verifying that `httpGet()` did not return an error. If the HTTP request fails (e.g., DNS resolution failure, timeout), `resp` is nil and accessing `.StatusCode` causes a panic. Additionally, `resp.Body` is never closed.

## Fix
Reorder the checks to test `err` first, then access `resp.StatusCode`, and ensure `resp.Body` is closed after use.
