### PR TITLE
Return the error when adding messages to a bundle fails

### DIFF
--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -620,7 +620,7 @@ func (b *OFBridge) AddOFEntriesInBundle(addEntries []OFEntry, modEntries []OFEnt
 		groupSet, flowSet,
 	} {
 		if err := addMessage(entries); err != nil {
-			return nil
+			return err
 		}
 	}
 


### PR DESCRIPTION
`AddOFEntriesInBundle` discarded the error returned by addMessage and returned nil instead, so the caller was told the operation succeeded even though no message had been added to the bundle and no commit had been sent to OVS. The caller then recorded the entries as installed, and because no error was surfaced, nothing retried them.