### PR TITLE
Fix inverted ipBlocksUpdated() causing dropped Group IPBlocks updates

### DIFF
--- a/pkg/controller/networkpolicy/group.go
+++ b/pkg/controller/networkpolicy/group.go
@@ -69,7 +69,7 @@ func (n *NetworkPolicyController) updateGroup(oldObj, curObj interface{}) {
 		for _, ipb := range newGroup.IPBlocks {
 			newIPBs.Insert(ipb.CIDR.String())
 		}
-		return oldIPBs.Equal(newIPBs)
+		return !oldIPBs.Equal(newIPBs)
 	}
 	childGroupsUpdated := func() bool {
 		oldChildGroups, newChildGroups := sets.Set[string]{}, sets.Set[string]{}

--- a/pkg/controller/networkpolicy/group_test.go
+++ b/pkg/controller/networkpolicy/group_test.go
@@ -471,6 +471,40 @@ func TestUpdateGroup(t *testing.T) {
 			assert.Equal(t, tt.expectedGroup, actualGroup)
 		})
 	}
+
+	// Regression test: ipBlocksUpdated() previously returned whether the old and new IPBlocks
+	// were equal instead of whether they differed, so an IPBlocks-only change was mistaken for no
+	// change and silently dropped. This needs its own starting Group, already in IPBlocks mode on
+	// both sides, since processGroup returns early on IPBlocks and never sets Selector, so reusing
+	// testG (selector-based) would also flip selectorUpdated() and mask the regression.
+	t.Run("g-update-ip-block-only-change", func(t *testing.T) {
+		ipBlockCIDR1 := "10.0.0.0/24"
+		ipBlockCIDR2 := "10.0.1.0/24"
+		controlplaneIPNet2, _ := cidrStrToIPNet(ipBlockCIDR2)
+		_, ipNet2, _ := net.ParseCIDR(ipBlockCIDR2)
+		baseG := crdv1beta1.Group{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "gA", UID: "uidA"},
+			Spec: crdv1beta1.GroupSpec{
+				IPBlocks: []crdv1beta1.IPBlock{
+					{CIDR: ipBlockCIDR1},
+				},
+			},
+		}
+		updatedG := &crdv1beta1.Group{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "gA", UID: "uidA"},
+			Spec: crdv1beta1.GroupSpec{
+				IPBlocks: []crdv1beta1.IPBlock{
+					{CIDR: ipBlockCIDR2},
+				},
+			},
+		}
+		npc.addGroup(&baseG)
+		npc.updateGroup(&baseG, updatedG)
+		actualGroupObj, _, _ := npc.internalGroupStore.Get(key)
+		actualGroup := actualGroupObj.(*antreatypes.Group)
+		assert.Equal(t, []controlplane.IPBlock{{CIDR: *controlplaneIPNet2}}, actualGroup.IPBlocks, "internal Group's IPBlocks should reflect the update")
+		assert.Equal(t, []*net.IPNet{ipNet2}, actualGroup.IPNets, "internal Group's IPNets should reflect the update")
+	})
 }
 
 func TestDeleteG(t *testing.T) {


### PR DESCRIPTION
`updateGroup`'s `ipBlocksUpdated()` closure returned `oldIPBs.Equal(newIPBs)` instead of the negation, unlike the identical helper in `clustergroup.go`, which correctly returns `!oldIPBs.Equal(newIPBs)`.

Because `updateGroup` skips `internalGroupStore.Update()` and `enqueueInternalGroup()` when `!ipBlocksUpdated() && !svcRefUpdated() && !selectorUpdated() && !childGroupsUpdated()` is true, the inverted boolean made an IPBlocks-only change on a Group CR look like "no change" whenever nothing else in the spec changed: the internal Group was left stale and never re-enqueued, so the updated IPBlocks were silently dropped instead of being propagated to policy enforcement.

Added a `g-update-ip-block-only-change` case to the existing `TestUpdateGroup` table instead of a separate top-level test function. It needs its own starting Group already in IPBlocks mode on both sides, rather than reusing `TestUpdateGroup`'s selector-based baseline: `processGroup` returns early on IPBlocks and never sets `Selector`, so transitioning from a selector-based Group to an IPBlocks one would also flip `selectorUpdated()` and mask whether `ipBlocksUpdated()` itself is correct. Verified the new case fails against the pre-fix code and passes after the fix, while the other six existing cases in the table stay green either way (none of them actually isolate this regression).

## Test plan
- [x] `go test ./pkg/controller/networkpolicy/...` passes
- [x] New case fails on pre-fix code, passes after the fix
- [x] `go vet` / `gofmt` / `golangci-lint` (linux + windows) clean
