### PR TITLE
Automated cherry pick of #8240: Fix host-local IPAM GC releasing in-use Pod IPs (#8240)

### DIFF
--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -74,6 +74,9 @@ var (
 	// Note, using a variable rather than constant for retryInterval because we may use a shorter time in the
 	// test code.
 	retryInterval = 5 * time.Second
+	// garbageCollectContainerIPs is declared as a variable so that it can be overridden by the
+	// test code.
+	garbageCollectContainerIPs = ipam.GarbageCollectContainerIPs
 )
 
 type podConfigurator struct {
@@ -443,8 +446,23 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 	// desiredPods is the set of Pods that should be present, based on the
 	// current list of Pods got from the Kubernetes API.
 	desiredPods := sets.New[string]()
-	// desiredPodIPs is the set of IPs allocated to desiredPods.
-	desiredPodIPs := sets.New[string]()
+	// ipsInUse is the set of IPs which must not be released by IPAM garbage collection: the union
+	// of the IPs reported in the status of the Pods scheduled to this Node and the IPs assigned to
+	// the Pod interfaces which are not deleted as part of reconciliation.
+	//
+	// Pod IPs are reported to the K8s API asynchronously by kubelet, *after* the CNI ADD has returned,
+	// so an agent restart in that window yields a running Pod with an empty Status.PodIPs even though
+	// its IP is already reserved by host-local. The interface store is restored from OVSDB and does not
+	// have this delay, so including it guarantees that we never release an IP claimed by a live local
+	// Pod interface, which host-local could then assign to a second Pod.
+	//
+	// The interface store only adds reasons to keep an IP: candidate IPs still come exclusively from the
+	// host-local data (one file per allocated IP), so an IP which is in neither the Pod statuses nor the
+	// interface store - e.g. because of an Antrea bug - is still released. Erring on the side of keeping
+	// an IP is the right trade-off, as an IP kept while no longer in use is reclaimed by a later CNI DEL
+	// or agent restart, while an IP released while in-use causes 2 Pods to share an IP until an operator
+	// intervenes.
+	ipsInUse := sets.New[string]()
 	// knownInterfaces is the list of interfaces currently in the local cache.
 	knownInterfaces := pc.ifaceStore.GetInterfacesByType(interfacestore.ContainerInterface)
 
@@ -453,7 +471,7 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 	for _, pod := range pods {
 		desiredPods.Insert(k8s.NamespacedName(pod.Namespace, pod.Name))
 		for _, podIP := range pod.Status.PodIPs {
-			desiredPodIPs.Insert(podIP.IP)
+			ipsInUse.Insert(podIP.IP)
 		}
 	}
 
@@ -462,6 +480,20 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 		namespace := containerConfig.PodNamespace
 		name := containerConfig.PodName
 		namespacedName := k8s.NamespacedName(namespace, name)
+
+		// retainIPs adds the IPs assigned to the interface to ipsInUse, so that they are not
+		// released by IPAM garbage collection. We log these IPs at the Info level, along with
+		// the provided reason, as it is useful information when troubleshooting IPAM issues.
+		retainIPs := func(reason string) {
+			for _, ip := range containerConfig.IPs {
+				ipStr := ip.String()
+				if ipsInUse.Has(ipStr) {
+					continue
+				}
+				klog.InfoS("Excluding IP from IPAM garbage collection", "reason", reason, "IP", ipStr, "Pod", klog.KRef(namespace, name), "container", containerConfig.ContainerID)
+				ipsInUse.Insert(ipStr)
+			}
+		}
 
 		// Find the OVS ports corresponding to Pods which no longer exist. This includes the case that the Pod using the
 		// Namespaced name constructed from OVSDB does not exist in kube-apiserver, and the case that a Pod with the
@@ -472,9 +504,19 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 			klog.V(4).InfoS("Deleting interface", "Pod", klog.KRef(namespace, name), "iface", containerConfig.InterfaceName)
 			if err := pc.removeInterfaces(containerConfig.ContainerID); err != nil {
 				klog.ErrorS(err, "Failed to delete interface", "Pod", klog.KRef(namespace, name), "iface", containerConfig.InterfaceName)
+				// The OVS port may still be present, so we conservatively choose not to
+				// reclaim the IPs assigned to the interface. They will be reclaimed during
+				// a future reconciliation, once the interface is no longer in the
+				// interface store.
+				retainIPs("Interface could not be deleted")
 			}
 			continue
 		}
+
+		// The interface matches an existing Pod, hence the IPs assigned to it are in use and must be
+		// preserved by IPAM garbage collection. An IP missing from the Pod status is not necessarily
+		// an error: this is expected for a Pod whose IP has not been reported to the K8s API yet.
+		retainIPs("IP is assigned to a local Pod interface but is missing from the Pod status")
 
 		// This should only happen on Windows Nodes because if this condition (OFPort is -1) is satisfied on Linux,
 		// the call to isInterfaceInvalid above will return true and the interface will be removed, and this code will
@@ -526,7 +568,7 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 
 	// clean-up IPs that may still be allocated
 	klog.V(4).InfoS("Running IPAM garbage collection for unused Pod IPs")
