### PR TITLE
Sync iptables rules with an event-driven loop

### DIFF
--- a/pkg/agent/controller/egress/egress_controller.go
+++ b/pkg/agent/controller/egress/egress_controller.go
@@ -698,6 +698,8 @@ func (c *EgressController) realizeEgressIP(egressName, egressIP string, subnetIn
 			ipState.flowsInstalled = true
 		}
 		if !ipState.ruleInstalled {
+			// AddSNATRule only caches the rule. The route Client installs it and retries on failure, so
+			// ruleInstalled means that the rule has been handed over, not that it is in the datapath.
 			if err := c.routeClient.AddSNATRule(ipState.egressIP, ipState.mark); err != nil {
 				return 0, fmt.Errorf("error installing SNAT rule for IP %s: %v", ipState.egressIP, err)
 			}

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	// SyncInterval is exported so that sync interval can be configured for running integration test with
-	// smaller values. It is meant to be used internally by Run.
+	// smaller values. NewClient also reads it, as the cap on the sync retry delay.
 	SyncInterval = 60 * time.Second
 )
 
@@ -57,9 +57,12 @@ type Interface interface {
 	UnMigrateRoutesFromGw(route *net.IPNet, linkName string) error
 
 	// AddSNATRule should add rule to SNAT outgoing traffic with the mark, using the provided SNAT IP.
+	// On Linux it only caches the SNAT IP. Returning nil says the rule will be programmed, not that it
+	// already is.
 	AddSNATRule(snatIP net.IP, mark uint32) error
 
-	// DeleteSNATRule should delete rule to SNAT outgoing traffic with the mark.
+	// DeleteSNATRule should delete rule to SNAT outgoing traffic with the mark. It is asynchronous in the
+	// same way as AddSNATRule.
 	DeleteSNATRule(mark uint32) error
 
 	// RestoreEgressRoutesAndRules restores the routes and rules configured on the system for Egresses to the cache.

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -60,6 +60,9 @@ const (
 	vxlanPort  = 4789
 	genevePort = 6081
 
+	// syncDebounceDuration is how long the iptables sync loop waits after being notified, to batch updates.
+	syncDebounceDuration = 100 * time.Millisecond
+
 	// Antrea managed ipset.
 	// antreaPodIPSet contains all Per-Node IPAM Pod CIDRs of this cluster.
 	antreaPodIPSet = "ANTREA-POD-IP"
@@ -241,6 +244,9 @@ type Client struct {
 	nodeNetworkPolicyIPSetsIPv6 sync.Map
 	// iptablesCache caches all existing iptables chains and rules for the features relying on it.
 	iptablesCache *iptablesCache
+	// iptablesSyncTrigger notifies the iptables sync loop that the iptables caches have been updated. It has a
+	// buffer of 1, as a pending notification makes another one redundant.
+	iptablesSyncTrigger chan struct{}
 	// podCIDRNFTablesSetIPv4 caches all existing IPv4 Pod CIDRs stored in antreaNFTablesSetPeerPodCIDR.
 	podCIDRNFTablesSetIPv4 sync.Map
 	// podCIDRNFTablesSetIPv6 caches all existing IPv6 Pod CIDRs stored in antreaNFTablesSetPeerPodCIDR.
@@ -288,6 +294,7 @@ func NewClient(networkConfig *config.NetworkConfig,
 		serviceExternalIPReferences: make(map[string]sets.Set[string]),
 		wireguardPort:               wireguardPort,
 		proxyHealthCheckPort:        proxyHealthCheckPort,
+		iptablesSyncTrigger:         make(chan struct{}, 1),
 	}, nil
 }
 
@@ -444,20 +451,58 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 func (c *Client) Run(ctx context.Context) {
 	<-c.iptablesInitialized
 	klog.InfoS("Starting host network configuration sync", "interval", SyncInterval)
+	// The loop only waits for notifications, the periodic reconciliation is driven by syncNetworkConfig.
+	go c.runSyncLoop(ctx, c.iptablesSyncTrigger, func() error { return c.syncIPTables(false) })
 	wait.UntilWithContext(ctx, c.syncNetworkConfig, SyncInterval)
+}
+
+// triggerIPTablesSync notifies the iptables sync loop that the iptables caches have been updated. It never blocks: a
+// pending notification already causes a sync that takes the latest caches into account.
+func (c *Client) triggerIPTablesSync() {
+	select {
+	case c.iptablesSyncTrigger <- struct{}{}:
+	default:
+		// A sync is already pending, nothing to do.
+	}
+}
+
+// runSyncLoop syncs the iptables rules to the datapath when it is notified. Concentrating the writes here matters
+// because a sync rewrites the whole state from the caches, undoing anything applied concurrently. It returns when ctx
+// is cancelled.
+func (c *Client) runSyncLoop(ctx context.Context, trigger chan struct{}, sync func() error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-trigger:
+			// Batch the updates occurring in quick succession into a single sync.
+			timer := time.NewTimer(syncDebounceDuration)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+			// The sync below reads the caches after this point, so it covers these notifications.
+			select {
+			case <-trigger:
+			default:
+			}
+			if err := sync(); err != nil {
+				klog.ErrorS(err, "Failed to sync iptables rules")
+			}
+		}
+	}
 }
 
 // syncNetworkConfig is idempotent and can be safely called on every sync operation.
 func (c *Client) syncNetworkConfig(ctx context.Context) {
-	// Sync ipset before syncing iptables rules
+	// Sync the ipsets first: iptables-restore fails as a whole if a referenced ipset is missing.
 	if err := c.syncIPSet(); err != nil {
 		klog.ErrorS(err, "Failed to sync ipset")
 		return
 	}
-	if err := c.syncIPTables(false); err != nil {
-		klog.ErrorS(err, "Failed to sync iptables")
-		return
-	}
+	c.triggerIPTablesSync()
 	if c.nftables != nil {
 		if err := c.syncNFTables(ctx); err != nil {
 			klog.ErrorS(err, "Failed to sync nftables")
@@ -1421,10 +1466,11 @@ func (c *Client) restoreIptablesData(podCIDR *net.IPNet,
 	}
 	// Egress rules must be inserted before the default masquerade rule.
 	for snatMark, snatIP := range snatMarkToIP {
-		// Cannot reuse snatRuleSpec to generate the rule as it doesn't have "`" in the comment.
 		rule := []string{
 			"-A", antreaPostRoutingChain,
 			"-m", "comment", "--comment", `"Antrea: SNAT Pod to external packets"`,
+			// The condition is needed to prevent the rule from being applied to local out packets destined
+			// for Pods, which have "0x1/0x1" mark.
 			"!", "-o", c.nodeConfig.GatewayConfig.Name,
 			"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", snatMark, types.SNATIPMarkMask),
 			"-j", iptables.SNATTarget, "--to", snatIP.String(),
@@ -2229,43 +2275,23 @@ func (c *Client) UnMigrateRoutesFromGw(route *net.IPNet, linkName string) error 
 	return nil
 }
 
-func (c *Client) snatRuleSpec(snatIP net.IP, snatMark uint32) []string {
-	rule := []string{
-		"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-		// The condition is needed to prevent the rule from being applied to local out packets destined for Pods, which
-		// have "0x1/0x1" mark.
-		"!", "-o", c.nodeConfig.GatewayConfig.Name,
-		"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", snatMark, types.SNATIPMarkMask),
-		"-j", iptables.SNATTarget, "--to", snatIP.String(),
-	}
-	if c.egressSNATRandomFully {
-		rule = append(rule, "--random-fully")
-	}
-	return rule
-}
-
+// AddSNATRule caches the SNAT IP and notifies the sync loop, which installs the rule. Installing it here would race
+// with the sync, which could overwrite it.
 func (c *Client) AddSNATRule(snatIP net.IP, mark uint32) error {
-	protocol := iptables.ProtocolIPv4
-	if snatIP.To4() == nil {
-		protocol = iptables.ProtocolIPv6
-	}
 	c.markToSNATIP.Store(mark, snatIP)
-	return c.iptables.InsertRule(protocol, iptables.NATTable, antreaPostRoutingChain, c.snatRuleSpec(snatIP, mark))
+	c.triggerIPTablesSync()
+	return nil
 }
 
+// DeleteSNATRule uncaches the SNAT IP and notifies the sync loop, which uninstalls the rule.
 func (c *Client) DeleteSNATRule(mark uint32) error {
-	value, ok := c.markToSNATIP.Load(mark)
-	if !ok {
+	if _, ok := c.markToSNATIP.Load(mark); !ok {
 		klog.InfoS("Didn't find SNAT rule with mark", "mark", fmt.Sprintf("%#x", mark))
 		return nil
 	}
 	c.markToSNATIP.Delete(mark)
-	snatIP := value.(net.IP)
-	protocol := iptables.ProtocolIPv4
-	if snatIP.To4() == nil {
-		protocol = iptables.ProtocolIPv6
-	}
-	return c.iptables.DeleteRule(protocol, iptables.NATTable, antreaPostRoutingChain, c.snatRuleSpec(snatIP, mark))
+	c.triggerIPTablesSync()
+	return nil
 }
 
 func (c *Client) AddEgressRoutes(tableID uint32, dev int, gateway net.IP, prefixLength int) error {

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
@@ -126,6 +127,22 @@ const (
 	antreaNFTablesSetNodePort6   = "nodeport-6"
 	antreaNFTablesSetExternalIP  = "externalip"
 	antreaNFTablesSetExternalIP6 = "externalip-6"
+)
+
+// The constants of the iptables sync loop.
+const (
+	// syncMinRetryDelay is the delay before a failed sync is retried. It doubles on every consecutive
+	// failure, up to SyncInterval.
+	syncMinRetryDelay = time.Second
+
+	// A sync rebuilds the whole state from the caches, so there is nothing to key it by. The period has a
+	// key of its own, which is what decides how often the work belonging to it runs.
+	iptablesSyncKey     = "iptables"
+	iptablesPeriodicKey = "iptables-periodic"
+
+	// A chain of this prefix which is not in the NodeNetworkPolicy caches is deleted, so a feature adding
+	// one has to cache it there.
+	nodeNetworkPolicyChainPrefix = "ANTREA-POL"
 )
 
 // Client implements Interface.
@@ -293,12 +310,17 @@ type Client struct {
 	egressNeighbors sync.Map
 	// The latest calculated Service CIDRs can be got from serviceCIDRProvider.
 	serviceCIDRProvider servicecidr.Interface
+	// staleNodeNetworkPolicyChains holds the chains found to be orphans in the previous run, by IP
+	// protocol. Only the sync loop touches it, so it needs no lock.
+	staleNodeNetworkPolicyChains map[iptables.Protocol]sets.Set[string]
 	// nodeNetworkPolicyIPSetsIPv4 caches all existing IPv4 ipsets for NodeNetworkPolicy.
 	nodeNetworkPolicyIPSetsIPv4 sync.Map
 	// nodeNetworkPolicyIPSetsIPv6 caches all existing IPv6 ipsets for NodeNetworkPolicy.
 	nodeNetworkPolicyIPSetsIPv6 sync.Map
 	// iptablesCache caches all existing iptables chains and rules for the features relying on it.
 	iptablesCache *iptablesCache
+	// iptablesSyncQueue is how a feature, and syncNetworkConfig on its period, notify the sync loop.
+	iptablesSyncQueue workqueue.TypedRateLimitingInterface[string]
 	// podCIDRNFTablesSetIPv4 caches all existing IPv4 Pod CIDRs stored in antreaNFTablesSetPeerPodCIDR.
 	podCIDRNFTablesSetIPv4 sync.Map
 	// podCIDRNFTablesSetIPv6 caches all existing IPv6 Pod CIDRs stored in antreaNFTablesSetPeerPodCIDR.
@@ -339,23 +361,28 @@ func NewClient(networkConfig *config.NetworkConfig,
 	ports := make(map[feature]int32, len(hostNetworkPortRules.ports))
 	maps.Copy(ports, hostNetworkPortRules.ports)
 	c := &Client{
-		networkConfig:               networkConfig,
-		noSNAT:                      noSNAT,
-		nodeSNATRandomFully:         nodeSNATRandomFully,
-		egressSNATRandomFully:       egressSNATRandomFully,
-		proxyAll:                    proxyAll,
-		multicastEnabled:            multicastEnabled,
-		connectUplinkToBridge:       connectUplinkToBridge,
-		nodeNetworkPolicyEnabled:    nodeNetworkPolicyEnabled,
-		nodeLatencyMonitorEnabled:   nodeLatencyMonitorEnabled,
-		egressEnabled:               egressEnabled,
-		serviceExternalIPEnabled:    serviceExternalIPEnabled,
-		ipset:                       ipset.NewClient(),
-		netlink:                     &netlink.Handle{},
-		isCloudEKS:                  env.IsCloudEKS(),
-		serviceCIDRProvider:         serviceCIDRProvider,
-		serviceExternalIPReferences: make(map[string]sets.Set[string]),
-		hostNetworkPortRules:        ports,
+		networkConfig:                networkConfig,
+		noSNAT:                       noSNAT,
+		nodeSNATRandomFully:          nodeSNATRandomFully,
+		egressSNATRandomFully:        egressSNATRandomFully,
+		proxyAll:                     proxyAll,
+		multicastEnabled:             multicastEnabled,
+		connectUplinkToBridge:        connectUplinkToBridge,
+		nodeNetworkPolicyEnabled:     nodeNetworkPolicyEnabled,
+		nodeLatencyMonitorEnabled:    nodeLatencyMonitorEnabled,
+		egressEnabled:                egressEnabled,
+		serviceExternalIPEnabled:     serviceExternalIPEnabled,
+		ipset:                        ipset.NewClient(),
+		netlink:                      &netlink.Handle{},
+		isCloudEKS:                   env.IsCloudEKS(),
+		serviceCIDRProvider:          serviceCIDRProvider,
+		serviceExternalIPReferences:  make(map[string]sets.Set[string]),
+		hostNetworkPortRules:         ports,
+		staleNodeNetworkPolicyChains: make(map[iptables.Protocol]sets.Set[string]),
+		iptablesSyncQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.NewTypedItemExponentialFailureRateLimiter[string](syncMinRetryDelay, SyncInterval),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "iptablesSync"},
+		),
 	}
 	// endpointResolver is a concrete pointer rather than the endpointResolver interface, because
 	// assigning a nil pointer to an interface would produce a non-nil interface, defeating the nil
@@ -537,20 +564,66 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 func (c *Client) Run(ctx context.Context) {
 	<-c.iptablesInitialized
 	klog.InfoS("Starting host network configuration sync", "interval", SyncInterval)
+	go func() {
+		<-ctx.Done()
+		c.iptablesSyncQueue.ShutDown()
+	}()
+	// The worker only waits for notifications, syncNetworkConfig drives the period.
+	go wait.Until(c.iptablesSyncWorker, time.Second, ctx.Done())
 	wait.UntilWithContext(ctx, c.syncNetworkConfig, SyncInterval)
+}
+
+// triggerIPTablesSync notifies the sync loop that the iptables caches have been updated. The queue holds a
+// single copy of the key, and one added while a sync runs is kept for the next, so a burst of updates costs
+// at most a sync for the first of them and another for the rest.
+func (c *Client) triggerIPTablesSync() {
+	c.iptablesSyncQueue.Add(iptablesSyncKey)
+}
+
+// iptablesSyncWorker writes the iptables rules when it is notified. A sync rewrites the whole state from
+// the caches, so it overwrites anything written to the datapath at the same time. Every other feature only
+// updates the caches and notifies the queue. The two NodeNetworkPolicy calls are the only ones which still
+// write to the datapath themselves, and they notify the queue as well, so that a sync which read the caches
+// before them is followed by one which reads what they wrote.
+//
+// The ipsets need no such loop. syncIPSet only creates and adds, so it never removes anything.
+func (c *Client) iptablesSyncWorker() {
+	for c.processNextIPTablesSync() {
+	}
+}
+
+func (c *Client) processNextIPTablesSync() bool {
+	key, quit := c.iptablesSyncQueue.Get()
+	if quit {
+		return false
+	}
+	// A defer runs when a function returns, and the worker's loop does not, which is why this is one.
+	defer c.iptablesSyncQueue.Done(key)
+
+	if err := c.syncIPTables(false); err != nil {
+		c.iptablesSyncQueue.AddRateLimited(key)
+		klog.ErrorS(err, "Failed to sync iptables rules, requeuing")
+		return true
+	}
+	c.iptablesSyncQueue.Forget(key)
+	if key == iptablesPeriodicKey {
+		// Deleting a chain writes to the datapath, so it happens here, after the sync which removed the
+		// rules pointing at the chains it deletes.
+		c.cleanupOrphanNodeNetworkPolicyChains()
+	}
+	return true
 }
 
 // syncNetworkConfig is idempotent and can be safely called on every sync operation.
 func (c *Client) syncNetworkConfig(ctx context.Context) {
-	// Sync ipset before syncing iptables rules
+	// Sync the ipsets first. A rule pointing at a missing one makes iptables-restore roll its table back.
 	if err := c.syncIPSet(); err != nil {
 		klog.ErrorS(err, "Failed to sync ipset")
 		return
 	}
-	if err := c.syncIPTables(false); err != nil {
-		klog.ErrorS(err, "Failed to sync iptables")
-		return
-	}
+	// The period is a notification like any other, so that the sync loop stays the only writer. Its key
+	// also tells the loop to delete the chains left behind.
+	c.iptablesSyncQueue.Add(iptablesPeriodicKey)
 	if c.nftables != nil {
 		if err := c.syncNFTables(ctx); err != nil {
 			klog.ErrorS(err, "Failed to sync nftables")
@@ -1069,6 +1142,71 @@ func (c *Client) removeUnexpectedAntreaJumpRule(protocol iptables.Protocol, jump
 	return nil
 }
 
+// cleanupOrphanNodeNetworkPolicyChains deletes the NodeNetworkPolicy chains which are in the datapath but
+// not in the caches any more. syncIPTables only rewrites the chains the caches know about, so a chain
+// deleted after a sync read the caches is written back by that sync, and nothing removes it afterwards.
+//
+// A chain has to be an orphan in two consecutive runs to be deleted. The writers update the datapath and
+// the caches one after the other, so it can be in one and not the other for an instant. It also runs when
+// the feature is disabled, which is when every chain is an orphan nothing else would remove. On a Node which
+// never enabled the feature this lists the chains for nothing every period, which is cheap enough not to be
+// worth tracking.
+//
+// The chains are deleted with one iptables-restore per IP protocol, so a run clears as many as disabling the
+// feature leaves behind.
+func (c *Client) cleanupOrphanNodeNetworkPolicyChains() {
+	chainsInDatapath, err := c.iptables.ListChains(c.getIPProtocol(), iptables.FilterTable)
+	if err != nil {
+		klog.ErrorS(err, "Failed to list the chains of the filter table")
+		return
+	}
+	staleChains := make(map[iptables.Protocol]sets.Set[string], len(chainsInDatapath))
+	for ipProtocol, chains := range chainsInDatapath {
+		cache := c.iptablesCache.ipv4[featureNodeNetworkPolicy]
+		if iptables.IsIPv6Protocol(ipProtocol) {
+			cache = c.iptablesCache.ipv6[featureNodeNetworkPolicy]
+		}
+		staleChains[ipProtocol] = sets.New[string]()
+		var orphanChains []string
+		for _, chain := range chains {
+			if !strings.HasPrefix(chain, nodeNetworkPolicyChainPrefix) {
+				continue
+			}
+			if _, exists := cache.Load(chain); exists {
+				continue
+			}
+			staleChains[ipProtocol].Insert(chain)
+			// A chain which was not an orphan in the previous run gets a period to be cached.
+			if c.staleNodeNetworkPolicyChains[ipProtocol].Has(chain) {
+				orphanChains = append(orphanChains, chain)
+			}
+		}
+		if len(orphanChains) == 0 {
+			continue
+		}
+		// An orphan chain keeps the rules it had, as syncIPTables does not touch the chains it does not know
+		// about, and a chain can only be deleted once it is empty. Every chain is flushed before any is
+		// deleted, so that a jump from one orphan to another does not stop the latter from being deleted.
+		iptablesData := bytes.NewBuffer(nil)
+		writeLine(iptablesData, "*filter")
+		for _, chain := range orphanChains {
+			writeLine(iptablesData, "-F", chain)
+		}
+		for _, chain := range orphanChains {
+			writeLine(iptablesData, "-X", chain)
+		}
+		writeLine(iptablesData, "COMMIT")
+		// A chain still referenced from outside the batch fails the whole restore. The chains stay
+		// candidates, so the next run retries them.
+		if err := c.iptables.Restore(iptablesData.String(), false, iptables.IsIPv6Protocol(ipProtocol)); err != nil {
+			klog.ErrorS(err, "Failed to delete orphan NodeNetworkPolicy chains, will retry", "chains", orphanChains)
+			continue
+		}
+		klog.InfoS("Deleted orphan NodeNetworkPolicy chains", "chains", orphanChains)
+	}
+	c.staleNodeNetworkPolicyChains = staleChains
+}
+
 // syncIPTables ensure that the iptables infrastructure we use is set up.
 // It's idempotent and can safely be called on every startup.
 func (c *Client) syncIPTables(cleanupStaleJumpRules bool) error {
@@ -1505,10 +1643,11 @@ func (c *Client) restoreIptablesData(podCIDR *net.IPNet,
 	}
 	// Egress rules must be inserted before the default masquerade rule.
 	for snatMark, snatIP := range snatMarkToIP {
-		// Cannot reuse snatRuleSpec to generate the rule as it doesn't have "`" in the comment.
 		rule := []string{
 			"-A", antreaPostRoutingChain,
 			"-m", "comment", "--comment", `"Antrea: SNAT Pod to external packets"`,
+			// The condition is needed to prevent the rule from being applied to local out packets destined
+			// for Pods, which have "0x1/0x1" mark.
 			"!", "-o", c.nodeConfig.GatewayConfig.Name,
 			"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", snatMark, types.SNATIPMarkMask),
 			"-j", iptables.SNATTarget, "--to", snatIP.String(),
@@ -1869,18 +2008,8 @@ func (c *Client) updateControllerAPIServerHostNetworkFilterRules() {
 	// periodic sync is up to SyncInterval later. Waiting for it would leave the Agent unable to open a
 	// connection to the Controller for that long whenever the default host network policy is to drop.
 	//
-	// This runs on the EndpointResolver's only worker, so it must not block: doing so would stop the
-	// queue from being drained, and no Endpoint change would be resolved for any listener.
-	select {
-	case <-c.iptablesInitialized:
-		if err := c.syncIPTables(false); err != nil {
-			klog.ErrorS(err, "Failed to sync iptables rules after the Antrea Service Endpoint changed")
-		}
-	default:
-		// The initial sync may already have read the cache, so it does not necessarily program these
-		// rules. What does is the first syncNetworkConfig, which Run performs as soon as it unblocks on
-		// iptablesInitialized, and which reads the cache again.
-	}
+	// The sync is left to the loop. This runs on the EndpointResolver's only worker, which must not block.
+	c.triggerIPTablesSync()
 }
 
 func (c *Client) initAgentClusterMembershipHostNetworkFilterRules() {
@@ -2576,43 +2705,23 @@ func (c *Client) UnMigrateRoutesFromGw(route *net.IPNet, linkName string) error 
 	return nil
 }
 
-func (c *Client) snatRuleSpec(snatIP net.IP, snatMark uint32) []string {
-	rule := []string{
-		"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-		// The condition is needed to prevent the rule from being applied to local out packets destined for Pods, which
-		// have "0x1/0x1" mark.
-		"!", "-o", c.nodeConfig.GatewayConfig.Name,
-		"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", snatMark, types.SNATIPMarkMask),
-		"-j", iptables.SNATTarget, "--to", snatIP.String(),
-	}
-	if c.egressSNATRandomFully {
-		rule = append(rule, "--random-fully")
-	}
-	return rule
-}
-
+// AddSNATRule caches the SNAT IP and notifies the sync loop, which installs the rule. Installing it here
+// would race with a sync, which could overwrite it.
 func (c *Client) AddSNATRule(snatIP net.IP, mark uint32) error {
-	protocol := iptables.ProtocolIPv4
-	if snatIP.To4() == nil {
-		protocol = iptables.ProtocolIPv6
-	}
 	c.markToSNATIP.Store(mark, snatIP)
-	return c.iptables.InsertRule(protocol, iptables.NATTable, antreaPostRoutingChain, c.snatRuleSpec(snatIP, mark))
+	c.triggerIPTablesSync()
+	return nil
 }
 
+// DeleteSNATRule uncaches the SNAT IP and notifies the sync loop, which uninstalls the rule.
 func (c *Client) DeleteSNATRule(mark uint32) error {
-	value, ok := c.markToSNATIP.Load(mark)
-	if !ok {
+	if _, ok := c.markToSNATIP.Load(mark); !ok {
 		klog.InfoS("Didn't find SNAT rule with mark", "mark", fmt.Sprintf("%#x", mark))
 		return nil
 	}
 	c.markToSNATIP.Delete(mark)
-	snatIP := value.(net.IP)
-	protocol := iptables.ProtocolIPv4
-	if snatIP.To4() == nil {
-		protocol = iptables.ProtocolIPv6
-	}
-	return c.iptables.DeleteRule(protocol, iptables.NATTable, antreaPostRoutingChain, c.snatRuleSpec(snatIP, mark))
+	c.triggerIPTablesSync()
+	return nil
 }
 
 func (c *Client) AddEgressRoutes(tableID uint32, dev int, gateway net.IP, prefixLength int) error {
@@ -3224,6 +3333,10 @@ func (c *Client) DeleteNodeNetworkPolicyIPSet(ipsetName string, isIPv6 bool) err
 	return nil
 }
 
+// AddOrUpdateNodeNetworkPolicyIPTables writes the rules itself, as callers rely on them being enforced when
+// it returns. A rule dropping its reference to an ipset must be applied before that ipset is destroyed. The
+// caches are only updated once iptables has taken the rules, as nothing would remove a rejected one and
+// every later sync would send it again and fail with it.
 func (c *Client) AddOrUpdateNodeNetworkPolicyIPTables(iptablesChains []string, iptablesRules [][]string, isIPv6 bool) error {
 	iptablesData := bytes.NewBuffer(nil)
 
@@ -3249,6 +3362,7 @@ func (c *Client) AddOrUpdateNodeNetworkPolicyIPTables(iptablesChains []string, i
 			c.iptablesCache.ipv4[featureNodeNetworkPolicy].Store(iptablesChain, iptablesRules[index])
 		}
 	}
+	c.triggerIPTablesSync()
 	return nil
 }
 
@@ -3271,7 +3385,7 @@ func (c *Client) DeleteNodeNetworkPolicyIPTables(iptablesChains []string, isIPv6
 			c.iptablesCache.ipv4[featureNodeNetworkPolicy].Delete(iptablesChain)
 		}
 	}
-
+	c.triggerIPTablesSync()
 	return nil
 }
 

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/knftables"
@@ -392,6 +394,103 @@ func TestNewClientCopiesHostNetworkPorts(t *testing.T) {
 	// nothing afterwards.
 	hostNetworkPortRules.Allow(10351, FeatureAgentClusterMembership)
 	assert.Equal(t, map[feature]int32{featureAgentAPIServer: 10350}, c.hostNetworkPortRules)
+}
+
+func TestCleanupOrphanNodeNetworkPolicyChains(t *testing.T) {
+	const orphanChain = "ANTREA-POL-RULE-ORPHAN"
+
+	// A run is one call to cleanupOrphanNodeNetworkPolicyChains.
+	type run struct {
+		cachedChain     string
+		deleteError     error
+		expectedDeletes []string
+	}
+	tests := []struct {
+		name                     string
+		nodeNetworkPolicyEnabled bool
+		chainsInDatapath         []string
+		runs                     []run
+	}{
+		{
+			name:                     "delete a chain which is not in the cache in two consecutive runs",
+			nodeNetworkPolicyEnabled: true,
+			// The first chain is cached by initNodeNetworkPolicy, the last one is not Antrea's.
+			chainsInDatapath: []string{config.NodeNetworkPolicyIngressRulesChain, orphanChain, "KUBE-SERVICES"},
+			runs: []run{
+				{}, // The first run only records the chain as a candidate.
+				{expectedDeletes: []string{orphanChain}},
+			},
+		},
+		{
+			// The chain was installed but not cached yet when the first run listed the chains.
+			name:                     "keep a chain which makes it to the cache before the second run",
+			nodeNetworkPolicyEnabled: true,
+			chainsInDatapath:         []string{orphanChain},
+			runs: []run{
+				{},
+				{cachedChain: orphanChain},
+			},
+		},
+		{
+			name:                     "retry a chain whose deletion failed",
+			nodeNetworkPolicyEnabled: true,
+			chainsInDatapath:         []string{orphanChain},
+			runs: []run{
+				{},
+				{deleteError: fmt.Errorf("chain is not empty"), expectedDeletes: []string{orphanChain}},
+				{expectedDeletes: []string{orphanChain}},
+			},
+		},
+		{
+			// The caches are empty when the feature is disabled, so every chain is an orphan.
+			name:                     "delete the chains a previous run left behind when the feature is disabled",
+			nodeNetworkPolicyEnabled: false,
+			chainsInDatapath:         []string{config.NodeNetworkPolicyIngressRulesChain, orphanChain, "KUBE-SERVICES"},
+			runs: []run{
+				{},
+				{expectedDeletes: []string{config.NodeNetworkPolicyIngressRulesChain, orphanChain}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIPTables := iptablestest.NewMockInterface(ctrl)
+			c := &Client{
+				networkConfig:            &config.NetworkConfig{IPv4Enabled: true},
+				nodeNetworkPolicyEnabled: tt.nodeNetworkPolicyEnabled,
+				iptablesCache:            newIPTablesCache(),
+				iptables:                 mockIPTables,
+			}
+			cache := c.iptablesCache.ipv4[featureNodeNetworkPolicy]
+			if tt.nodeNetworkPolicyEnabled {
+				// initNodeNetworkPolicy seeds the core chains, and only runs when the feature is on.
+				cache.Store(config.NodeNetworkPolicyIngressRulesChain, []string{})
+			}
+
+			for i, r := range tt.runs {
+				if r.cachedChain != "" {
+					cache.Store(r.cachedChain, []string{})
+				}
+				mockIPTables.EXPECT().ListChains(iptables.ProtocolIPv4, iptables.FilterTable).Return(
+					map[iptables.Protocol][]string{iptables.ProtocolIPv4: tt.chainsInDatapath}, nil)
+				if len(r.expectedDeletes) > 0 {
+					iptablesData := "*filter\n"
+					for _, chain := range r.expectedDeletes {
+						iptablesData += "-F " + chain + "\n"
+					}
+					for _, chain := range r.expectedDeletes {
+						iptablesData += "-X " + chain + "\n"
+					}
+					iptablesData += "COMMIT\n"
+					mockIPTables.EXPECT().Restore(iptablesData, false, false).Return(r.deleteError)
+				}
+
+				c.cleanupOrphanNodeNetworkPolicyChains()
+				assert.Truef(t, ctrl.Satisfied(), "Unexpected calls in run %d", i)
+			}
+		})
+	}
 }
 
 func TestSyncIPTables(t *testing.T) {
@@ -2322,156 +2421,46 @@ func TestUnMigrateRoutesToGw(t *testing.T) {
 }
 
 func TestAddSNATRule(t *testing.T) {
-	tests := []struct {
-		name          string
-		networkConfig *config.NetworkConfig
-		nodeConfig    *config.NodeConfig
-		snatIP        net.IP
-		mark          uint32
-		expectedCalls func(mockIPTables *iptablestest.MockInterfaceMockRecorder)
-	}{
-		{
-			name: "IPv4",
-			nodeConfig: &config.NodeConfig{
-				GatewayConfig: &config.GatewayConfig{
-					Name: "antrea-gw0",
-				},
-			},
-			snatIP: net.ParseIP("1.1.1.1"),
-			mark:   10,
-			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
-				mockIPTables.InsertRule(iptables.ProtocolIPv4, iptables.NATTable, antreaPostRoutingChain, []string{
-					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-					"!", "-o", "antrea-gw0",
-					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 10, types.SNATIPMarkMask),
-					"-j", iptables.SNATTarget, "--to", "1.1.1.1",
-				})
-			},
-		},
-		{
-			name: "IPv6",
-			nodeConfig: &config.NodeConfig{
-				GatewayConfig: &config.GatewayConfig{
-					Name: "antrea-gw0",
-				},
-			},
-			snatIP: net.ParseIP("fe80::e643:4bff:fe44:1"),
-			mark:   11,
-			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
-				mockIPTables.InsertRule(iptables.ProtocolIPv6, iptables.NATTable, antreaPostRoutingChain, []string{
-					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-					"!", "-o", "antrea-gw0",
-					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 11, types.SNATIPMarkMask),
-					"-j", iptables.SNATTarget, "--to", "fe80::e643:4bff:fe44:1",
-				})
-			},
-		},
+	c := &Client{
+		markToSNATIP:      sync.Map{},
+		iptablesSyncQueue: newIPTablesSyncQueue(),
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockIPTables := iptablestest.NewMockInterface(ctrl)
-			c := &Client{iptables: mockIPTables,
-				nodeConfig: tt.nodeConfig,
-			}
-			tt.expectedCalls(mockIPTables.EXPECT())
-			assert.NoError(t, c.AddSNATRule(tt.snatIP, tt.mark))
-		})
-	}
+	snatIPv4 := net.ParseIP("1.1.1.1")
+	snatIPv6 := net.ParseIP("fe80::e643:4bff:fe44:1")
+
+	// The SNAT rules are not installed here, only cached, and a sync is triggered.
+	assert.NoError(t, c.AddSNATRule(snatIPv4, 10))
+	assert.NoError(t, c.AddSNATRule(snatIPv6, 11))
+
+	assert.Equal(t, map[uint32]net.IP{10: snatIPv4, 11: snatIPv6}, getMarkToSNATIP(c))
+	assertSyncQueued(t, c.iptablesSyncQueue)
 }
 
 func TestDeleteSNATRule(t *testing.T) {
-	tests := []struct {
-		name                  string
-		networkConfig         *config.NetworkConfig
-		egressSNATRandomFully bool
-		markToSNATIP          map[uint32]net.IP
-		nodeConfig            *config.NodeConfig
-		mark                  uint32
-		expectedCalls         func(mockIPTables *iptablestest.MockInterfaceMockRecorder)
-	}{
-		{
-			name: "IPv4",
-			nodeConfig: &config.NodeConfig{
-				GatewayConfig: &config.GatewayConfig{
-					Name: "antrea-gw0",
-				},
-			},
-			markToSNATIP: map[uint32]net.IP{
-				10: net.ParseIP("1.1.1.1"),
-				11: net.ParseIP("1.1.1.2"),
-			},
-			mark: 10,
-			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
-				mockIPTables.DeleteRule(iptables.ProtocolIPv4, iptables.NATTable, antreaPostRoutingChain, []string{
-					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-					"!", "-o", "antrea-gw0",
-					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 10, types.SNATIPMarkMask),
-					"-j", iptables.SNATTarget, "--to", "1.1.1.1",
-				})
-			},
-		},
-		{
-			name: "IPv6",
-			nodeConfig: &config.NodeConfig{
-				GatewayConfig: &config.GatewayConfig{
-					Name: "antrea-gw0",
-				},
-			},
-			markToSNATIP: map[uint32]net.IP{
-				10: net.ParseIP("fe80::e643:4bff:fe44:1"),
-				11: net.ParseIP("fe80::e643:4bff:fe44:2"),
-			},
-			mark: 11,
-			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
-				mockIPTables.DeleteRule(iptables.ProtocolIPv6, iptables.NATTable, antreaPostRoutingChain, []string{
-					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-					"!", "-o", "antrea-gw0",
-					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 11, types.SNATIPMarkMask),
-					"-j", iptables.SNATTarget, "--to", "fe80::e643:4bff:fe44:2",
-				})
-			},
-		},
-		{
-			name: "IPv4 with random ports for SNAT",
-			nodeConfig: &config.NodeConfig{
-				GatewayConfig: &config.GatewayConfig{
-					Name: "antrea-gw0",
-				},
-			},
-			egressSNATRandomFully: true,
-			markToSNATIP: map[uint32]net.IP{
-				10: net.ParseIP("1.1.1.1"),
-				11: net.ParseIP("1.1.1.2"),
-			},
-			mark: 10,
-			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
-				mockIPTables.DeleteRule(iptables.ProtocolIPv4, iptables.NATTable, antreaPostRoutingChain, []string{
-					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-					"!", "-o", "antrea-gw0",
-					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 10, types.SNATIPMarkMask),
-					"-j", iptables.SNATTarget, "--to", "1.1.1.1", "--random-fully",
-				})
-			},
-		},
+	snatIPv4 := net.ParseIP("1.1.1.1")
+	snatIPv6 := net.ParseIP("fe80::e643:4bff:fe44:1")
+	newClient := func() *Client {
+		c := &Client{
+			markToSNATIP:      sync.Map{},
+			iptablesSyncQueue: newIPTablesSyncQueue(),
+		}
+		c.markToSNATIP.Store(uint32(10), snatIPv4)
+		c.markToSNATIP.Store(uint32(11), snatIPv6)
+		return c
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockIPTables := iptablestest.NewMockInterface(ctrl)
-			c := &Client{
-				iptables:              mockIPTables,
-				nodeConfig:            tt.nodeConfig,
-				egressSNATRandomFully: tt.egressSNATRandomFully,
-				markToSNATIP:          sync.Map{},
-			}
-			for mark, snatIP := range tt.markToSNATIP {
-				c.markToSNATIP.Store(mark, snatIP)
-			}
-			tt.expectedCalls(mockIPTables.EXPECT())
-			assert.NoError(t, c.DeleteSNATRule(tt.mark))
-		})
-	}
+
+	t.Run("existing mark", func(t *testing.T) {
+		c := newClient()
+		assert.NoError(t, c.DeleteSNATRule(10))
+		assert.Equal(t, map[uint32]net.IP{11: snatIPv6}, getMarkToSNATIP(c))
+		assertSyncQueued(t, c.iptablesSyncQueue)
+	})
+	t.Run("unknown mark", func(t *testing.T) {
+		c := newClient()
+		assert.NoError(t, c.DeleteSNATRule(12))
+		assert.Equal(t, map[uint32]net.IP{10: snatIPv4, 11: snatIPv6}, getMarkToSNATIP(c))
+		assertSyncNotQueued(t, c.iptablesSyncQueue)
+	})
 }
 
 func TestAddNodePortConfigs(t *testing.T) {
@@ -3712,7 +3701,8 @@ COMMIT
 					IPv4Enabled: true,
 					IPv6Enabled: true,
 				},
