### PR TITLE
Fix nil panic when ClickHouse BeginTx fails

### DIFF
--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
@@ -264,7 +264,9 @@ func (ch *ClickHouseExportProcess) batchCommitAll(ctx context.Context) (int, err
 	}
 	if err != nil {
 		klog.ErrorS(err, "Error when preparing insert statement")
-		_ = tx.Rollback()
+		if tx != nil {
+			_ = tx.Rollback()
+		}
 		return 0, err
 	}
 

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
@@ -191,6 +191,28 @@ func TestBatchCommitAllError(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet(), "unfulfilled expectations for db sql operation")
 }
 
+func TestBatchCommitAllBeginTxError(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err, "error when opening a stub database connection")
+	defer db.Close()
+
+	chExportProc := &ClickHouseExportProcess{
+		db:        db,
+		queueSize: maxQueueSize,
+	}
+	recordRow := flowrecord.FlowRecord{}
+	chExportProc.deque.PushBack(&recordRow)
+
+	beginErr := fmt.Errorf("connection refused")
+	mock.ExpectBegin().WillReturnError(beginErr)
+
+	count, err := chExportProc.batchCommitAll(t.Context())
+	assert.ErrorIs(t, err, beginErr)
+	assert.Equal(t, 0, count)
+	assert.Equal(t, 1, chExportProc.deque.Len())
+	assert.NoError(t, mock.ExpectationsWereMet(), "unfulfilled expectations for db sql operation")
+}
+
 func TestPushRecordsToFrontOfQueue(t *testing.T) {
 	chExportProc := &ClickHouseExportProcess{
 		queueSize: 4,


### PR DESCRIPTION
## Summary

When ClickHouse export fails at `BeginTx`, Flow Aggregator calls `Rollback()` on a nil transaction and panics. This change guards the rollback so the error is returned and the pod keeps running.

Fixes #8207

## Changes

- Skip `tx.Rollback()` when `BeginTx` fails and `tx` is nil
- Add `TestBatchCommitAllBeginTxError` using sqlmock to cover the failure path

## Test plan

- [x] `go test ./pkg/flowaggregator/clickhouseclient/...`
- [x] `TestBatchCommitAllBeginTxError` passes without panic