### PR TITLE
Automated cherry pick of #8190: Recover Service group install after a timed-out bundle commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	antrea.io/libOpenflow v0.16.0
-	antrea.io/ofnet v0.15.0
+	antrea.io/ofnet v0.15.1
 	github.com/ClickHouse/clickhouse-go/v2 v2.6.1
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Mellanox/sriovnet v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 antrea.io/libOpenflow v0.16.0 h1:8YDpJQsg6SyCAURQOaGL2UVvNdSyjGiTPfrgB7bo/88=
 antrea.io/libOpenflow v0.16.0/go.mod h1:NSO1euB06IQBcK+cxGI5z6nrB2Uz9lQ153iSUe4PRYg=
-antrea.io/ofnet v0.15.0 h1:VQqw77JXj7k+zSQ+jSp4qBz+H0iun+I+JNfaGVKH/DA=
-antrea.io/ofnet v0.15.0/go.mod h1:bBQvoJMUDrrWSOSC/sqBHooffSAJpjkR5f0JiXsaVbA=
+antrea.io/ofnet v0.15.1 h1:Rokg5q2rSjpKpB+BfgpCWiuWb2T//loOei2qu9xigW4=
+antrea.io/ofnet v0.15.1/go.mod h1:bBQvoJMUDrrWSOSC/sqBHooffSAJpjkR5f0JiXsaVbA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -15,9 +15,11 @@
 package openflow
 
 import (
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"net"
+	"sync"
 
 	"antrea.io/libOpenflow/openflow15"
 	"antrea.io/libOpenflow/protocol"
@@ -723,22 +725,54 @@ func (c *client) GetPodFlowKeys(interfaceName string) []string {
 	return c.getFlowKeysFromCache(c.featurePodConnectivity.podCachedFlows, interfaceName)
 }
 
+func (c *client) installGroup(cache *sync.Map, groupID binding.GroupIDType, group binding.Group) error {
+	entry := []binding.OFEntry{group}
+	_, installed := cache.Load(groupID)
+	if !installed {
+		if err := c.ofEntryOperations.AddOFEntries(entry); err != nil {
+			if errors.Is(err, ofctrl.ErrBundleCommitReplyTimeout) || errors.Is(err, ofctrl.ErrBundleCommitReplyCanceled) {
+				// A timed-out or canceled commit leaves the outcome unknown: OVS may have
+				// applied the bundle anyway. Delete the group so that its ID is reusable.
+				//
+				//   - The group is not added to the cache below, so nothing would ever
+				//     delete it, while the caller recycles the group ID. A group Add is not
+				//     idempotent, so the next Service given that ID would fail with
+				//     OFPGMFC_GROUP_EXISTS.
+				//   - Deleting a group that does not exist is a no-op on OVS, so the cleanup
+				//     is harmless if the bundle was in fact never applied.
+				//   - Any other error means the commit request was never sent, or that OVS
+				//     replied that it did not apply the bundle, so nothing was installed and
+				//     no cleanup is needed.
+				//   - The cleanup is best effort. If it fails because the connection to OVS
+				//     dropped, reconnection recovers instead: ReplayFlows calls initialize,
+				//     which runs DeleteGroupAll to wipe every group on the bridge and then
+				//     replays only the cached groups, so a group left behind here is removed.
+				//     The only remaining case is a timeout while the connection stays up,
+				//     which is cleared by the next reconnection or agent restart.
+				if errDelete := c.ofEntryOperations.DeleteOFEntries(entry); errDelete != nil {
+					klog.ErrorS(errDelete, "Failed to clean up group after failed commit", "groupID", groupID)
+				}
+			}
+			return err
+		}
+	} else {
+		if err := c.ofEntryOperations.ModifyOFEntries(entry); err != nil {
+			return err
+		}
+	}
+	// Update the cache only after a successful Add or Modify
+	cache.Store(groupID, group)
+	return nil
+}
+
 func (c *client) InstallServiceGroup(groupID binding.GroupIDType, withSessionAffinity bool, endpoints []proxy.Endpoint) error {
 	c.replayMutex.RLock()
 	defer c.replayMutex.RUnlock()
 
 	group := c.featureService.serviceEndpointGroup(groupID, withSessionAffinity, endpoints...)
-	_, installed := c.featureService.groupCache.Load(groupID)
-	if !installed {
-		if err := c.ofEntryOperations.AddOFEntries([]binding.OFEntry{group}); err != nil {
-			return fmt.Errorf("error when installing Service Endpoints Group %d: %w", groupID, err)
-		}
-	} else {
-		if err := c.ofEntryOperations.ModifyOFEntries([]binding.OFEntry{group}); err != nil {
-			return fmt.Errorf("error when modifying Service Endpoints Group %d: %w", groupID, err)
-		}
+	if err := c.installGroup(&c.featureService.groupCache, groupID, group); err != nil {
+		return fmt.Errorf("error when syncing Service Endpoints group %d: %w", groupID, err)
 	}
-	c.featureService.groupCache.Store(groupID, group)
 	return nil
 }
 
@@ -748,7 +782,7 @@ func (c *client) UninstallServiceGroup(groupID binding.GroupIDType) error {
 	gCache, ok := c.featureService.groupCache.Load(groupID)
 	if ok {
 		if err := c.ofEntryOperations.DeleteOFEntries([]binding.OFEntry{gCache.(binding.Group)}); err != nil {
-			return fmt.Errorf("error when deleting Openflow entries for Service Endpoints Group %d: %w", groupID, err)
+			return fmt.Errorf("error when deleting Openflow entries for Service Endpoints group %d: %w", groupID, err)
 		}
 		c.featureService.groupCache.Delete(groupID)
 	}
@@ -1566,17 +1600,9 @@ func (c *client) InstallMulticastGroup(groupID binding.GroupIDType, localReceive
 	}
 
 	group := c.featureMulticast.multicastReceiversGroup(groupID, nextTable, localReceivers, remoteNodeReceivers)
-	_, installed := c.featureMulticast.groupCache.Load(groupID)
-	if !installed {
-		if err := c.ofEntryOperations.AddOFEntries([]binding.OFEntry{group}); err != nil {
-			return fmt.Errorf("error when installing Multicast receiver Group %d: %w", groupID, err)
-		}
-	} else {
-		if err := c.ofEntryOperations.ModifyOFEntries([]binding.OFEntry{group}); err != nil {
-			return fmt.Errorf("error when modifying Multicast receiver Group %d: %w", groupID, err)
-		}
+	if err := c.installGroup(&c.featureMulticast.groupCache, groupID, group); err != nil {
+		return fmt.Errorf("error when syncing Multicast receiver Group %d: %w", groupID, err)
 	}
-	c.featureMulticast.groupCache.Store(groupID, group)
 	return nil
 }
 

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -1123,6 +1123,70 @@ func Test_client_InstallServiceGroup(t *testing.T) {
 	}
 }
 
+func Test_client_InstallServiceGroupFailure(t *testing.T) {
+	groupID := binding.GroupIDType(100)
+	endpoints := []proxy.Endpoint{
+		proxy.NewBaseEndpointInfo("10.10.0.100", "node1", "", 80, false, true, false, false, nil),
+	}
+	opError := ofctrl.ErrBundleCommitReplyTimeout
+	otherError := fmt.Errorf("some other error")
+
+	testCases := []struct {
+		name        string
+		installed   bool
+		addError    error
+		modifyError error
+		wantCached  bool
+		wantDeleted bool
+	}{
+		{
+			name:        "ADD times out, the group is deleted for cleanup",
+			addError:    opError,
+			wantCached:  false,
+			wantDeleted: true,
+		},
+		{
+			name:        "ADD fails with a real error, the group is not deleted",
+			addError:    otherError,
+			wantCached:  false,
+			wantDeleted: false,
+		},
+		{
+			name:        "MODIFY fails, the group is not deleted",
+			installed:   true,
+			modifyError: opError,
+			wantCached:  true,
+			wantDeleted: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			m := opstest.NewMockOFEntryOperations(ctrl)
+
+			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap)
+			defer resetPipelines()
+
+			if tc.installed {
+				// A successful install first, so the group is cached and the next install uses MODIFY.
+				m.EXPECT().AddOFEntries(gomock.Any()).Return(nil).Times(1)
+				require.NoError(t, fc.InstallServiceGroup(groupID, false, endpoints))
+				m.EXPECT().ModifyOFEntries(gomock.Any()).Return(tc.modifyError).Times(1)
+			} else {
+				m.EXPECT().AddOFEntries(gomock.Any()).Return(tc.addError).Times(1)
+				if tc.wantDeleted {
+					// The cleanup delete is best-effort; the code ignores its result, but logs it.
+					m.EXPECT().DeleteOFEntries(gomock.Any()).Return(nil).Times(1)
+				}
+			}
+
+			assert.Error(t, fc.InstallServiceGroup(groupID, false, endpoints))
+			_, ok := fc.featureService.groupCache.Load(groupID)
+			assert.Equal(t, tc.wantCached, ok)
+		})
+	}
+}
+
 func Test_client_InstallEndpointFlows(t *testing.T) {
 	ep1IPv4 := "10.10.0.100"
 	ep2IPv4 := "10.10.0.101"
@@ -2571,6 +2635,69 @@ func Test_client_InstallMulticastGroup(t *testing.T) {
 				_, ok = fc.featureMulticast.groupCache.Load(groupID)
 				require.True(t, ok)
 			}
+		})
+	}
+}
+
+func Test_client_InstallMulticastGroupFailure(t *testing.T) {
+	groupID := binding.GroupIDType(101)
+	localReceivers := []uint32{50, 100}
+	remoteNodeReceivers := []net.IP{net.ParseIP("192.168.77.101"), net.ParseIP("192.168.77.102")}
+	opError := ofctrl.ErrBundleCommitReplyTimeout
+	otherError := fmt.Errorf("some other error")
+
+	testCases := []struct {
+		name        string
+		installed   bool
+		addError    error
+		modifyError error
+		wantCached  bool
+		wantDeleted bool
+	}{
+		{
+			name:        "ADD times out, the group is deleted for cleanup",
+			addError:    opError,
+			wantCached:  false,
+			wantDeleted: true,
+		},
+		{
+			name:        "ADD fails with a real error, the group is not deleted",
+			addError:    otherError,
+			wantCached:  false,
+			wantDeleted: false,
+		},
+		{
+			name:        "MODIFY fails, the group is not deleted",
+			installed:   true,
+			modifyError: opError,
+			wantCached:  true,
+			wantDeleted: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			m := opstest.NewMockOFEntryOperations(ctrl)
+
+			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap, enableMulticast)
+			defer resetPipelines()
+
+			if tc.installed {
+				// A successful install first, so the group is cached and the next install uses MODIFY.
+				m.EXPECT().AddOFEntries(gomock.Any()).Return(nil).Times(1)
+				require.NoError(t, fc.InstallMulticastGroup(groupID, localReceivers, remoteNodeReceivers))
+				m.EXPECT().ModifyOFEntries(gomock.Any()).Return(tc.modifyError).Times(1)
+			} else {
+				m.EXPECT().AddOFEntries(gomock.Any()).Return(tc.addError).Times(1)
+				if tc.wantDeleted {
+					// The cleanup delete is best-effort; the code ignores its result, but logs it.
+					m.EXPECT().DeleteOFEntries(gomock.Any()).Return(nil).Times(1)
+				}
+			}
+
+			assert.Error(t, fc.InstallMulticastGroup(groupID, localReceivers, remoteNodeReceivers))
+			_, ok := fc.featureMulticast.groupCache.Load(groupID)
+			assert.Equal(t, tc.wantCached, ok)
 		})
 	}
 }

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -444,10 +444,14 @@ func TestBundleErrorWhenOVSRestart(t *testing.T) {
 	}()
 
 	expectedErrorMsgs := map[string]bool{
-		"bundle reply is timeout": true,
-		"bundle reply is canceled because of disconnection from the Switch": true,
-		"message is timeout": true,
-		"message is canceled because of disconnection from the Switch": true,
+		"bundle reply is timeout on open":                                             true,
+		"bundle reply is canceled because of disconnection from the Switch on open":   true,
+		"bundle reply is timeout on commit":                                           true,
+		"bundle reply is canceled because of disconnection from the Switch on commit": true,
+		"bundle reply is timeout on close":                                            true,
+		"bundle reply is canceled because of disconnection from the Switch on close":  true,
+		"message send timeout":                                                        true,
+		"message is canceled because of disconnection from the Switch":                true,
 	}
 
 	var failCount, successCount int


### PR DESCRIPTION
Cherry pick of #8190 on release-2.4.

#8190: Recover Service group install after a timed-out bundle commit

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.