### PR TITLE
Fix nil transaction panic in ClickHouse batchCommitAll when BeginTx fails

### DIFF
--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
@@ -264,7 +264,9 @@ func (ch *ClickHouseExportProcess) batchCommitAll(ctx context.Context) (int, err
 	}
 	if err != nil {
 		klog.ErrorS(err, "Error when preparing insert statement")
-		_ = tx.Rollback()
+		if tx != nil {
+			_ = tx.Rollback()
+		}
 		return 0, err
 	}
 

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
@@ -192,6 +192,27 @@ func TestBatchCommitAllError(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet(), "unfulfilled expectations for db sql operation")
 }
 
+func TestBatchCommitAllBeginError(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err, "error when opening a stub database connection")
+	defer db.Close()
+
+	chExportProc := &ClickHouseExportProcess{
+		db:        db,
+		queueSize: maxQueueSize,
+	}
+	recordRow := flowrecord.FlowRecord{}
+	chExportProc.deque.PushBack(&recordRow)
+
+	mock.ExpectBegin().WillReturnError(fmt.Errorf("mock error for begin transaction"))
+
+	count, err := chExportProc.batchCommitAll(t.Context())
+	assert.Error(t, err, "expected error when SQL transaction cannot begin")
+	assert.Equal(t, 0, count)
+	assert.Equal(t, 1, chExportProc.deque.Len())
+	assert.NoError(t, mock.ExpectationsWereMet(), "unfulfilled expectations for db sql operation")
+}
+
 func TestPushRecordsToFrontOfQueue(t *testing.T) {
 	chExportProc := &ClickHouseExportProcess{
 		queueSize: 4,


### PR DESCRIPTION
When ClickHouse export starts a transaction, `batchCommitAll` calls `tx.Rollback()` on the shared error path even when `ch.db.BeginTx` is the call that failed. In that case `tx` is nil, so the rollback dereferences a nil pointer and panics, taking down the Flow Aggregator instead of logging the error and retrying on the next commit cycle. This happens whenever ClickHouse is down, misconfigured, or unreachable.

The guard only runs `tx.Rollback()` when a transaction actually started (i.e. the failure came from `PrepareContext`), matching the existing error handling further down.

Added `TestBatchCommitAllBeginError`, which makes `ExpectBegin()` return an error and asserts the records stay queued. It panics on the current code and passes with the fix.

Fixes #8207