### PR TITLE
Fix FlowAggregator IPFIX export missing proxySnat fields

### DIFF
--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -151,7 +151,7 @@ parameters.
 
 ### IPFIX Information Elements (IEs) in a Flow Record
 
-There are 34 IPFIX IEs in each exported flow record, which are defined in the
+There are 43 IPFIX IEs in each exported flow record, which are defined in the
 IANA-assigned IE registry, the Reverse IANA-assigned IE registry and the Antrea
 IE registry. The reverse IEs are used to provide bi-directional information about
 the flow. The Enterprise ID is 0 for IANA-assigned IE registry, 29305 for reverse
@@ -200,6 +200,9 @@ Flow Exporter are listed below:
 | destinationClusterIPv6         | 107      | ipv6Address | DEPRECATED in favor of destinationServiceIPv6.                                                                                                                              |
 | destinationServiceIPv4         | 168      | ipv4Address |                                                                                                                                                                             |
 | destinationServiceIPv6         | 169      | ipv6Address |                                                                                                                                                                             |
+| proxySnatIPv4                  | 170      | ipv4Address | The IPv4 SNAT address (e.g. by the Antrea gateway for an inter-Node "from external" flow). Unset (0.0.0.0) if the connection was not SNAT'd.                                |
+| proxySnatIPv6                  | 171      | ipv6Address | Same as proxySnatIPv4, for IPv6. Unset (::) if the connection was not SNAT'd.                                                                                               |
+| proxySnatPort                  | 172      | unsigned16  | The port the connection's source was translated to via SNAT, alongside proxySnatIPv4 / proxySnatIPv6. Unset (0) if the connection was not SNAT'd.                           |
 | destinationServicePort         | 108      | unsigned16  |                                                                                                                                                                             |
 | destinationServicePortName     | 109      | string      |                                                                                                                                                                             |
 | ingressNetworkPolicyName       | 110      | string      | Name of the ingress network policy applied to the destination Pod for this flow.                                                                                            |
@@ -214,6 +217,9 @@ Flow Exporter are listed below:
 | egressNetworkPolicyRuleAction  | 140      | unsigned8   |                                                                                                                                                                             |
 | tcpState                       | 136      | string      | The state of the TCP connection. The states are: LISTEN, SYN-SENT, SYN-RECEIVED, ESTABLISHED, FIN-WAIT-1, FIN-WAIT-2, CLOSE-WAIT, CLOSING, LAST-ACK, TIME-WAIT, and CLOSED. |
 | flowType                       | 137      | unsigned8   | 1 stands for Intra-Node. 2 stands for Inter-Node. 3 stands for To External. 4 stands for From External.                                                                     |
+| egressName                     | 153      | string      | Name of the Egress applied to this flow, if any.                                                                                                                            |
+| egressIP                       | 154      | string      | SNAT IP address used for the Egress applied to this flow.                                                                                                                   |
+| egressNodeName                 | 157      | string      | Name of the Node that currently holds the Egress IP for the Egress applied to this flow.                                                                                    |
 
 ### Supported Capabilities
 

--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -413,7 +413,9 @@ func (e *IPFIXExporter) makeIPFIXRecord(flow *flowpb.Flow, isIPv6 bool) ipfixent
 	if e.includeK8sUIDs {
 		setUUID(flow.K8S.EgressNodeUid)
 	}
+	next().SetUnsigned16Value(uint16(flow.ProxySnatPort))
 	setIPAddress(flow.K8S.DestinationClusterIp)
+	setIPAddress(flow.ProxySnatIp)
 	setIPAddress(flow.K8S.DestinationServiceIp)
 	if e.aggregatorMode == flowaggregatorconfig.AggregatorModeAggregate {
 		// The element order here must match prepareElements: per metric (octetDelta,

--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -414,8 +414,8 @@ func (e *IPFIXExporter) makeIPFIXRecord(flow *flowpb.Flow, isIPv6 bool) ipfixent
 		setUUID(flow.K8S.EgressNodeUid)
 	}
 	next().SetUnsigned16Value(uint16(flow.ProxySnatPort))
-	setIPAddress(flow.K8S.DestinationClusterIp)
 	setIPAddress(flow.ProxySnatIp)
