### PR TITLE
fix(compress): close files explicitly in extraction loop to prevent FD exhaustion

### DIFF
--- a/pkg/util/compress/compress.go
+++ b/pkg/util/compress/compress.go
@@ -90,15 +90,18 @@ func UnpackReader(fs afero.Fs, file io.Reader, useGzip bool, targetDir string) e
 			if err != nil {
 				return err
 			}
-			defer outFile.Close()
 			for {
 				// to resolve G110: Potential DoS vulnerability via decompression bomb
 				if _, err := io.CopyN(outFile, tarReader, 1024); err != nil {
 					if err == io.EOF {
 						break
 					}
+					outFile.Close()
 					return err
 				}
+			}
+			if err := outFile.Close(); err != nil {
+				return err
 			}
 		default:
 			// Note in particular that we do not handle symlinks.


### PR DESCRIPTION
## Summary
- Fix deferred file close inside tar extraction loop that can exhaust file descriptors

## Bug
`defer outFile.Close()` is used inside a for loop in `UnpackReader`. Since `defer` executes when the enclosing function returns (not when the loop iteration ends), all extracted files remain open simultaneously. Archives with many files can exhaust the process's file descriptor limit.

## Fix
Replace `defer outFile.Close()` with explicit `outFile.Close()` at the end of each loop iteration.
