### PR TITLE
Tidy up CI test scripts

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -36,9 +36,6 @@ DEBUG=false
 USE_SYSTEM_GO=false
 GOLANG_RELEASE_DIR=${WORKDIR}/golang-releases
 
-multicluster_kubeconfigs=($EAST_CLUSTER_CONFIG $LEADER_CLUSTER_CONFIG $WEST_CLUSTER_CONFIG)
-membercluster_kubeconfigs=($EAST_CLUSTER_CONFIG $WEST_CLUSTER_CONFIG)
-
 CLEAN_STALE_IMAGES="docker system prune --force --all --filter until=4h"
 PRINT_DOCKER_STATUS="docker system df -v"
 
@@ -183,7 +180,7 @@ function clean_multicluster {
         if [[ $DEBUG != "true" ]]; then
             echo "====== Cleanup Kind clusters ======"
             for name in ${CLUSTER_NAMES[*]}; do
-                ./ci/kind/kind-setup.sh destroy ${name}
+                $WORKSPACE/ci/kind/kind-setup.sh destroy ${name}
             done
         fi
     else
@@ -299,7 +296,7 @@ EOF
 function deliver_antrea_multicluster {
     echo "====== Building Antrea for the Following Commit ======"
 
-    git show --numstat
+    git --no-pager show --numstat
     make clean
 
     # Ensure that files in the Docker context have the correct permissions, or Docker caching cannot

--- a/ci/jenkins/test-rancher.sh
+++ b/ci/jenkins/test-rancher.sh
@@ -135,7 +135,7 @@ function deliver_antrea {
     export GOCACHE="${WORKSPACE}/../gocache"
     export PATH=${GOROOT}/bin:$PATH
 
-    git show --numstat
+    git --no-pager show --numstat
     make clean
     ${CLEAN_STALE_IMAGES}
     check_and_upgrade_golang

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -347,7 +347,7 @@ function run_codecov { (set -e
 
 function deliver_antrea {
     echo "====== Building Antrea for the Following Commit ======"
-    git show --numstat
+    git --no-pager show --numstat
 
     export GO111MODULE=on
     export GOPATH=$WORKDIR/go

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -351,7 +351,7 @@ function prepare_env {
     export GOCACHE=${WORKSPACE}/../gocache
     export PATH=${GOROOT}/bin:$PATH
 
-    git show --numstat
+    git --no-pager show --numstat
     make clean
 }
 
@@ -529,7 +529,7 @@ function deliver_antrea {
     export GOCACHE="${WORKSPACE}/../gocache"
     export PATH=${GOROOT}/bin:$PATH
 
-    git show --numstat
+    git --no-pager show --numstat
     make clean
     ${CLEAN_STALE_IMAGES}
     ${PRINT_DOCKER_STATUS}

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -183,7 +183,7 @@ function setup_aks() {
 
 function deliver_antrea_to_aks() {
     echo "====== Building Antrea for the Following Commit ======"
-    git show --numstat
+    git --no-pager show --numstat
 
     export GO111MODULE=on
     export GOROOT=/usr/local/go

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -253,7 +253,7 @@ function setup_eks() {
 
 function deliver_antrea_to_eks() {
     echo "====== Building Antrea for the Following Commit ======"
-    git show --numstat
+    git --no-pager show --numstat
 
     export GO111MODULE=on
     export GOROOT=/usr/local/go

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -238,7 +238,7 @@ function setup_gke() {
 
 function deliver_antrea_to_gke() {
     echo "====== Building Antrea for the Following Commit ======"
-    git show --numstat
+    git --no-pager show --numstat
 
     export GO111MODULE=on
     export GOROOT=/usr/local/go


### PR DESCRIPTION
Disable paging when printing commit details so CI jobs cannot block on interactive output. Use the workspace path for multicluster cleanup and remove unused kubeconfig arrays.