+	setIPAddress(flow.K8S.DestinationClusterIp)
 	setIPAddress(flow.K8S.DestinationServiceIp)
 	if e.aggregatorMode == flowaggregatorconfig.AggregatorModeAggregate {
 		// The element order here must match prepareElements: per metric (octetDelta,

--- a/pkg/flowaggregator/exporter/ipfix_test.go
+++ b/pkg/flowaggregator/exporter/ipfix_test.go
@@ -454,8 +454,12 @@ func assertRecordMatchesFlow(t *testing.T, elems []ipfixentities.InfoElementWith
 			assert.Equal(t, want, e.GetStringValue(), name)
 		case "egressNodeName":
 			assert.Equal(t, record.K8S.EgressNodeName, e.GetStringValue(), name)
+		case "proxySnatPort":
+			assert.Equal(t, uint16(record.ProxySnatPort), e.GetUnsigned16Value(), name)
 		case "destinationClusterIPv4", "destinationClusterIPv6":
 			assert.Truef(t, wantIPOrZero(record.K8S.DestinationClusterIp).Equal(e.GetIPAddressValue()), "unexpected value for %s", name)
+		case "proxySnatIPv4", "proxySnatIPv6":
+			assert.Truef(t, wantIPOrZero(record.ProxySnatIp).Equal(e.GetIPAddressValue()), "unexpected value for %s", name)
 		case "destinationServiceIPv4", "destinationServiceIPv6":
 			assert.Truef(t, wantIPOrZero(record.K8S.DestinationServiceIp).Equal(e.GetIPAddressValue()), "unexpected value for %s", name)
 		case "octetDeltaCountFromSourceNode":

--- a/pkg/flowaggregator/infoelements/elements.go
+++ b/pkg/flowaggregator/infoelements/elements.go
@@ -175,11 +175,14 @@ func AntreaInfoElements(includeK8sNames, includeK8sUIDs, isIPv6 bool) []string {
 	if includeK8sUIDs {
 		ies = append(ies, "egressNodeUUID")
 	}
+	ies = append(ies, "proxySnatPort")
 	if isIPv6 {
 		ies = append(ies, "destinationClusterIPv6")
+		ies = append(ies, "proxySnatIPv6")
 		ies = append(ies, "destinationServiceIPv6")
 	} else {
 		ies = append(ies, "destinationClusterIPv4")
+		ies = append(ies, "proxySnatIPv4")
 		ies = append(ies, "destinationServiceIPv4")
 	}
 	return ies

--- a/pkg/flowaggregator/infoelements/elements.go
+++ b/pkg/flowaggregator/infoelements/elements.go
@@ -177,12 +177,12 @@ func AntreaInfoElements(includeK8sNames, includeK8sUIDs, isIPv6 bool) []string {
 	}
 	ies = append(ies, "proxySnatPort")
 	if isIPv6 {
-		ies = append(ies, "destinationClusterIPv6")
 		ies = append(ies, "proxySnatIPv6")
+		ies = append(ies, "destinationClusterIPv6")
 		ies = append(ies, "destinationServiceIPv6")
 	} else {
-		ies = append(ies, "destinationClusterIPv4")
 		ies = append(ies, "proxySnatIPv4")
+		ies = append(ies, "destinationClusterIPv4")
 		ies = append(ies, "destinationServiceIPv4")
 	}
 	return ies

--- a/pkg/flowaggregator/infoelements/elements_test.go
+++ b/pkg/flowaggregator/infoelements/elements_test.go
@@ -45,6 +45,7 @@ func TestAntreaInfoElements(t *testing.T) {
 		"egressName",
 		"egressIP",
 		"egressNodeName",
+		"proxySnatPort",
 	}
 
 	infoElementsK8sUIDs := []string{
@@ -67,6 +68,7 @@ func TestAntreaInfoElements(t *testing.T) {
 		"egressUUID",
 		"egressIP",
 		"egressNodeUUID",
+		"proxySnatPort",
 	}
 
 	infoElementsNoK8sIdentifiers := []string{
@@ -78,6 +80,7 @@ func TestAntreaInfoElements(t *testing.T) {
 		"tcpState",
 		"flowType",
 		"egressIP",
+		"proxySnatPort",
 	}
 
 	infoElementsK8sNamesAndUIDs := []string{
@@ -113,6 +116,7 @@ func TestAntreaInfoElements(t *testing.T) {
 		"egressIP",
 		"egressNodeName",
 		"egressNodeUUID",
+		"proxySnatPort",
 	}
 
 	testCases := []struct {
@@ -150,11 +154,11 @@ func TestAntreaInfoElements(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("ipv4", func(t *testing.T) {
-				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv4", "destinationServiceIPv4")
+				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv4", "proxySnatIPv4", "destinationServiceIPv4")
 				assert.Equal(t, expectedIEs, AntreaInfoElements(tc.includeK8sNames, tc.includeK8sUIDs, false))
 			})
 			t.Run("ipv6", func(t *testing.T) {
-				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv6", "destinationServiceIPv6")
+				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv6", "proxySnatIPv6", "destinationServiceIPv6")
 				assert.Equal(t, expectedIEs, AntreaInfoElements(tc.includeK8sNames, tc.includeK8sUIDs, true))
 			})
 		})

--- a/pkg/flowaggregator/infoelements/elements_test.go
+++ b/pkg/flowaggregator/infoelements/elements_test.go
@@ -154,11 +154,11 @@ func TestAntreaInfoElements(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("ipv4", func(t *testing.T) {
-				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv4", "proxySnatIPv4", "destinationServiceIPv4")
+				expectedIEs := append(tc.expectedIEs, "proxySnatIPv4", "destinationClusterIPv4", "destinationServiceIPv4")
 				assert.Equal(t, expectedIEs, AntreaInfoElements(tc.includeK8sNames, tc.includeK8sUIDs, false))
 			})
 			t.Run("ipv6", func(t *testing.T) {
-				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv6", "proxySnatIPv6", "destinationServiceIPv6")
+				expectedIEs := append(tc.expectedIEs, "proxySnatIPv6", "destinationClusterIPv6", "destinationServiceIPv6")
 				assert.Equal(t, expectedIEs, AntreaInfoElements(tc.includeK8sNames, tc.includeK8sUIDs, true))
 			})
 		})

--- a/pkg/flowaggregator/testing/util.go
+++ b/pkg/flowaggregator/testing/util.go
@@ -29,6 +29,7 @@ func PrepareTestFlowRecord(isIPv4 bool) *flowpb.Flow {
 	destination := netip.MustParseAddr("10.10.0.80")
 	destinationClusterIP := netip.MustParseAddr("10.10.1.10")
 	destinationServiceIP := netip.MustParseAddr("10.10.2.10")
+	proxySnatIP := netip.MustParseAddr("10.10.3.10")
 	egressIP := netip.MustParseAddr("172.18.0.1")
 	if !isIPv4 {
 		ipVersion = flowpb.IPVersion_IP_VERSION_6
@@ -36,6 +37,7 @@ func PrepareTestFlowRecord(isIPv4 bool) *flowpb.Flow {
 		destination = netip.MustParseAddr("2001:0:3238:dfe1:63::fefc")
 		destinationClusterIP = netip.MustParseAddr("2001:0:3238:dfe1:64::a")
 		destinationServiceIP = netip.MustParseAddr("2001:0:3238:dfe1:65::a")
+		proxySnatIP = netip.MustParseAddr("2001:0:3238:dfe1:66::a")
 		egressIP = netip.MustParseAddr("2001:0:3238:dfe1::ac12:1")
 	}
 	return &flowpb.Flow{
@@ -150,6 +152,8 @@ func PrepareTestFlowRecord(isIPv4 bool) *flowpb.Flow {
 			ReverseThroughputFromSource:      12381345,
 			ReverseThroughputFromDestination: 12381346,
 		},
+		ProxySnatIp:   proxySnatIP.AsSlice(),
+		ProxySnatPort: 34000,
 		FlowDirection: flowpb.FlowDirection_FLOW_DIRECTION_UNKNOWN,
 	}
 }

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -367,28 +367,9 @@ func TestFlowAggregatorProxyMode(t *testing.T) {
 		if v4Enabled {
 			t.Run("IPv4", func(t *testing.T) { testHelperProxyMode(t, data, false, k8sUIDsInsteadOfNames) })
 		}
+
 		if v6Enabled {
 			t.Run("IPv6", func(t *testing.T) { testHelperProxyMode(t, data, true, k8sUIDsInsteadOfNames) })
-		}
-
-		// ExternalToPodFlows exercises the proxySnat and destinationServiceIP IEs specifically. In
-		// Proxy mode, records are never merged across Nodes; most K8s fields missing from a single
-		// Node's record are instead backfilled independently via live IP-based lookups (see
-		// fillK8sMetadata). proxySnat/destinationServiceIP have no such lookup: they only exist
-		// because the exporting agent captured them from its own conntrack observation, so the
-		// FlowAggregator must pass them through unchanged, or an external collector loses the only
-		// signal that could let it correlate the two Node-local legs of an inter-Node "from
-		// external" flow itself. This is orthogonal to the collector TLS setup that the other
-		// subtests vary, so it only needs to run once (plaintext, names instead of UIDs).
-		if !tls && !k8sUIDsInsteadOfNames {
-			t.Run("ExternalToPodFlows", func(t *testing.T) {
-				if v4Enabled {
-					t.Run("IPv4", func(t *testing.T) { testExternalToPodFlows(t, data, false, true) })
-				}
-				if v6Enabled {
-					t.Run("IPv6", func(t *testing.T) { testExternalToPodFlows(t, data, true, true) })
-				}
-			})
 		}
 	}
 
@@ -938,7 +919,7 @@ func testHelper(t *testing.T, data *TestData, isIPv6 bool) {
 
 	// ExternalToPod flows tests the case where connections are made to pods from outside the cluster and their flow information is exported
 	// while maintaining the original source IP.
-	t.Run("ExternalToPodFlows", func(t *testing.T) { testExternalToPodFlows(t, data, isIPv6, false) })
+	t.Run("ExternalToPodFlows", func(t *testing.T) { testExternalToPodFlows(t, data, isIPv6) })
 }
 
 func checkAntctlGetFlowRecordsJson(t *testing.T, data *TestData, podName string, podAIPs, podBIPs *PodIPs, isIPv6 bool) {
@@ -2175,11 +2156,7 @@ func createNPLConnection(t *testing.T, data *TestData, nodeIndex int, nodeIP str
 	return srcIP, sourcePort
 }
 
-// testExternalToPodFlows verifies the flow records exported for connections that reach a Pod from
-// outside the cluster. proxyMode selects the FlowAggregator mode the cluster is running in: in
-// Proxy mode each Node's record is exported as-is, without the cross-Node merge that Aggregate mode
-// performs, which changes what a single record can be expected to carry (see below).
-func testExternalToPodFlows(t *testing.T, data *TestData, isIPv6 bool, proxyMode bool) {
+func testExternalToPodFlows(t *testing.T, data *TestData, isIPv6 bool) {
 	destinationNodeIndex := 1
 	nodeName := nodeName(destinationNodeIndex)
 	nginxPodName, nginxIP, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "external-to-pod-flows", nodeName, data.testNamespace, false)
@@ -2215,22 +2192,11 @@ func testExternalToPodFlows(t *testing.T, data *TestData, isIPv6 bool, proxyMode
 			srcPortFilter := "sourceTransportPort: " + sourcePort
 			records := getCollectorOutput(t, sourceIP, dstIP, srcPortFilter, false, false, isIPv6, data, "", getCollectorOutputDefaultTimeout)
 			assert.NotEmpty(t, records, "Expected flows from ipfix collector to include source IP %s and destination ip %s", sourceIP, dstIP)
-			// The records matched above are the ones whose source is the external client, i.e.
-			// those exported by the Node the connection entered through. That Node only knows
-			// the destination Pod when the Pod runs on it: otherwise the Pod is remote and the
-			// destination Pod fields are empty. Aggregate mode fills them in by merging this
-			// record with the destination Node's record (keyed on the proxySnat address/port),
-			// but Proxy mode exports each Node's record unmerged, and proxyRecord only calls
-			// fillK8sMetadata for INTER_NODE flows, not FROM_EXTERNAL ones. So expect the
-			// destination Pod name only in Aggregate mode or on the destination Node.
-			expectDestinationPod := !proxyMode || tc.node == destinationNodeIndex
 			for _, record := range records {
 				assert := assert.New(t)
-				if expectDestinationPod {
-					assert.Contains(record, nginxPodName, "Record does not have Destination Pod name")
-				}
-				assert.Contains(record, nodePortService, "Record does not have service information")
-				assert.Contains(record, strconv.Itoa(int(containerPort)), "Record does not have the service port")
+				assert.Contains(record, nginxPodName, "Aggregated Record does not have Destination Pod name")
+				assert.Contains(record, nodePortService, "Aggregated Record does not have service information")
+				assert.Contains(record, strconv.Itoa(int(containerPort)), "Aggregated Record does not have the service port")
 				assertIPFIXRecordProxySnatSet(t, record, isIPv6)
 			}
 		})

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -367,9 +367,28 @@ func TestFlowAggregatorProxyMode(t *testing.T) {
 		if v4Enabled {
 			t.Run("IPv4", func(t *testing.T) { testHelperProxyMode(t, data, false, k8sUIDsInsteadOfNames) })
 		}
-
 		if v6Enabled {
 			t.Run("IPv6", func(t *testing.T) { testHelperProxyMode(t, data, true, k8sUIDsInsteadOfNames) })
+		}
+
+		// ExternalToPodFlows exercises the proxySnat and destinationServiceIP IEs specifically. In
+		// Proxy mode, records are never merged across Nodes; most K8s fields missing from a single
+		// Node's record are instead backfilled independently via live IP-based lookups (see
+		// fillK8sMetadata). proxySnat/destinationServiceIP have no such lookup: they only exist
+		// because the exporting agent captured them from its own conntrack observation, so the
+		// FlowAggregator must pass them through unchanged, or an external collector loses the only
+		// signal that could let it correlate the two Node-local legs of an inter-Node "from
+		// external" flow itself. This is orthogonal to the collector TLS setup that the other
+		// subtests vary, so it only needs to run once (plaintext, names instead of UIDs).
+		if !tls && !k8sUIDsInsteadOfNames {
+			t.Run("ExternalToPodFlows", func(t *testing.T) {
+				if v4Enabled {
+					t.Run("IPv4", func(t *testing.T) { testExternalToPodFlows(t, data, false, true) })
+				}
+				if v6Enabled {
+					t.Run("IPv6", func(t *testing.T) { testExternalToPodFlows(t, data, true, true) })
+				}
+			})
 		}
 	}
 
@@ -919,7 +938,7 @@ func testHelper(t *testing.T, data *TestData, isIPv6 bool) {
 
 	// ExternalToPod flows tests the case where connections are made to pods from outside the cluster and their flow information is exported
 	// while maintaining the original source IP.
-	t.Run("ExternalToPodFlows", func(t *testing.T) { testExternalToPodFlows(t, data, isIPv6) })
+	t.Run("ExternalToPodFlows", func(t *testing.T) { testExternalToPodFlows(t, data, isIPv6, false) })
 }
 
 func checkAntctlGetFlowRecordsJson(t *testing.T, data *TestData, podName string, podAIPs, podBIPs *PodIPs, isIPv6 bool) {
@@ -1454,22 +1473,43 @@ func getUint64FieldFromRecord(t require.TestingT, record string, field string) u
 	return 0
 }
 
+// ipfixRecordFieldValue returns the value of the named field in the IPFIX collector's text
+// representation of a record, and whether the field was present at all. Lines look like
+// "    proxySnatIPv6: fd00:10:244::1 ".
+func ipfixRecordFieldValue(record, field string) (string, bool) {
+	for _, line := range strings.Split(record, "\n") {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(line), field+":"); ok {
+			return strings.TrimSpace(v), true
+		}
+	}
+	return "", false
+}
+
+// proxySnatIPField returns the name of the proxy SNAT address IE for the given IP family, along
+// with the unspecified address it is set to when no SNAT was applied. Note that these values must
+// be compared for equality rather than as substrings: a *set* IPv6 address legitimately contains
+// "::" when it is written with zero compression (e.g. "fd00:10:244::1").
+func proxySnatIPField(isIPv6 bool) (string, string) {
+	if isIPv6 {
+		return "proxySnatIPv6", "::"
+	}
+	return "proxySnatIPv4", "0.0.0.0"
+}
+
 // assertIPFIXRecordProxySnatUnset checks IPFIX collector text for proxy SNAT info elements. For
 // NodePort traffic with externalTrafficPolicy Local hitting a local endpoint, conntrack is
 // symmetric so the agent should not export a non-zero proxy SNAT (see NetlinkFlowToAntreaConnection
 // and correlateExternal).
-func assertIPFIXRecordProxySnatUnset(t *testing.T, record string) {
+func assertIPFIXRecordProxySnatUnset(t *testing.T, record string, isIPv6 bool) {
 	t.Helper()
-	for _, line := range strings.Split(record, "\n") {
-		s := strings.TrimSpace(line)
-		switch {
-		case strings.HasPrefix(s, "proxySnatIPv4:"):
-			assert.Contains(t, s, "0.0.0.0", "proxySnatIPv4 should be unset for symmetric/local-endpoint flows, line: %s", line)
-		case strings.HasPrefix(s, "proxySnatIPv6:"):
-			assert.Contains(t, s, "::", "proxySnatIPv6 should be unset (::), line: %s", line)
-		case strings.HasPrefix(s, "proxySnatPort:"):
-			assert.Regexp(t, `proxySnatPort:\s*0\b`, s, "proxySnatPort should be 0, line: %s", line)
-		}
+	field, unspecified := proxySnatIPField(isIPv6)
+	// Assert presence as well as value: if the IE ever drops out of the FlowAggregator template
+	// again, these checks would otherwise silently pass without ever comparing anything.
+	if v, ok := ipfixRecordFieldValue(record, field); assert.Truef(t, ok, "record has no %s field, record: %s", field, record) {
+		assert.Equalf(t, unspecified, v, "%s should be unset for symmetric/local-endpoint flows, record: %s", field, record)
+	}
+	if v, ok := ipfixRecordFieldValue(record, "proxySnatPort"); assert.Truef(t, ok, "record has no proxySnatPort field, record: %s", record) {
+		assert.Equalf(t, "0", v, "proxySnatPort should be 0 for symmetric/local-endpoint flows, record: %s", record)
 	}
 }
 
@@ -1478,16 +1518,12 @@ func assertIPFIXRecordProxySnatUnset(t *testing.T, record string) {
 // SNAT so these fields should be populated on the exported record.
 func assertIPFIXRecordProxySnatSet(t *testing.T, record string, isIPv6 bool) {
 	t.Helper()
-	for _, line := range strings.Split(record, "\n") {
-		s := strings.TrimSpace(line)
-		switch {
-		case !isIPv6 && strings.HasPrefix(s, "proxySnatIPv4:"):
-			assert.NotContains(t, s, "0.0.0.0", "proxySnatIPv4 should be set for SNAT flows, line: %s", line)
-		case isIPv6 && strings.HasPrefix(s, "proxySnatIPv6:"):
-			assert.NotContains(t, s, "::", "proxySnatIPv6 should be set for SNAT flows, line: %s", line)
-		case strings.HasPrefix(s, "proxySnatPort:"):
-			assert.NotRegexp(t, `proxySnatPort:\s*0\b`, s, "proxySnatPort should be non-zero for SNAT flows, line: %s", line)
-		}
+	field, unspecified := proxySnatIPField(isIPv6)
+	if v, ok := ipfixRecordFieldValue(record, field); assert.Truef(t, ok, "record has no %s field, record: %s", field, record) {
+		assert.NotEqualf(t, unspecified, v, "%s should be set for SNAT flows, record: %s", field, record)
+	}
+	if v, ok := ipfixRecordFieldValue(record, "proxySnatPort"); assert.Truef(t, ok, "record has no proxySnatPort field, record: %s", record) {
+		assert.NotEqualf(t, "0", v, "proxySnatPort should be non-zero for SNAT flows, record: %s", record)
 	}
 }
 
@@ -2139,7 +2175,11 @@ func createNPLConnection(t *testing.T, data *TestData, nodeIndex int, nodeIP str
 	return srcIP, sourcePort
 }
 
-func testExternalToPodFlows(t *testing.T, data *TestData, isIPv6 bool) {
+// testExternalToPodFlows verifies the flow records exported for connections that reach a Pod from
+// outside the cluster. proxyMode selects the FlowAggregator mode the cluster is running in: in
+// Proxy mode each Node's record is exported as-is, without the cross-Node merge that Aggregate mode
+// performs, which changes what a single record can be expected to carry (see below).
+func testExternalToPodFlows(t *testing.T, data *TestData, isIPv6 bool, proxyMode bool) {
 	destinationNodeIndex := 1
 	nodeName := nodeName(destinationNodeIndex)
 	nginxPodName, nginxIP, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "external-to-pod-flows", nodeName, data.testNamespace, false)
@@ -2175,11 +2215,22 @@ func testExternalToPodFlows(t *testing.T, data *TestData, isIPv6 bool) {
 			srcPortFilter := "sourceTransportPort: " + sourcePort
 			records := getCollectorOutput(t, sourceIP, dstIP, srcPortFilter, false, false, isIPv6, data, "", getCollectorOutputDefaultTimeout)
 			assert.NotEmpty(t, records, "Expected flows from ipfix collector to include source IP %s and destination ip %s", sourceIP, dstIP)
+			// The records matched above are the ones whose source is the external client, i.e.
+			// those exported by the Node the connection entered through. That Node only knows
+			// the destination Pod when the Pod runs on it: otherwise the Pod is remote and the
+			// destination Pod fields are empty. Aggregate mode fills them in by merging this
+			// record with the destination Node's record (keyed on the proxySnat address/port),
+			// but Proxy mode exports each Node's record unmerged, and proxyRecord only calls
+			// fillK8sMetadata for INTER_NODE flows, not FROM_EXTERNAL ones. So expect the
+			// destination Pod name only in Aggregate mode or on the destination Node.
+			expectDestinationPod := !proxyMode || tc.node == destinationNodeIndex
 			for _, record := range records {
 				assert := assert.New(t)
-				assert.Contains(record, nginxPodName, "Aggregated Record does not have Destination Pod name")
-				assert.Contains(record, nodePortService, "Aggregated Record does not have service information")
-				assert.Contains(record, strconv.Itoa(int(containerPort)), "Aggregated Record does not have the service port")
+				if expectDestinationPod {
+					assert.Contains(record, nginxPodName, "Record does not have Destination Pod name")
+				}
+				assert.Contains(record, nodePortService, "Record does not have service information")
+				assert.Contains(record, strconv.Itoa(int(containerPort)), "Record does not have the service port")
 				assertIPFIXRecordProxySnatSet(t, record, isIPv6)
 			}
 		})
@@ -2204,7 +2255,7 @@ func testExternalToPodFlows(t *testing.T, data *TestData, isIPv6 bool) {
 		for _, record := range records {
 			assert.Contains(t, record, nginxPodName, "Record should include destination Pod name")
 			assert.Contains(t, record, svcLocalName, "Record should include Service name for ExternalTrafficPolicy Local flow")
-			assertIPFIXRecordProxySnatUnset(t, record)
+			assertIPFIXRecordProxySnatUnset(t, record, isIPv6)
 		}
 	})
 
@@ -2272,7 +2323,7 @@ func testExternalToPodFlows(t *testing.T, data *TestData, isIPv6 bool) {
 			assert.Contains(t, record, nplSvcName, "Record should include the NPL-backed Service name in DestinationServicePortName")
 			assert.Contains(t, record, wantDstServiceIPField, "Record should include destinationServiceIP as the NPL node IP")
 			assert.Contains(t, record, fmt.Sprintf("destinationServicePort: %d", nplNodePort), "Record should include destinationServicePort as the NPL node port")
-			assertIPFIXRecordProxySnatUnset(t, record)
+			assertIPFIXRecordProxySnatUnset(t, record, isIPv6)
 		}
 	})
 }


### PR DESCRIPTION
This PR is based on #8228.

proxySnatPort/proxySnatIPv4/proxySnatIPv6 are exported for inter-Node "from external" flows, and the FlowAggregator's collector already decodes them into the internal Flow message, but they were never added to the FlowAggregator's own outgoing IPFIX template.

Add the three IEs to the template and value-writer, in the same relative order the agent uses. Added UT coverage for the template and value-writer changes.
