### PR TITLE
Automated cherry pick of #8211: Return the error when adding messages to a bundle fails

### DIFF
--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -617,7 +617,7 @@ func (b *OFBridge) AddOFEntriesInBundle(addEntries []OFEntry, modEntries []OFEnt
 		groupSet, flowSet,
 	} {
 		if err := addMessage(entries); err != nil {
-			return nil
+			return err
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #8211 on release-2.5.

#8211: Return the error when adding messages to a bundle fails

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.