### PR TITLE
Automated cherry pick of #8185: Fix assert object usage in secondary network e2e test (#8185)

### DIFF
--- a/test/e2e-secondary-network/secondary_network_test.go
+++ b/test/e2e-secondary-network/secondary_network_test.go
@@ -94,6 +94,7 @@ func (data *testData) formAnnotationStringOfPod(pod *testPodInfo) string {
 			annotationString = annotationString + ", " + podNetworkSpec
 		}
 	}
+
 	annotationString += "]"
 	return annotationString
 }
@@ -161,7 +162,7 @@ func (data *testData) assertPodNetworkStatus(t *testing.T, clientset *kubernetes
 			}
 			if secondaryNetworkList == nil {
 				_, ok := podItem.Annotations[nadv1.NetworkStatusAnnot]
-				assert.False(t, ok, "Pod network status annotation should be deleted")
+				assert.False(collect, ok, "Pod network status annotation should be deleted")
 				return
 			}
 
@@ -180,9 +181,9 @@ func (data *testData) assertPodNetworkStatus(t *testing.T, clientset *kubernetes
 			var secondaryNetworkStatus []nadv1.NetworkStatus
 			for i, network := range networkStatus {
 				if network.Interface == "eth0" {
-					assert.Equal(t, macMap[network.Interface], network.Mac, "The primary network status `Mac` is not as expected")
-					assert.Equal(t, cniserver.AntreaCNIType, network.Name, "The primary network status `Name` is not as expected")
-					assert.Equal(t, true, network.Default, "The primary network status `Default` is not as expected")
+					assert.Equal(collect, macMap[network.Interface], network.Mac, "The primary network status `Mac` is not as expected")
+					assert.Equal(collect, cniserver.AntreaCNIType, network.Name, "The primary network status `Name` is not as expected")
+					assert.Equal(collect, true, network.Default, "The primary network status `Default` is not as expected")
 				} else {
 					secondaryNetworkStatus = append(secondaryNetworkStatus, networkStatus[i])
 				}


### PR DESCRIPTION
Cherry pick of #8185 on release-2.6.

#8185: Fix assert object usage in secondary network e2e test (#8185)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.