### PR TITLE
fix(windows): don't overwrite host system PATH with container's PATH

### DIFF
--- a/hack/windows/Install-OVS.ps1
+++ b/hack/windows/Install-OVS.ps1
@@ -93,12 +93,18 @@ function AddToEnvPath(){
     param (
         [Parameter(Mandatory = $true)] [String]$path
     )
-    $envPaths = $env:Path -split ";" | Select-Object -Unique
+    # Read the Machine Path directly instead of using $env:Path, as $env:Path may not reflect the
+    # actual system Path when this script runs in a container (e.g. a HostProcess container): it
+    # can be a minimal Path value set by the container runtime rather than the host's real Path.
+    # Writing that back would wipe out any custom entries in the host's system Path. See issue #8111.
+    $machinePath = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine)
+    $envPaths = $machinePath -split ";" | Where-Object { $_ -ne "" } | Select-Object -Unique
     if (-not $envPaths.Contains($path)) {
         $envPaths += $path
     }
-    $env:Path = [system.String]::Join(";", $envPaths)
-    [Environment]::SetEnvironmentVariable("Path", $env:Path, [EnvironmentVariableTarget]::Machine)
+    $newMachinePath = [system.String]::Join(";", $envPaths)
+    [Environment]::SetEnvironmentVariable("Path", $newMachinePath, [EnvironmentVariableTarget]::Machine)
+    $env:Path = $newMachinePath
 }
 
 function CheckAndInstallScripts {


### PR DESCRIPTION
Motivation:
Install-OVS.ps1's AddToEnvPath helper appended the OVS binary directory
to $env:Path (the current process's PATH) and wrote that whole value
back to the Machine-scoped PATH environment variable. When this script
runs inside a Windows HostProcess container, as it does during a normal
Antrea deployment, $env:Path for that process reflects the minimal PATH
supplied by the container image/runtime, not the host's actual Machine
PATH. Writing that minimal value back to the Machine scope silently
erased any customizations the user had previously added to the host's
system PATH (e.g. via Prepare-Node.ps1 or an Ansible script), as
reported in #8111.

Approach:
Read the current PATH directly from the Machine scope via
[Environment]::GetEnvironmentVariable("Path", ...Machine) instead of
$env:Path, append the new directory (deduped, filtering out empty
entries), and write the merged value back to the Machine scope. This
also makes the operation idempotent: re-running the script no longer
resets Machine PATH to "container's minimal PATH + new dir" each time.
$env:Path in the current process is updated too, so later steps in the
same script still see the newly added directories.

Validation:
No automated test or CI job exercises this PowerShell script (it
requires a real Windows host with OVS), and pwsh is unavailable in this
environment, so it could not be executed directly. Validated by manual
code review, a brace/paren balance check on the file, and an
independent adversarial review of the diff for PowerShell correctness,
edge cases (empty Machine PATH, duplicate separators, commands that run
after AddToEnvPath), and conformance with the reported root cause.
Behavior for users who deploy on a host with no prior custom PATH
entries is unchanged; the fix only prevents the erasure of pre-existing
customizations.

Fixes #8111

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