-				iptablesCache: newIPTablesCache(),
+				iptablesCache:     newIPTablesCache(),
+				iptablesSyncQueue: newIPTablesSyncQueue(),
 			}
 			c.initNodeNetworkPolicy()
 
@@ -3925,29 +3915,25 @@ func TestEnqueue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockIPTables := iptablestest.NewMockInterface(ctrl)
-			// The content of the sync is covered by TestSyncIPTables, only the fact that it runs matters
-			// here: the rules must be programmed, not only cached.
 			mockIPTables.EXPECT().EnsureChain(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			mockIPTables.EXPECT().AppendRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			mockIPTables.EXPECT().InsertRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			if tt.expectSync {
-				mockIPTables.EXPECT().Restore(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).MinTimes(1)
-			} else {
-				mockIPTables.EXPECT().Restore(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
-			}
-			// Report iptables as initialized, so that Enqueue syncs the rules instead of only caching
-			// them.
-			iptablesInitialized := make(chan struct{})
-			close(iptablesInitialized)
 			c := &Client{
-				endpointResolver:    tt.endpointResolver,
-				networkConfig:       tt.networkConfig,
-				iptablesCache:       newIPTablesCache(),
-				iptables:            mockIPTables,
-				iptablesInitialized: iptablesInitialized,
-				nodeConfig:          &config.NodeConfig{GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"}},
+				endpointResolver:  tt.endpointResolver,
+				networkConfig:     tt.networkConfig,
+				iptablesCache:     newIPTablesCache(),
+				iptables:          mockIPTables,
+				iptablesSyncQueue: newIPTablesSyncQueue(),
+				nodeConfig:        &config.NodeConfig{GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"}},
 			}
 			c.Enqueue()
+
+			// Enqueue leaves the programming to the sync loop, so what it must do is notify it.
+			if tt.expectSync {
+				assertSyncQueued(t, c.iptablesSyncQueue)
+			} else {
+				assertSyncNotQueued(t, c.iptablesSyncQueue)
+			}
 
 			expectedInputRules := []string{
 				`-A ANTREA-INPUT -m comment --comment "Antrea: allow Controller APIServer input packets" -p tcp --dport 10349 -j ACCEPT`,
@@ -3997,19 +3983,14 @@ func TestEnqueueRemovesRulesWhenEndpointGoesAway(t *testing.T) {
 	mockIPTables.EXPECT().EnsureChain(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockIPTables.EXPECT().AppendRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockIPTables.EXPECT().InsertRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	// Once for the Endpoint being resolved, once for it going away.
-	mockIPTables.EXPECT().Restore(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
-
-	iptablesInitialized := make(chan struct{})
-	close(iptablesInitialized)
 	resolver := &fakeEndpointResolver{url: &url.URL{Scheme: "https", Host: "antrea.kube-system.svc:10349"}}
 	c := &Client{
-		endpointResolver:    resolver,
-		networkConfig:       &config.NetworkConfig{IPv4Enabled: true},
-		iptablesCache:       newIPTablesCache(),
-		iptables:            mockIPTables,
-		iptablesInitialized: iptablesInitialized,
-		nodeConfig:          &config.NodeConfig{GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"}},
+		endpointResolver:  resolver,
+		networkConfig:     &config.NetworkConfig{IPv4Enabled: true},
+		iptablesCache:     newIPTablesCache(),
+		iptables:          mockIPTables,
+		iptablesSyncQueue: newIPTablesSyncQueue(),
+		nodeConfig:        &config.NodeConfig{GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"}},
 	}
 
 	getRules := func(chain string) []string {
@@ -4021,11 +4002,16 @@ func TestEnqueueRemovesRulesWhenEndpointGoesAway(t *testing.T) {
 	c.Enqueue()
 	assert.Len(t, getRules(antreaInputChain), 2)
 	assert.Len(t, getRules(antreaOutputChain), 2)
+	// Take this first notification out, so that the one for the removal below can be told apart.
+	assertSyncQueued(t, c.iptablesSyncQueue)
+	key, _ := c.iptablesSyncQueue.Get()
+	c.iptablesSyncQueue.Done(key)
 
 	resolver.url = nil
 	c.Enqueue()
 	assert.Empty(t, getRules(antreaInputChain), "the rules must be removed when no Endpoint is resolved")
 	assert.Empty(t, getRules(antreaOutputChain), "the rules must be removed when no Endpoint is resolved")
+	assertSyncQueued(t, c.iptablesSyncQueue)
 }
 
 func TestInitIPsecHostNetworkFilterRules(t *testing.T) {
@@ -4170,4 +4156,180 @@ func newMockNFTables(enableIPv4, enableIPv6 bool) (*nftables.Client, error) {
 	}
 
 	return mockNFTables, nil
+}
+
+func getMarkToSNATIP(c *Client) map[uint32]net.IP {
+	markToSNATIP := map[uint32]net.IP{}
+	c.markToSNATIP.Range(func(key, value interface{}) bool {
+		markToSNATIP[key.(uint32)] = value.(net.IP)
+		return true
+	})
+	return markToSNATIP
+}
+
+func newIPTablesSyncQueue() workqueue.TypedRateLimitingInterface[string] {
+	return workqueue.NewTypedRateLimitingQueue(
+		workqueue.NewTypedItemExponentialFailureRateLimiter[string](syncMinRetryDelay, SyncInterval))
+}
+
+// expectIPTablesSync expects the calls syncIPTables makes. TestSyncIPTables covers what it writes.
+func expectIPTablesSync(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
+	mockIPTables.EnsureChain(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockIPTables.InsertRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockIPTables.AppendRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockIPTables.ListRules(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockIPTables.Restore(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+}
+
+// A notification is queued immediately, but a failed sync is requeued after a delay, which this waits for.
+func assertSyncQueued(t *testing.T, queue workqueue.TypedRateLimitingInterface[string]) {
+	t.Helper()
+	require.Eventually(t, func() bool { return queue.Len() > 0 }, 2*time.Second, 10*time.Millisecond,
+		"Expected a sync to be queued")
+}
+
+func assertSyncNotQueued(t *testing.T, queue workqueue.TypedRateLimitingInterface[string]) {
+	t.Helper()
+	assert.Never(t, func() bool { return queue.Len() > 0 }, 200*time.Millisecond, 10*time.Millisecond,
+		"Expected no sync to be queued")
+}
+
+func TestTriggerIPTablesSync(t *testing.T) {
+	c := &Client{iptablesSyncQueue: newIPTablesSyncQueue()}
+
+	for i := 0; i < 3; i++ {
+		c.triggerIPTablesSync()
+	}
+
+	assertSyncQueued(t, c.iptablesSyncQueue)
+	assert.Equal(t, 1, c.iptablesSyncQueue.Len())
+}
+
+func TestProcessNextIPTablesSync(t *testing.T) {
+	tests := []struct {
+		name              string
+		key               string
+		syncFails         bool
+		expectedRequeued  bool
+		expectedReclaimed bool
+	}{
+		{
+			name: "update",
+			key:  iptablesSyncKey,
+		},
+		{
+			name:             "update with a failing sync",
+			key:              iptablesSyncKey,
+			syncFails:        true,
+			expectedRequeued: true,
+		},
+		{
+			name:              "period",
+			key:               iptablesPeriodicKey,
+			expectedReclaimed: true,
+		},
+		{
+			name:             "period with a failing sync",
+			key:              iptablesPeriodicKey,
+			syncFails:        true,
+			expectedRequeued: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIPTables := iptablestest.NewMockInterface(ctrl)
+			c := &Client{
+				iptables:                 mockIPTables,
+				networkConfig:            &config.NetworkConfig{IPv4Enabled: true},
+				nodeConfig:               &config.NodeConfig{GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"}},
+				nodeNetworkPolicyEnabled: true,
+				iptablesCache:            newIPTablesCache(),
+				iptablesSyncQueue:        newIPTablesSyncQueue(),
+			}
+			if tt.syncFails {
+				mockIPTables.EXPECT().EnsureChain(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(fmt.Errorf("the datapath is busy"))
+			}
+			expectIPTablesSync(mockIPTables.EXPECT())
+			// Listing the chains is the first thing the cleanup does.
+			reclaimed := 0
+			mockIPTables.EXPECT().ListChains(iptables.ProtocolIPv4, iptables.FilterTable).
+				DoAndReturn(func(iptables.Protocol, string) (map[iptables.Protocol][]string, error) {
+					reclaimed++
+					return nil, nil
+				}).AnyTimes()
+
+			c.iptablesSyncQueue.Add(tt.key)
+			require.True(t, c.processNextIPTablesSync())
+
+			if tt.expectedRequeued {
+				assertSyncQueued(t, c.iptablesSyncQueue)
+			} else {
+				assertSyncNotQueued(t, c.iptablesSyncQueue)
+			}
+			if tt.expectedReclaimed {
+				assert.Equal(t, 1, reclaimed)
+			} else {
+				assert.Zero(t, reclaimed)
+			}
+		})
+	}
+}
+
+func TestProcessNextIPTablesSyncOnShutDown(t *testing.T) {
+	c := &Client{iptablesSyncQueue: newIPTablesSyncQueue()}
+	c.iptablesSyncQueue.ShutDown()
+
+	assert.False(t, c.processNextIPTablesSync())
+}
+
+func TestIPTablesSyncWorker(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockIPTables := iptablestest.NewMockInterface(ctrl)
+	c := &Client{
+		iptables:          mockIPTables,
+		networkConfig:     &config.NetworkConfig{},
+		nodeConfig:        &config.NodeConfig{GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"}},
+		iptablesCache:     newIPTablesCache(),
+		iptablesSyncQueue: newIPTablesSyncQueue(),
+	}
+	// Neither IPv4 nor IPv6 is enabled, so syncIPTables only ensures the jump rules and chains.
+	syncCh := make(chan struct{}, 10)
+	mockIPTables.EXPECT().EnsureChain(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockIPTables.EXPECT().InsertRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockIPTables.EXPECT().AppendRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Do(
+		func(_ iptables.Protocol, _, _ string, _ []string) {
+			select {
+			case syncCh <- struct{}{}:
+			default:
+			}
+		})
+
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		c.iptablesSyncWorker()
+	}()
+
+	select {
+	case <-syncCh:
+		t.Fatal("iptables were synced before the worker was notified")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	c.triggerIPTablesSync()
+	select {
+	case <-syncCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("iptables were not synced after the worker was notified")
+	}
+
+	// Run shuts the queue down when its context is cancelled, which makes the worker return.
+	c.iptablesSyncQueue.ShutDown()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the worker did not stop after the queue was shut down")
+	}
 }

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2158,156 +2159,46 @@ func TestUnMigrateRoutesToGw(t *testing.T) {
 }
 
 func TestAddSNATRule(t *testing.T) {
-	tests := []struct {
-		name          string
-		networkConfig *config.NetworkConfig
-		nodeConfig    *config.NodeConfig
-		snatIP        net.IP
-		mark          uint32
-		expectedCalls func(mockIPTables *iptablestest.MockInterfaceMockRecorder)
-	}{
-		{
-			name: "IPv4",
-			nodeConfig: &config.NodeConfig{
-				GatewayConfig: &config.GatewayConfig{
-					Name: "antrea-gw0",
-				},
-			},
-			snatIP: net.ParseIP("1.1.1.1"),
-			mark:   10,
-			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
-				mockIPTables.InsertRule(iptables.ProtocolIPv4, iptables.NATTable, antreaPostRoutingChain, []string{
-					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-					"!", "-o", "antrea-gw0",
-					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 10, types.SNATIPMarkMask),
-					"-j", iptables.SNATTarget, "--to", "1.1.1.1",
-				})
-			},
-		},
-		{
-			name: "IPv6",
-			nodeConfig: &config.NodeConfig{
-				GatewayConfig: &config.GatewayConfig{
-					Name: "antrea-gw0",
-				},
-			},
-			snatIP: net.ParseIP("fe80::e643:4bff:fe44:1"),
-			mark:   11,
-			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
-				mockIPTables.InsertRule(iptables.ProtocolIPv6, iptables.NATTable, antreaPostRoutingChain, []string{
-					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-					"!", "-o", "antrea-gw0",
-					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 11, types.SNATIPMarkMask),
-					"-j", iptables.SNATTarget, "--to", "fe80::e643:4bff:fe44:1",
-				})
-			},
-		},
+	c := &Client{
+		markToSNATIP:        sync.Map{},
+		iptablesSyncTrigger: make(chan struct{}, 1),
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockIPTables := iptablestest.NewMockInterface(ctrl)
-			c := &Client{iptables: mockIPTables,
-				nodeConfig: tt.nodeConfig,
-			}
-			tt.expectedCalls(mockIPTables.EXPECT())
-			assert.NoError(t, c.AddSNATRule(tt.snatIP, tt.mark))
-		})
-	}
+	snatIPv4 := net.ParseIP("1.1.1.1")
+	snatIPv6 := net.ParseIP("fe80::e643:4bff:fe44:1")
+
+	// The SNAT rules are not installed synchronously: only the cache is updated, and a sync is triggered.
+	assert.NoError(t, c.AddSNATRule(snatIPv4, 10))
+	assert.NoError(t, c.AddSNATRule(snatIPv6, 11))
+
+	assert.Equal(t, map[uint32]net.IP{10: snatIPv4, 11: snatIPv6}, getMarkToSNATIP(c))
+	assertSyncTriggered(t, c.iptablesSyncTrigger)
 }
 
 func TestDeleteSNATRule(t *testing.T) {
-	tests := []struct {
-		name                  string
-		networkConfig         *config.NetworkConfig
-		egressSNATRandomFully bool
-		markToSNATIP          map[uint32]net.IP
-		nodeConfig            *config.NodeConfig
-		mark                  uint32
-		expectedCalls         func(mockIPTables *iptablestest.MockInterfaceMockRecorder)
-	}{
-		{
-			name: "IPv4",
-			nodeConfig: &config.NodeConfig{
-				GatewayConfig: &config.GatewayConfig{
-					Name: "antrea-gw0",
-				},
-			},
-			markToSNATIP: map[uint32]net.IP{
-				10: net.ParseIP("1.1.1.1"),
-				11: net.ParseIP("1.1.1.2"),
-			},
-			mark: 10,
-			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
-				mockIPTables.DeleteRule(iptables.ProtocolIPv4, iptables.NATTable, antreaPostRoutingChain, []string{
-					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-					"!", "-o", "antrea-gw0",
-					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 10, types.SNATIPMarkMask),
-					"-j", iptables.SNATTarget, "--to", "1.1.1.1",
-				})
-			},
-		},
-		{
-			name: "IPv6",
-			nodeConfig: &config.NodeConfig{
-				GatewayConfig: &config.GatewayConfig{
-					Name: "antrea-gw0",
-				},
-			},
-			markToSNATIP: map[uint32]net.IP{
-				10: net.ParseIP("fe80::e643:4bff:fe44:1"),
-				11: net.ParseIP("fe80::e643:4bff:fe44:2"),
-			},
-			mark: 11,
-			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
-				mockIPTables.DeleteRule(iptables.ProtocolIPv6, iptables.NATTable, antreaPostRoutingChain, []string{
-					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-					"!", "-o", "antrea-gw0",
-					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 11, types.SNATIPMarkMask),
-					"-j", iptables.SNATTarget, "--to", "fe80::e643:4bff:fe44:2",
-				})
-			},
-		},
-		{
-			name: "IPv4 with random ports for SNAT",
-			nodeConfig: &config.NodeConfig{
-				GatewayConfig: &config.GatewayConfig{
-					Name: "antrea-gw0",
-				},
-			},
-			egressSNATRandomFully: true,
-			markToSNATIP: map[uint32]net.IP{
-				10: net.ParseIP("1.1.1.1"),
-				11: net.ParseIP("1.1.1.2"),
-			},
-			mark: 10,
-			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
-				mockIPTables.DeleteRule(iptables.ProtocolIPv4, iptables.NATTable, antreaPostRoutingChain, []string{
-					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
-					"!", "-o", "antrea-gw0",
-					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 10, types.SNATIPMarkMask),
-					"-j", iptables.SNATTarget, "--to", "1.1.1.1", "--random-fully",
-				})
-			},
-		},
+	snatIPv4 := net.ParseIP("1.1.1.1")
+	snatIPv6 := net.ParseIP("fe80::e643:4bff:fe44:1")
+	newClient := func() *Client {
+		c := &Client{
+			markToSNATIP:        sync.Map{},
+			iptablesSyncTrigger: make(chan struct{}, 1),
+		}
+		c.markToSNATIP.Store(uint32(10), snatIPv4)
+		c.markToSNATIP.Store(uint32(11), snatIPv6)
+		return c
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockIPTables := iptablestest.NewMockInterface(ctrl)
-			c := &Client{
-				iptables:              mockIPTables,
-				nodeConfig:            tt.nodeConfig,
-				egressSNATRandomFully: tt.egressSNATRandomFully,
-				markToSNATIP:          sync.Map{},
-			}
-			for mark, snatIP := range tt.markToSNATIP {
-				c.markToSNATIP.Store(mark, snatIP)
-			}
-			tt.expectedCalls(mockIPTables.EXPECT())
-			assert.NoError(t, c.DeleteSNATRule(tt.mark))
-		})
-	}
+
+	t.Run("existing mark", func(t *testing.T) {
+		c := newClient()
+		assert.NoError(t, c.DeleteSNATRule(10))
+		assert.Equal(t, map[uint32]net.IP{11: snatIPv6}, getMarkToSNATIP(c))
+		assertSyncTriggered(t, c.iptablesSyncTrigger)
+	})
+	t.Run("unknown mark", func(t *testing.T) {
+		c := newClient()
+		assert.NoError(t, c.DeleteSNATRule(12))
+		assert.Equal(t, map[uint32]net.IP{10: snatIPv4, 11: snatIPv6}, getMarkToSNATIP(c))
+		assertSyncNotTriggered(t, c.iptablesSyncTrigger)
+	})
 }
 
 func TestAddNodePortConfigs(t *testing.T) {
@@ -3682,4 +3573,92 @@ func newMockNFTables(enableIPv4, enableIPv6 bool) (*nftables.Client, error) {
 	}
 
 	return mockNFTables, nil
+}
+
+func getMarkToSNATIP(c *Client) map[uint32]net.IP {
+	markToSNATIP := map[uint32]net.IP{}
+	c.markToSNATIP.Range(func(key, value interface{}) bool {
+		markToSNATIP[key.(uint32)] = value.(net.IP)
+		return true
+	})
+	return markToSNATIP
+}
+
+func assertSyncTriggered(t *testing.T, trigger chan struct{}) {
+	t.Helper()
+	select {
+	case <-trigger:
+	default:
+		t.Error("Expected a sync to be triggered")
+	}
+}
+
+func assertSyncNotTriggered(t *testing.T, trigger chan struct{}) {
+	t.Helper()
+	select {
+	case <-trigger:
+		t.Error("Expected no sync to be triggered")
+	default:
+	}
+}
+
+func TestTriggerSync(t *testing.T) {
+	c := &Client{iptablesSyncTrigger: make(chan struct{}, 1)}
+	// Triggering the sync multiple times must not block, and must not queue more than one notification.
+	for i := 0; i < 3; i++ {
+		c.triggerIPTablesSync()
+	}
+	assertSyncTriggered(t, c.iptablesSyncTrigger)
+	assertSyncNotTriggered(t, c.iptablesSyncTrigger)
+}
+
+func TestRunSyncLoopIPTables(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockIPTables := iptablestest.NewMockInterface(ctrl)
+	c := &Client{
+		iptables:            mockIPTables,
+		networkConfig:       &config.NetworkConfig{},
+		nodeConfig:          &config.NodeConfig{GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"}},
+		iptablesCache:       newIPTablesCache(),
+		iptablesSyncTrigger: make(chan struct{}, 1),
+	}
+	// Neither IPv4 nor IPv6 is enabled, so syncIPTables only ensures the jump rules and chains.
+	syncCh := make(chan struct{}, 10)
+	mockIPTables.EXPECT().EnsureChain(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockIPTables.EXPECT().InsertRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockIPTables.EXPECT().AppendRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Do(
+		func(_ iptables.Protocol, _, _ string, _ []string) {
+			select {
+			case syncCh <- struct{}{}:
+			default:
+			}
+		})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		c.runSyncLoop(ctx, c.iptablesSyncTrigger, func() error { return c.syncIPTables(false) })
+	}()
+
+	// No sync is expected until the loop is triggered.
+	select {
+	case <-syncCh:
+		t.Fatal("iptables were synced before the sync loop was triggered")
+	case <-time.After(2 * syncDebounceDuration):
+	}
+
+	c.triggerIPTablesSync()
+	select {
+	case <-syncCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("iptables were not synced after the sync loop was triggered")
+	}
+
+	cancel()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the sync loop did not stop after the context was cancelled")
+	}
 }

--- a/pkg/agent/util/iptables/iptables.go
+++ b/pkg/agent/util/iptables/iptables.go
@@ -118,6 +118,8 @@ type Interface interface {
 
 	ListRules(protocol Protocol, table string, chain string) (map[Protocol][]string, error)
 
+	ListChains(protocol Protocol, table string) (map[Protocol][]string, error)
+
 	Restore(data string, flush bool, useIPv6 bool) error
 
 	Save() ([]byte, error)
@@ -402,6 +404,23 @@ func (c *Client) Restore(data string, flush bool, useIPv6 bool) error {
 		return fmt.Errorf("error executing %s: %v", iptablesCmd, err)
 	}
 	return nil
+}
+
+// ListChains lists the names of the chains of the given table, for every matching protocol.
+func (c *Client) ListChains(protocol Protocol, table string) (map[Protocol][]string, error) {
+	allChains := make(map[Protocol][]string)
+	for p := range c.ipts {
+		ipt := c.ipts[p]
+		if !matchProtocol(ipt, protocol) {
+			continue
+		}
+		chains, err := ipt.ListChains(table)
+		if err != nil {
+			return nil, fmt.Errorf("error listing chains of table %s: %w", table, err)
+		}
+		allChains[p] = chains
+	}
+	return allChains, nil
 }
 
 // Save calls iptables-saves to dump chains and tables in iptables.

--- a/pkg/agent/util/iptables/testing/mock_iptables_linux.go
+++ b/pkg/agent/util/iptables/testing/mock_iptables_linux.go
@@ -154,6 +154,21 @@ func (mr *MockInterfaceMockRecorder) InsertRule(protocol, table, chain, ruleSpec
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertRule", reflect.TypeOf((*MockInterface)(nil).InsertRule), protocol, table, chain, ruleSpec)
 }
 
+// ListChains mocks base method.
+func (m *MockInterface) ListChains(protocol iptables.Protocol, table string) (map[iptables.Protocol][]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListChains", protocol, table)
+	ret0, _ := ret[0].(map[iptables.Protocol][]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListChains indicates an expected call of ListChains.
+func (mr *MockInterfaceMockRecorder) ListChains(protocol, table any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListChains", reflect.TypeOf((*MockInterface)(nil).ListChains), protocol, table)
+}
+
 // ListRules mocks base method.
 func (m *MockInterface) ListRules(protocol iptables.Protocol, table, chain string) (map[iptables.Protocol][]string, error) {
 	m.ctrl.T.Helper()

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -550,7 +550,25 @@ func TestIpTablesSync(t *testing.T) {
 		{Table: "filter", Cmd: "-A", Chain: "ANTREA-OUTPUT", RuleSpec: "-p tcp -m comment --comment \"Antrea: allow Agent APIServer reply packets\" -m tcp --sport 10350 -m conntrack --ctstate ESTABLISHED -j ACCEPT"},
 		{Table: "nat", Cmd: "-A", Chain: "ANTREA-POSTROUTING", RuleSpec: fmt.Sprintf("! -o antrea-gw0 -m comment --comment \"Antrea: SNAT Pod to external packets\" -m mark --mark %#x/0xff -j SNAT --to-source %s", mark, snatIP)},
 	}
-	// we delete some rules, start the sync goroutine, wait for sync operation to restore them.
+	assertRulesInstalled := func(c *assert.CollectT) {
+		for _, tc := range tcs {
+			saveCmd := fmt.Sprintf("iptables-save -t %s | grep -e '%s %s'", tc.Table, tc.Cmd, tc.Chain)
+			// #nosec G204: ignore in test code
+			actualData, err := exec.Command("bash", "-c", saveCmd).Output()
+			assert.NoError(c, err, "error executing iptables-save cmd")
+			contains := fmt.Sprintf("%s %s %s", tc.Cmd, tc.Chain, tc.RuleSpec)
+			assert.Contains(c, string(actualData), contains, "%s command's output did not contain rule: %s", saveCmd, contains)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	route.SyncInterval = 2 * time.Second
+	go routeClient.Run(ctx)
+	// The SNAT rule is applied by the sync loop, so it has to be there before the rules are removed.
+	assert.EventuallyWithT(t, assertRulesInstalled, 5*time.Second, 100*time.Millisecond, "iptables rules were not installed")
+
+	// we delete some rules, and wait for the sync operation to restore them.
 	for _, tc := range tcs {
 		delCmd := fmt.Sprintf("iptables -t %s -D %s  %s", tc.Table, tc.Chain, tc.RuleSpec)
 		// #nosec G204: ignore in test code
@@ -558,19 +576,7 @@ func TestIpTablesSync(t *testing.T) {
 		assert.NoError(t, err, "error executing iptables cmd: %s", delCmd)
 		assert.Equal(t, "", string(actualData), "failed to remove iptables rule for %v", tc)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	route.SyncInterval = 2 * time.Second
-	go routeClient.Run(ctx)
-	time.Sleep(route.SyncInterval) // wait for one iteration of sync operation.
-	for _, tc := range tcs {
-		saveCmd := fmt.Sprintf("iptables-save -t %s | grep -e '%s %s'", tc.Table, tc.Cmd, tc.Chain)
-		// #nosec G204: ignore in test code
-		actualData, err := exec.Command("bash", "-c", saveCmd).Output()
-		assert.NoError(t, err, "error executing iptables-save cmd")
-		contains := fmt.Sprintf("%s %s %s", tc.Cmd, tc.Chain, tc.RuleSpec)
-		assert.Contains(t, string(actualData), contains, "%s command's output did not contain rule: %s", saveCmd, contains)
-	}
+	assert.EventuallyWithT(t, assertRulesInstalled, 5*time.Second, 100*time.Millisecond, "iptables rules were not restored")
 }
 
 func TestNFTablesSync(t *testing.T) {
@@ -638,6 +644,11 @@ func TestAddAndDeleteSNATRule(t *testing.T) {
 	gwLink := createDummyGW(t)
 	defer netlink.LinkDel(gwLink)
 
+	// Shorten the period, so that the rule outlives several periodic syncs within the test.
+	originalSyncInterval := route.SyncInterval
+	route.SyncInterval = time.Second
+	defer func() { route.SyncInterval = originalSyncInterval }()
+
 	routeClient, err := newTestRouteClient(&config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap, IPv4Enabled: true}, routeClientOptions{})
 	require.NoError(t, err)
 
@@ -648,22 +659,39 @@ func TestAddAndDeleteSNATRule(t *testing.T) {
 	assert.NoError(t, err)
 	<-inited // Node network initialized
 
+	// The SNAT rules are applied by the sync loop, which is started by Run.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go routeClient.Run(ctx)
+
 	snatIP := net.ParseIP("1.1.1.1")
 	mark := uint32(1)
 	expectedRule := fmt.Sprintf("! -o antrea-gw0 -m comment --comment \"Antrea: SNAT Pod to external packets\" -m mark --mark %#x/0xff -j SNAT --to-source %s", mark, snatIP)
+	saveCmd := "iptables-save -t nat | grep ANTREA-POSTROUTING"
 
 	assert.NoError(t, routeClient.AddSNATRule(snatIP, mark))
-	saveCmd := "iptables-save -t nat | grep ANTREA-POSTROUTING"
-	// #nosec G204: ignore in test code
-	actualData, err := exec.Command("bash", "-c", saveCmd).Output()
-	assert.NoError(t, err, "error executing iptables-save cmd")
-	assert.Contains(t, string(actualData), expectedRule)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		// #nosec G204: ignore in test code
+		actualData, err := exec.Command("bash", "-c", saveCmd).Output()
+		assert.NoError(c, err, "error executing iptables-save cmd")
+		assert.Contains(c, string(actualData), expectedRule)
+	}, 5*time.Second, 100*time.Millisecond, "SNAT rule was not installed")
+
+	// The periodic sync rewrites the chain from the caches. That is what used to wipe a rule installed
+	// between its snapshot of the caches and its restore, so the rule has to survive several periods.
+	assert.Never(t, func() bool {
+		// #nosec G204: ignore in test code
+		actualData, err := exec.Command("bash", "-c", saveCmd).Output()
+		return err != nil || !strings.Contains(string(actualData), expectedRule)
+	}, 3*time.Second, 50*time.Millisecond, "SNAT rule was removed by a periodic sync")
 
 	assert.NoError(t, routeClient.DeleteSNATRule(mark))
-	// #nosec G204: ignore in test code
-	actualData, err = exec.Command("bash", "-c", saveCmd).Output()
-	assert.NoError(t, err, "error executing iptables-save cmd")
-	assert.NotContains(t, string(actualData), expectedRule)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		// #nosec G204: ignore in test code
+		actualData, err := exec.Command("bash", "-c", saveCmd).Output()
+		assert.NoError(c, err, "error executing iptables-save cmd")
+		assert.NotContains(c, string(actualData), expectedRule)
+	}, 5*time.Second, 100*time.Millisecond, "SNAT rule was not uninstalled")
 }
 
 func TestAddAndDeleteRoutes(t *testing.T) {

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -475,7 +475,6 @@ func TestIpTablesSync(t *testing.T) {
 
 	snatIP := net.ParseIP("1.1.1.1")
 	mark := uint32(1)
-	assert.NoError(t, routeClient.AddSNATRule(snatIP, mark))
 
 	tcs := []struct {
 		RuleSpec, Cmd, Table, Chain string
@@ -484,7 +483,27 @@ func TestIpTablesSync(t *testing.T) {
 		{Table: "filter", Cmd: "-A", Chain: "ANTREA-FORWARD", RuleSpec: "-i antrea-gw0 -m comment --comment \"Antrea: accept packets from local Pods\" -j ACCEPT"},
 		{Table: "nat", Cmd: "-A", Chain: "ANTREA-POSTROUTING", RuleSpec: fmt.Sprintf("! -o antrea-gw0 -m comment --comment \"Antrea: SNAT Pod to external packets\" -m mark --mark %#x/0xff -j SNAT --to-source %s", mark, snatIP)},
 	}
-	// we delete some rules, start the sync goroutine, wait for sync operation to restore them.
+	assertRulesInstalled := func(c *assert.CollectT) {
+		for _, tc := range tcs {
+			saveCmd := fmt.Sprintf("iptables-save -t %s | grep -e '%s %s'", tc.Table, tc.Cmd, tc.Chain)
+			// #nosec G204: ignore in test code
+			actualData, err := exec.Command("bash", "-c", saveCmd).Output()
+			assert.NoError(c, err, "error executing iptables-save cmd")
+			contains := fmt.Sprintf("%s %s %s", tc.Cmd, tc.Chain, tc.RuleSpec)
+			assert.Contains(c, string(actualData), contains, "%s command's output did not contain rule: %s", saveCmd, contains)
+		}
+	}
+
+	// The SNAT rule is applied by the sync loop, which is started by Run.
+	route.SyncInterval = 2 * time.Second
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go routeClient.Run(ctx)
+
+	assert.NoError(t, routeClient.AddSNATRule(snatIP, mark))
+	assert.EventuallyWithT(t, assertRulesInstalled, 5*time.Second, 100*time.Millisecond, "iptables rules were not installed")
+
+	// we delete some rules, and wait for the sync operation to restore them.
 	for _, tc := range tcs {
 		delCmd := fmt.Sprintf("iptables -t %s -D %s  %s", tc.Table, tc.Chain, tc.RuleSpec)
 		// #nosec G204: ignore in test code
@@ -492,19 +511,7 @@ func TestIpTablesSync(t *testing.T) {
 		assert.NoError(t, err, "error executing iptables cmd: %s", delCmd)
 		assert.Equal(t, "", string(actualData), "failed to remove iptables rule for %v", tc)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	route.SyncInterval = 2 * time.Second
-	go routeClient.Run(ctx)
-	time.Sleep(route.SyncInterval) // wait for one iteration of sync operation.
-	for _, tc := range tcs {
-		saveCmd := fmt.Sprintf("iptables-save -t %s | grep -e '%s %s'", tc.Table, tc.Cmd, tc.Chain)
-		// #nosec G204: ignore in test code
-		actualData, err := exec.Command("bash", "-c", saveCmd).Output()
-		assert.NoError(t, err, "error executing iptables-save cmd")
-		contains := fmt.Sprintf("%s %s %s", tc.Cmd, tc.Chain, tc.RuleSpec)
-		assert.Contains(t, string(actualData), contains, "%s command's output did not contain rule: %s", saveCmd, contains)
-	}
+	assert.EventuallyWithT(t, assertRulesInstalled, 5*time.Second, 100*time.Millisecond, "iptables rules were not restored")
 }
 
 func TestNFTablesSync(t *testing.T) {
@@ -582,22 +589,31 @@ func TestAddAndDeleteSNATRule(t *testing.T) {
 	assert.NoError(t, err)
 	<-inited // Node network initialized
 
+	// The SNAT rules are applied by the sync loop, which is started by Run.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go routeClient.Run(ctx)
+
 	snatIP := net.ParseIP("1.1.1.1")
 	mark := uint32(1)
 	expectedRule := fmt.Sprintf("! -o antrea-gw0 -m comment --comment \"Antrea: SNAT Pod to external packets\" -m mark --mark %#x/0xff -j SNAT --to-source %s", mark, snatIP)
+	saveCmd := "iptables-save -t nat | grep ANTREA-POSTROUTING"
+	getRules := func(c *assert.CollectT) string {
+		// #nosec G204: ignore in test code
+		actualData, err := exec.Command("bash", "-c", saveCmd).Output()
+		assert.NoError(c, err, "error executing iptables-save cmd")
+		return string(actualData)
+	}
 
 	assert.NoError(t, routeClient.AddSNATRule(snatIP, mark))
-	saveCmd := "iptables-save -t nat | grep ANTREA-POSTROUTING"
-	// #nosec G204: ignore in test code
-	actualData, err := exec.Command("bash", "-c", saveCmd).Output()
-	assert.NoError(t, err, "error executing iptables-save cmd")
-	assert.Contains(t, string(actualData), expectedRule)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Contains(c, getRules(c), expectedRule)
+	}, 5*time.Second, 100*time.Millisecond, "SNAT rule was not installed")
 
 	assert.NoError(t, routeClient.DeleteSNATRule(mark))
-	// #nosec G204: ignore in test code
-	actualData, err = exec.Command("bash", "-c", saveCmd).Output()
-	assert.NoError(t, err, "error executing iptables-save cmd")
-	assert.NotContains(t, string(actualData), expectedRule)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NotContains(c, getRules(c), expectedRule)
+	}, 5*time.Second, 100*time.Millisecond, "SNAT rule was not uninstalled")
 }
 
 func TestAddAndDeleteRoutes(t *testing.T) {


### PR DESCRIPTION
Fix: #8285

iptables rules were managed with two different mechanisms: most features
only updated their in-memory caches and waited for the 60s periodic sync
to apply them with iptables-restore, while Egress installed and removed
its SNAT rules directly with iptables -I / -D. The periodic sync rewrites
the whole state from the caches, so it could overwrite a SNAT rule
inserted after its snapshot of the caches was taken, leaving the traffic
unSNATed until the next sync, up to 60s later.

The iptables rules are now written by a single loop, fed by a queue which
a feature notifies once it has updated the caches, and which
syncNetworkConfig notifies on its period. Egress only updates the caches
and notifies the queue, which removes the race without having to
serialize its updates with the sync. AddSNATRule and DeleteSNATRule
become asynchronous, applied by the loop right after they return, and
snatRuleSpec is removed, as restoreIptablesData now builds those rules.

The queue holds a single copy of the notification, and one sent while a
sync runs is kept for the next, so a burst of updates costs at most a
sync for the first of them and another for the rest. Any feature updating
the caches has its rules applied right away instead of waiting for the
next period. A failed sync is requeued with an exponential backoff, as
the notification which caused it was consumed by the worker.

The two NodeNetworkPolicy calls keep writing to the datapath themselves,
as their callers rely on the rules being enforced when they return: a
rule dropping its reference to an ipset has to be applied before that
ipset is destroyed. They update the caches only once the datapath has
accepted the rules, and notify the queue after that, so that a sync
holding an older snapshot is followed by one which reads what they
cached.

syncNetworkConfig notifies the queue after syncing the ipsets, keeping
the existing ordering, as a rule referring to a missing ipset makes
iptables-restore roll its table back. It notifies with a key of its own,
which is what tells the loop that this is the period and not an update.

The loop also reclaims the NodeNetworkPolicy chains left behind in the
datapath, which nothing removed before: syncIPTables only rewrites the
chains the caches know about, so a chain deleted while a sync held an
older snapshot was recreated by that sync and stayed there until the
Agent restarted. Reclaiming lists the chains of the filter table, which
is why it only runs on the period, and deletes the ones which have been
missing from the caches in two consecutive runs, with one iptables-restore
per IP protocol which flushes them all before deleting any, as an orphan
keeps the rules it had and may jump to another. Deciding on a single
observation would risk deleting a chain which is about to be cached, as
the writers update the datapath and the caches one after the other. It
also runs when the feature is disabled, which is when it matters most:
the caches are then empty, so every chain of the feature is an orphan and
nothing else would remove it.

Signed-off-by: Hongliang Liu <hongliang.liu@broadcom.com>
