### PR TITLE
Bump Windows CI unit test runner to windows-2025

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,8 +63,8 @@ jobs:
   test-unit-windows:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
-    name: Unit test (windows-2022)
-    runs-on: [windows-2022]
+    name: Unit test (windows-2025)
+    runs-on: [windows-2025]
     steps:
       - name: Check-out code
         uses: actions/checkout@v7


### PR DESCRIPTION
windows-2022 was overdue for an upgrade. This also gives us a chance to see if it clears up a rare, flaky Go runtime crash (fatal error: fault / access violation, seen in pkg/agent/controller/bgp unit tests) that has been intermittently hitting the windows-2022 unit test job with go1.26.5.