### PR TITLE
Add CNP networkpolicy type in flow record

### DIFF
--- a/pkg/agent/flowexporter/utils/utils.go
+++ b/pkg/agent/flowexporter/utils/utils.go
@@ -56,6 +56,7 @@ const (
 	PolicyTypeK8sNetworkPolicy           = uint8(flowpb.NetworkPolicyType_NETWORK_POLICY_TYPE_K8S)
 	PolicyTypeAntreaNetworkPolicy        = uint8(flowpb.NetworkPolicyType_NETWORK_POLICY_TYPE_ANP)
 	PolicyTypeAntreaClusterNetworkPolicy = uint8(flowpb.NetworkPolicyType_NETWORK_POLICY_TYPE_ACNP)
+	PolicyTypeK8sClusterNetworkPolicy    = uint8(flowpb.NetworkPolicyType_NETWORK_POLICY_TYPE_K8SCNP)
 )
 
 const (
@@ -116,6 +117,8 @@ func PolicyTypeToUint8(policyType v1beta2.NetworkPolicyType) uint8 {
 		return PolicyTypeAntreaNetworkPolicy
 	case v1beta2.AntreaClusterNetworkPolicy:
 		return PolicyTypeAntreaClusterNetworkPolicy
+	case v1beta2.K8sClusterNetworkPolicy:
+		return PolicyTypeK8sClusterNetworkPolicy
 	default:
 		return PolicyTypeUnspecified
 	}

--- a/pkg/agent/flowexporter/utils/utils_test.go
+++ b/pkg/agent/flowexporter/utils/utils_test.go
@@ -93,6 +93,7 @@ func TestPolicyTypeToUint8(t *testing.T) {
 		{v1beta2.K8sNetworkPolicy, 1},
 		{v1beta2.AntreaNetworkPolicy, 2},
 		{v1beta2.AntreaClusterNetworkPolicy, 3},
+		{v1beta2.K8sClusterNetworkPolicy, 4},
 	} {
 		result := PolicyTypeToUint8(tc.policyType)
 		assert.Equal(t, tc.expectedResult, result)

--- a/pkg/apis/controlplane/v1beta2/helper.go
+++ b/pkg/apis/controlplane/v1beta2/helper.go
@@ -19,7 +19,7 @@ import (
 )
 
 func (r *NetworkPolicyReference) ToString() string {
-	if r.Type == AntreaClusterNetworkPolicy {
+	if r.Type == AntreaClusterNetworkPolicy || r.Type == K8sClusterNetworkPolicy {
 		return fmt.Sprintf("%s:%s", r.Type, r.Name)
 	}
 	return fmt.Sprintf("%s:%s/%s", r.Type, r.Namespace, r.Name)

--- a/pkg/apis/controlplane/v1beta2/helper_test.go
+++ b/pkg/apis/controlplane/v1beta2/helper_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworkPolicyReferenceToString(t *testing.T) {
+	tests := []struct {
+		name    string
+		inNPRef *NetworkPolicyReference
+		out     string
+	}{
+		{
+			name: "k8s-np-ref",
+			inNPRef: &NetworkPolicyReference{
+				Type:      K8sNetworkPolicy,
+				Namespace: "nsA",
+				Name:      "npA",
+			},
+			out: "K8sNetworkPolicy:nsA/npA",
+		},
+		{
+			name: "annp-ref",
+			inNPRef: &NetworkPolicyReference{
+				Type:      AntreaNetworkPolicy,
+				Namespace: "nsA",
+				Name:      "annpA",
+			},
+			out: "AntreaNetworkPolicy:nsA/annpA",
+		},
+		{
+			name: "acnp-ref",
+			inNPRef: &NetworkPolicyReference{
+				Type:      AntreaClusterNetworkPolicy,
+				Namespace: "",
+				Name:      "acnpA",
+			},
+			out: "AntreaClusterNetworkPolicy:acnpA",
+		},
+		{
+			name: "cnp-ref",
+			inNPRef: &NetworkPolicyReference{
+				Type:      K8sClusterNetworkPolicy,
+				Namespace: "",
+				Name:      "cnpA",
+			},
+			out: "K8sClusterNetworkPolicy:cnpA",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualOut := tt.inNPRef.ToString()
+			assert.Equal(t, tt.out, actualOut)
+		})
+	}
+}

--- a/pkg/apis/controlplane/v1beta2/types.go
+++ b/pkg/apis/controlplane/v1beta2/types.go
@@ -200,6 +200,7 @@ const (
 	AntreaNetworkPolicy        NetworkPolicyType = "AntreaNetworkPolicy"
 	AdminNetworkPolicy         NetworkPolicyType = "AdminNetworkPolicy"
 	BaselineAdminNetworkPolicy NetworkPolicyType = "BaselineAdminNetworkPolicy"
+	K8sClusterNetworkPolicy    NetworkPolicyType = "K8sClusterNetworkPolicy"
 )
 
 type NetworkPolicyReference struct {

--- a/pkg/apis/flow/v1alpha1/flow.pb.go
+++ b/pkg/apis/flow/v1alpha1/flow.pb.go
@@ -205,6 +205,7 @@ const (
 	NetworkPolicyType_NETWORK_POLICY_TYPE_K8S         NetworkPolicyType = 1
 	NetworkPolicyType_NETWORK_POLICY_TYPE_ANP         NetworkPolicyType = 2
 	NetworkPolicyType_NETWORK_POLICY_TYPE_ACNP        NetworkPolicyType = 3
+	NetworkPolicyType_NETWORK_POLICY_TYPE_K8SCNP      NetworkPolicyType = 4
 )
 
 // Enum value maps for NetworkPolicyType.
@@ -214,12 +215,14 @@ var (
 		1: "NETWORK_POLICY_TYPE_K8S",
 		2: "NETWORK_POLICY_TYPE_ANP",
 		3: "NETWORK_POLICY_TYPE_ACNP",
+		4: "NETWORK_POLICY_TYPE_K8SCNP",
 	}
 	NetworkPolicyType_value = map[string]int32{
 		"NETWORK_POLICY_TYPE_UNSPECIFIED": 0,
 		"NETWORK_POLICY_TYPE_K8S":         1,
 		"NETWORK_POLICY_TYPE_ANP":         2,
 		"NETWORK_POLICY_TYPE_ACNP":        3,
+		"NETWORK_POLICY_TYPE_K8SCNP":      4,
 	}
 )
 
@@ -1520,12 +1523,13 @@ const file_pkg_apis_flow_v1alpha1_flow_proto_rawDesc = "" +
 	"\x14FLOW_TYPE_INTRA_NODE\x10\x01\x12\x18\n" +
 	"\x14FLOW_TYPE_INTER_NODE\x10\x02\x12\x19\n" +
 	"\x15FLOW_TYPE_TO_EXTERNAL\x10\x03\x12\x1b\n" +
-	"\x17FLOW_TYPE_FROM_EXTERNAL\x10\x04*\x90\x01\n" +
+	"\x17FLOW_TYPE_FROM_EXTERNAL\x10\x04*\xb0\x01\n" +
 	"\x11NetworkPolicyType\x12#\n" +
 	"\x1fNETWORK_POLICY_TYPE_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17NETWORK_POLICY_TYPE_K8S\x10\x01\x12\x1b\n" +
 	"\x17NETWORK_POLICY_TYPE_ANP\x10\x02\x12\x1c\n" +
-	"\x18NETWORK_POLICY_TYPE_ACNP\x10\x03*\xb5\x01\n" +
+	"\x18NETWORK_POLICY_TYPE_ACNP\x10\x03\x12\x1e\n" +
+	"\x1aNETWORK_POLICY_TYPE_K8SCNP\x10\x04*\xb5\x01\n" +
 	"\x17NetworkPolicyRuleAction\x12(\n" +
 	"$NETWORK_POLICY_RULE_ACTION_NO_ACTION\x10\x00\x12$\n" +
 	" NETWORK_POLICY_RULE_ACTION_ALLOW\x10\x01\x12#\n" +

--- a/pkg/apis/flow/v1alpha1/flow.proto
+++ b/pkg/apis/flow/v1alpha1/flow.proto
@@ -83,6 +83,7 @@ enum NetworkPolicyType {
   NETWORK_POLICY_TYPE_K8S = 1;
   NETWORK_POLICY_TYPE_ANP = 2;
   NETWORK_POLICY_TYPE_ACNP = 3;
+  NETWORK_POLICY_TYPE_K8SCNP = 4;
 }
 
 enum NetworkPolicyRuleAction {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -127,11 +127,12 @@ type NetworkPolicyQueryFilter struct {
 
 // From user shorthand input to cpv1beta1.NetworkPolicyType
 var NetworkPolicyTypeMap = map[string]cpv1beta.NetworkPolicyType{
-	"K8SNP": cpv1beta.K8sNetworkPolicy,
-	"ACNP":  cpv1beta.AntreaClusterNetworkPolicy,
-	"ANNP":  cpv1beta.AntreaNetworkPolicy,
-	"ANP":   cpv1beta.AdminNetworkPolicy,
-	"BANP":  cpv1beta.BaselineAdminNetworkPolicy,
+	"K8SNP":  cpv1beta.K8sNetworkPolicy,
+	"ACNP":   cpv1beta.AntreaClusterNetworkPolicy,
+	"ANNP":   cpv1beta.AntreaNetworkPolicy,
+	"ANP":    cpv1beta.AdminNetworkPolicy,
+	"BANP":   cpv1beta.BaselineAdminNetworkPolicy,
+	"K8SCNP": cpv1beta.K8sClusterNetworkPolicy,
 }
 
 func GetNetworkPolicyTypeShorthands() []string {


### PR DESCRIPTION
Flows hitting CNPs will now correctly be exported with network policy type ClusterNetworkPolicy instead of Unspecified.