### PR TITLE
Fix assert object usage in Eventually blocks

### DIFF
--- a/pkg/apiserver/registry/system/supportbundle/rest_test.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest_test.go
@@ -107,7 +107,7 @@ func TestClean(t *testing.T) {
 			}
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				exist, err := afero.Exists(defaultFS, f.Name())
-				require.NoError(t, err)
+				require.NoError(c, err)
 				assert.False(c, exist)
 			}, 1*time.Second, 10*time.Millisecond, "Supportbundle file was not deleted")
 			assert.Equal(t, system.SupportBundleStatusNone, storage.SupportBundle.cache.Status)
@@ -167,11 +167,11 @@ func TestControllerStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	var collectedBundle *system.SupportBundle
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		object, err := storage.SupportBundle.Get(context.TODO(), modeController, nil)
-		require.NoError(t, err)
+		require.NoError(c, err)
 		collectedBundle = object.(*system.SupportBundle)
-		return collectedBundle.Status == system.SupportBundleStatusCollected
+		assert.Equal(c, system.SupportBundleStatusCollected, collectedBundle.Status)
 	}, time.Second*2, time.Millisecond*100)
 	filePath := collectedBundle.Filepath
 	require.NotEmpty(t, filePath)
@@ -198,10 +198,10 @@ func TestControllerStorage(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: modeController},
 		Status:     system.SupportBundleStatusNone,
 	}, object)
-	assert.Eventuallyf(t, func() bool {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		exist, err := afero.Exists(defaultFS, filePath)
-		require.NoError(t, err)
-		return !exist
+		require.NoError(c, err)
+		assert.False(c, exist)
 	}, time.Second*2, time.Millisecond*100, "Supportbundle file %s was not deleted after deleting the Supportbundle object", filePath)
 }
 
@@ -277,11 +277,11 @@ func TestAgentStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	var collectedBundle *system.SupportBundle
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		object, err := storage.SupportBundle.Get(ctx, modeAgent, nil)
-		require.NoError(t, err)
+		require.NoError(c, err)
 		collectedBundle = object.(*system.SupportBundle)
-		return collectedBundle.Status == system.SupportBundleStatusCollected
+		assert.Equal(c, system.SupportBundleStatusCollected, collectedBundle.Status)
 	}, time.Second*2, time.Millisecond*100)
 	require.NotEmpty(t, collectedBundle.Filepath)
 	filePath := collectedBundle.Filepath
@@ -301,10 +301,10 @@ func TestAgentStorage(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: modeAgent},
 		Status:     system.SupportBundleStatusNone,
 	}, object)
-	assert.Eventuallyf(t, func() bool {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		exist, err := afero.Exists(defaultFS, filePath)
-		require.NoError(t, err)
-		return !exist
+		require.NoError(c, err)
+		assert.False(c, exist)
 	}, time.Second*2, time.Millisecond*100, "Supportbundle file %s was not deleted after deleting the Supportbundle object", filePath)
 }
 
@@ -337,11 +337,11 @@ func TestAgentStorageFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	var collectedBundle *system.SupportBundle
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		object, err := storage.SupportBundle.Get(ctx, modeAgent, nil)
-		require.NoError(t, err)
+		require.NoError(c, err)
 		collectedBundle = object.(*system.SupportBundle)
-		return collectedBundle.Status == system.SupportBundleStatusNone
+		assert.Equal(c, system.SupportBundleStatusNone, collectedBundle.Status)
 	}, time.Second*2, time.Millisecond*100)
 	assert.Empty(t, collectedBundle.Filepath)
 	assert.Empty(t, collectedBundle.Sum)

--- a/pkg/apiserver/registry/system/supportbundle/rest_test.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest_test.go
@@ -105,7 +105,7 @@ func TestClean(t *testing.T) {
 			} else {
 				fakeClock.Step(tc.duration)
 			}
-			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				exist, err := afero.Exists(defaultFS, f.Name())
 				require.NoError(c, err)
 				assert.False(c, exist)
@@ -167,7 +167,7 @@ func TestControllerStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	var collectedBundle *system.SupportBundle
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		object, err := storage.SupportBundle.Get(context.TODO(), modeController, nil)
 		require.NoError(c, err)
 		collectedBundle = object.(*system.SupportBundle)