-	if err := ipam.GarbageCollectContainerIPs(AntreaCNIType, desiredPodIPs); err != nil {
+	if err := garbageCollectContainerIPs(AntreaCNIType, ipsInUse); err != nil {
 		klog.ErrorS(err, "Error when garbage collecting previously-allocated IPs")
 	}
 

--- a/pkg/agent/cniserver/server_linux_test.go
+++ b/pkg/agent/cniserver/server_linux_test.go
@@ -28,6 +28,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 
 	"antrea.io/antrea/pkg/agent/cniserver/ipam"
@@ -44,9 +47,47 @@ import (
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
 	ovsconfigtest "antrea.io/antrea/pkg/ovs/ovsconfig/testing"
 	"antrea.io/antrea/pkg/util/channel"
+	utilip "antrea.io/antrea/pkg/util/ip"
 )
 
 var mockCNIDeleteChecker *typestest.MockCNIDeleteChecker
+
+var (
+	// pod4 reports an IP in its status, but has no corresponding interface in the interface
+	// store.
+	pod4 = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "p4",
+			Namespace: testPodNamespace,
+		},
+		Spec: v1.PodSpec{
+			NodeName: nodeName,
+		},
+		Status: v1.PodStatus{
+			PodIPs: []v1.PodIP{
+				{IP: "1.1.1.3"},
+			},
+		},
+	}
+	// undeletableInterface corresponds to a Pod which no longer exists, but which cannot be
+	// removed from the interface store because deleting the OVS port fails.
+	undeletableInterface = &interfacestore.InterfaceConfig{
+		InterfaceName: "iface5",
+		Type:          interfacestore.ContainerInterface,
+		IPs:           []net.IP{net.ParseIP("1.1.1.4")},
+		MAC:           utilip.MustParseMAC("00:11:22:33:44:03"),
+		OVSPortConfig: &interfacestore.OVSPortConfig{
+			PortUUID: generateUUID(),
+			OFPort:   int32(5),
+		},
+		ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{
+			PodName:      "another-non-existing-pod",
+			PodNamespace: testPodNamespace,
+			ContainerID:  generateUUID(),
+			NetNS:        "netns4",
+		},
+	}
+)
 
 func TestValidatePrevResult(t *testing.T) {
 	cniServer := newCNIServer(t)
@@ -639,7 +680,7 @@ func TestCmdCheck(t *testing.T) {
 
 func TestReconcile(t *testing.T) {
 	controller := gomock.NewController(t)
-	kubeClient := fakeclientset.NewClientset(pod1, pod2, pod3)
+	kubeClient := fakeclientset.NewClientset(pod1, pod2, pod3, pod4)
 	mockOVSBridgeClient = ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient = openflowtest.NewMockClient(controller)
 	ifaceStore = interfacestore.NewInterfaceStore()
@@ -652,7 +693,7 @@ func TestReconcile(t *testing.T) {
 		Name: nodeName,
 	}
 	cniServer.kubeClient = kubeClient
-	for _, containerIface := range []*interfacestore.InterfaceConfig{normalInterface, staleInterface, unconnectedInterface} {
+	for _, containerIface := range []*interfacestore.InterfaceConfig{normalInterface, staleInterface, unconnectedInterface, undeletableInterface} {
 		ifaceStore.AddInterface(containerIface)
 	}
 	podFlowsInstalled := make(chan struct{})
@@ -662,15 +703,34 @@ func TestReconcile(t *testing.T) {
 		}).Times(1)
 	mockOFClient.EXPECT().UninstallPodFlows(staleInterface.InterfaceName).Return(nil).Times(1)
 	mockOFClient.EXPECT().UninstallPodFlows(unconnectedInterface.InterfaceName).Return(nil).Times(1)
+	mockOFClient.EXPECT().UninstallPodFlows(undeletableInterface.InterfaceName).Return(nil).Times(1)
 	mockOVSBridgeClient.EXPECT().DeletePort(staleInterface.PortUUID).Return(nil).Times(1)
 	mockOVSBridgeClient.EXPECT().DeletePort(unconnectedInterface.PortUUID).Return(nil).Times(1)
+	mockOVSBridgeClient.EXPECT().DeletePort(undeletableInterface.PortUUID).Return(ovsconfig.NewTransactionError(fmt.Errorf("transaction error"), true)).Times(1)
 	mockRoute.EXPECT().DeleteLocalAntreaFlexibleIPAMPodRule(gomock.Any()).Return(nil).Times(2)
+	var gcIPs sets.Set[string]
+	oriGarbageCollectContainerIPs := garbageCollectContainerIPs
+	garbageCollectContainerIPs = func(network string, ipsInUse sets.Set[string]) error {
+		gcIPs = ipsInUse
+		return nil
+	}
+	t.Cleanup(func() {
+		garbageCollectContainerIPs = oriGarbageCollectContainerIPs
+	})
 	err := cniServer.reconcile()
 	assert.NoError(t, err)
+	// pod1 does not report an IP in its status: its IP is only protected from garbage
+	// collection because normalInterface is present in the interface store. pod4 reports an IP
+	// in its status but has no interface. The IP of undeletableInterface is protected because
+	// that interface could not be removed from the interface store. The IP of
+	// unconnectedInterface is not protected, as that interface is deleted during reconciliation.
+	assert.Equal(t, sets.New[string]("1.1.1.1", "1.1.1.3", "1.1.1.4"), gcIPs)
 	_, exists := ifaceStore.GetInterfaceByName(staleInterface.InterfaceName)
 	assert.False(t, exists)
 	_, exists = ifaceStore.GetInterfaceByName(unconnectedInterface.InterfaceName)
 	assert.False(t, exists)
+	_, exists = ifaceStore.GetInterfaceByName(undeletableInterface.InterfaceName)
+	assert.True(t, exists)
 	select {
 	case <-podFlowsInstalled:
 	case <-time.After(500 * time.Millisecond):

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -878,6 +878,11 @@ func TestCNIServerGCForHostLocalIPAM(t *testing.T) {
 	usedIPv6 := net.ParseIP("2001:db8:a::1")
 	unusedIPv4 := net.ParseIP("10.0.0.2")
 	unusedIPv6 := net.ParseIP("2001:db8:a::2")
+	// IPs which are in-use by a Pod, but which are missing from the Pod status. This is the case
+	// when the CNI ADD for the Pod completed right before the agent restarted, as kubelet
+	// reports Pod IPs to the K8s API asynchronously.
+	notReportedIPv4 := net.ParseIP("10.0.0.3")
+	notReportedIPv6 := net.ParseIP("2001:db8:a::3")
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -893,6 +898,15 @@ func TestCNIServerGCForHostLocalIPAM(t *testing.T) {
 				{IP: usedIPv4.String()},
 				{IP: usedIPv6.String()},
 			},
+		},
+	}
+	podWithoutStatusIPs := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-2",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: testNodeConfig.Name,
 		},
 	}
 
@@ -919,6 +933,7 @@ func TestCNIServerGCForHostLocalIPAM(t *testing.T) {
 	}
 	reserveIPs("c0", usedIPv4, usedIPv6)
 	reserveIPs("c1", unusedIPv4, unusedIPv6)
+	reserveIPs("c2", notReportedIPv4, notReportedIPv6)
 
 	// create mocks and test CNIServer
 	controller := mock.NewController(t)
@@ -929,9 +944,18 @@ func TestCNIServerGCForHostLocalIPAM(t *testing.T) {
 	ofServiceMock := openflowtest.NewMockClient(controller)
 	routeMock := routetest.NewMockInterface(controller)
 	ifaceStore := interfacestore.NewInterfaceStore()
+	// The interface store is restored from OVSDB on agent restart: it knows about the IPs which
+	// have not been reported to the K8s API yet.
+	notReportedIface := interfacestore.NewContainerInterface(
+		"iface2", "c2", podWithoutStatusIPs.Name, podWithoutStatusIPs.Namespace,
+		IFName, "netns2", nil, []net.IP{notReportedIPv4, notReportedIPv6}, 0)
+	notReportedIface.OVSPortConfig = &interfacestore.OVSPortConfig{PortUUID: "uuid2", OFPort: 10}
+	ifaceStore.AddInterface(notReportedIface)
+	// reconciliation replays the OpenFlow entries for this interface, as the Pod still exists
+	ofServiceMock.EXPECT().InstallPodFlows("iface2", notReportedIface.IPs, nil, uint32(10), uint16(0), nil).Return(nil).Times(1)
 	podNetworkWait := wait.NewGroup()
 	flowRestoreCompleteWait := wait.NewGroup()
-	k8sClient := k8sFake.NewSimpleClientset(pod)
+	k8sClient := k8sFake.NewSimpleClientset(pod, podWithoutStatusIPs)
 	server := cniserver.New(
 		testSock,
 		"",
@@ -945,6 +969,8 @@ func TestCNIServerGCForHostLocalIPAM(t *testing.T) {
 
 	// call Initialize, which will run reconciliation and perform host-local IPAM garbage collection
 	server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, channel.NewSubscribableChannel("PodUpdate", 100))
+	// wait for the asynchronous part of reconciliation (OpenFlow entries replay) to complete
+	require.NoError(t, flowRestoreCompleteWait.WaitWithTimeout(5*time.Second))
 
 	getIPs := func(cID string) []net.IP {
 		ipamStore, err := disk.New("antrea", "")
@@ -956,6 +982,9 @@ func TestCNIServerGCForHostLocalIPAM(t *testing.T) {
 	}
 	assert.ElementsMatch(t, getIPs("c0"), []net.IP{usedIPv4, usedIPv6})
 	assert.Empty(t, getIPs("c1"))
+	// These IPs must not be released: they are assigned to a Pod interface which is known to
+	// the interface store, even though the Pod status does not report them yet.
+	assert.ElementsMatch(t, getIPs("c2"), []net.IP{notReportedIPv4, notReportedIPv6})
 }
 
 func getTestNodeConfig(dualStack bool) *config.NodeConfig {


### PR DESCRIPTION
Cherry pick of #8240 on release-2.6.

#8240: Fix host-local IPAM GC releasing in-use Pod IPs (#8240)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.