@@ -198,7 +198,7 @@ func TestControllerStorage(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: modeController},
 		Status:     system.SupportBundleStatusNone,
 	}, object)
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		exist, err := afero.Exists(defaultFS, filePath)
 		require.NoError(c, err)
 		assert.False(c, exist)
@@ -277,7 +277,7 @@ func TestAgentStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	var collectedBundle *system.SupportBundle
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		object, err := storage.SupportBundle.Get(ctx, modeAgent, nil)
 		require.NoError(c, err)
 		collectedBundle = object.(*system.SupportBundle)
@@ -301,7 +301,7 @@ func TestAgentStorage(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: modeAgent},
 		Status:     system.SupportBundleStatusNone,
 	}, object)
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		exist, err := afero.Exists(defaultFS, filePath)
 		require.NoError(c, err)
 		assert.False(c, exist)
@@ -337,7 +337,7 @@ func TestAgentStorageFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	var collectedBundle *system.SupportBundle
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		object, err := storage.SupportBundle.Get(ctx, modeAgent, nil)
 		require.NoError(c, err)
 		collectedBundle = object.(*system.SupportBundle)

--- a/pkg/controller/serviceexternalip/controller_test.go
+++ b/pkg/controller/serviceexternalip/controller_test.go
@@ -204,7 +204,7 @@ func TestAddService(t *testing.T) {
 			require.NoError(t, err)
 			var svcUpdated *corev1.Service
 			var externalIP string
-			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				var err error
 				svcUpdated, err = controller.client.CoreV1().Services(tt.service.Namespace).Get(context.TODO(), tt.service.Name, metav1.GetOptions{})
 				require.NoError(c, err)
@@ -487,7 +487,7 @@ func TestSyncService(t *testing.T) {
 
 func checkForServiceExternalIP(t *testing.T, controller *loadBalancerController, name, namespace, expectedExternalIP string) {
 	t.Helper()
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		serviceUpdated, err := controller.client.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		require.NoError(c, err)
 		externalIP := getServiceExternalIP(serviceUpdated)
@@ -499,7 +499,7 @@ func checkExternalIPPoolUsed(t *testing.T, controller *loadBalancerController, p
 	t.Helper()
 	exists := controller.externalIPAllocator.IPPoolExists(poolName)
 	require.True(t, exists)
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		eip, err := controller.crdClient.CrdV1beta1().ExternalIPPools().Get(context.TODO(), poolName, metav1.GetOptions{})
 		require.NoError(c, err)
 		t.Logf("current status %#v", eip.Status)

--- a/pkg/controller/serviceexternalip/controller_test.go
+++ b/pkg/controller/serviceexternalip/controller_test.go
@@ -204,12 +204,12 @@ func TestAddService(t *testing.T) {
 			require.NoError(t, err)
 			var svcUpdated *corev1.Service
 			var externalIP string
-			assert.Eventually(t, func() bool {
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				var err error
 				svcUpdated, err = controller.client.CoreV1().Services(tt.service.Namespace).Get(context.TODO(), tt.service.Name, metav1.GetOptions{})
-				require.NoError(t, err)
+				require.NoError(c, err)
 				externalIP = getServiceExternalIP(svcUpdated)
-				return externalIP == tt.expectedExternalIP
+				assert.Equal(c, tt.expectedExternalIP, externalIP)
 			}, 500*time.Millisecond, 100*time.Millisecond)
 			ipPool := svcUpdated.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey]
 			assert.NotEmpty(t, ipPool)
@@ -487,11 +487,11 @@ func TestSyncService(t *testing.T) {
 
 func checkForServiceExternalIP(t *testing.T, controller *loadBalancerController, name, namespace, expectedExternalIP string) {
 	t.Helper()
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		serviceUpdated, err := controller.client.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		require.NoError(t, err)
+		require.NoError(c, err)
 		externalIP := getServiceExternalIP(serviceUpdated)
-		return externalIP == expectedExternalIP
+		assert.Equal(c, expectedExternalIP, externalIP)
 	}, 500*time.Millisecond, 100*time.Millisecond)
 }
 
@@ -499,10 +499,10 @@ func checkExternalIPPoolUsed(t *testing.T, controller *loadBalancerController, p
 	t.Helper()
 	exists := controller.externalIPAllocator.IPPoolExists(poolName)
 	require.True(t, exists)
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		eip, err := controller.crdClient.CrdV1beta1().ExternalIPPools().Get(context.TODO(), poolName, metav1.GetOptions{})
-		require.NoError(t, err)
+		require.NoError(c, err)
 		t.Logf("current status %#v", eip.Status)
-		return eip.Status.Usage.Used == used
+		assert.Equal(c, used, eip.Status.Usage.Used)
 	}, 500*time.Millisecond, 100*time.Millisecond)
 }

--- a/pkg/controller/supportbundlecollection/controller_test.go
+++ b/pkg/controller/supportbundlecollection/controller_test.go
@@ -1612,7 +1612,7 @@ func TestUpdateStatus(t *testing.T) {
 			Type:   v1alpha1.CollectionCompleted,
 			Status: metav1.ConditionTrue,
 		}))
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			err := controller.syncSupportBundleCollection(collectionName)
 			assert.NoError(c, err)
 			_, exists, err := controller.supportBundleCollectionStore.Get(collectionName)

--- a/pkg/controller/supportbundlecollection/controller_test.go
+++ b/pkg/controller/supportbundlecollection/controller_test.go
@@ -1612,12 +1612,12 @@ func TestUpdateStatus(t *testing.T) {
 			Type:   v1alpha1.CollectionCompleted,
 			Status: metav1.ConditionTrue,
 		}))
-		assert.Eventually(t, func() bool {
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			err := controller.syncSupportBundleCollection(collectionName)
-			assert.NoError(t, err)
+			assert.NoError(c, err)
 			_, exists, err := controller.supportBundleCollectionStore.Get(collectionName)
-			assert.NoError(t, err)
-			return !exists
+			assert.NoError(c, err)
+			assert.False(c, exists)
 		}, time.Second, time.Millisecond*10)
 
 		_, exists := controller.statuses[collectionName]

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -244,7 +244,7 @@ func TestOFctrlFlow(t *testing.T) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			flowList, err := OfctlDumpTableFlowsWithoutName(ovsCtlClient, myTable.GetID())
 			require.NoError(c, err)
-			assert.Len(c, flowList, 0)
+			assert.Empty(c, flowList)
 		}, time.Second, time.Millisecond*100, "Failed to delete flows by CookieID")
 	}
 }
@@ -347,7 +347,7 @@ func TestOFctrlGroup(t *testing.T) {
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				groups, err := OfCtlDumpGroups(ovsCtlClient)
 				require.NoError(c, err)
-				assert.Len(c, groups, 0)
+				assert.Empty(c, groups)
 			}, openFlowCheckTimeout, openFlowCheckInterval, "Failed to delete group")
 		})
 		id++

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -241,10 +241,10 @@ func TestOFctrlFlow(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to DeleteFlowsByCookie: %v", err)
 		}
-		require.Eventually(t, func() bool {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			flowList, err := OfctlDumpTableFlowsWithoutName(ovsCtlClient, myTable.GetID())
-			require.NoError(t, err)
-			return len(flowList) == 0
+			require.NoError(c, err)
+			assert.Len(c, flowList, 0)
 		}, time.Second, time.Millisecond*100, "Failed to delete flows by CookieID")
 	}
 }
@@ -344,10 +344,10 @@ func TestOFctrlGroup(t *testing.T) {
 			}
 			// Check if the group could be deleted.
 			require.NoError(t, group.Delete())
-			require.Eventually(t, func() bool {
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				groups, err := OfCtlDumpGroups(ovsCtlClient)
-				require.NoError(t, err)
-				return len(groups) == 0
+				require.NoError(c, err)
+				assert.Len(c, groups, 0)
 			}, openFlowCheckTimeout, openFlowCheckInterval, "Failed to delete group")
 		})
 		id++


### PR DESCRIPTION
Several test files incorrectly used the outer `t` (*testing.T) instead of `c` (*assert.CollectT) within `assert.Eventually` and `assert.Eventuallyf` closures. This caused the tests to fail immediately on the first polling attempt if an error occurred or a condition was not met, bypassing the intended asynchronous waiting mechanism and leading to flaky test failures.

This commit replaces `Eventually` and `Eventuallyf` with `EventuallyWithT`, and updates all assertions inside the blocks to use `c` instead of `t` to ensure correct polling behavior.