### PR TITLE
Support IPv6 SFTP URL in PacketCapture CRD

### DIFF
--- a/build/charts/antrea/crds/packetcapture.yaml
+++ b/build/charts/antrea/crds/packetcapture.yaml
@@ -231,7 +231,7 @@ spec:
                   properties:
                     url:
                       type: string
-                      pattern: 'sftp:\/\/[\w-_./]+:\d+'
+                      pattern: 'sftp:\/\/([\w-_./]+|\[[\w-_.:/]+\]):\d+'
                     hostPublicKey:
                       type: string
                       format: byte

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3495,7 +3495,7 @@ spec:
                   properties:
                     url:
                       type: string
-                      pattern: 'sftp:\/\/[\w-_./]+:\d+'
+                      pattern: 'sftp:\/\/([\w-_./]+|\[[\w-_.:/]+\]):\d+'
                     hostPublicKey:
                       type: string
                       format: byte

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -3460,7 +3460,7 @@ spec:
                   properties:
                     url:
                       type: string
-                      pattern: 'sftp:\/\/[\w-_./]+:\d+'
+                      pattern: 'sftp:\/\/([\w-_./]+|\[[\w-_.:/]+\]):\d+'
                     hostPublicKey:
                       type: string
                       format: byte

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3491,7 +3491,7 @@ spec:
                   properties:
                     url:
                       type: string
-                      pattern: 'sftp:\/\/[\w-_./]+:\d+'
+                      pattern: 'sftp:\/\/([\w-_./]+|\[[\w-_.:/]+\]):\d+'
                     hostPublicKey:
                       type: string
                       format: byte

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3491,7 +3491,7 @@ spec:
                   properties:
                     url:
                       type: string
-                      pattern: 'sftp:\/\/[\w-_./]+:\d+'
+                      pattern: 'sftp:\/\/([\w-_./]+|\[[\w-_.:/]+\]):\d+'
                     hostPublicKey:
                       type: string
                       format: byte

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3491,7 +3491,7 @@ spec:
                   properties:
                     url:
                       type: string
-                      pattern: 'sftp:\/\/[\w-_./]+:\d+'
+                      pattern: 'sftp:\/\/([\w-_./]+|\[[\w-_.:/]+\]):\d+'
                     hostPublicKey:
                       type: string
                       format: byte

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3491,7 +3491,7 @@ spec:
                   properties:
                     url:
                       type: string
-                      pattern: 'sftp:\/\/[\w-_./]+:\d+'
+                      pattern: 'sftp:\/\/([\w-_./]+|\[[\w-_.:/]+\]):\d+'
                     hostPublicKey:
                       type: string
                       format: byte

--- a/pkg/util/sftp/ftp_test.go
+++ b/pkg/util/sftp/ftp_test.go
@@ -37,6 +37,22 @@ func TestParseFTPUploadUrl(t *testing.T) {
 			},
 		},
 		{
+			url: "sftp://[2001:db8::1]:22/path",
+			expectedURL: url.URL{
+				Scheme: "sftp",
+				Host:   "[2001:db8::1]:22",
+				Path:   "/path",
+			},
+		},
+		{
+			url: "[2001:db8::1]:22/path",
+			expectedURL: url.URL{
+				Scheme: "sftp",
+				Host:   "[2001:db8::1]:22",
+				Path:   "/path",
+			},
+		},
+		{
 			url: "127.0.0.1:22/path",
 			expectedURL: url.URL{
 				Scheme: "sftp",


### PR DESCRIPTION
## Summary
- Update the `fileServer.url` pattern regex in the `PacketCapture` CRD (`build/charts/antrea/crds/packetcapture.yaml`) to support standard IPv6 address formats with brackets and colons (e.g., `sftp://[2001:db8::1]:22/path`).
- Regenerate all dev manifests automatically using `make manifest`.
- Add unit tests in `pkg/util/sftp/ftp_test.go` to verify parsing of standard IPv6 SFTP URLs.

## Test plan
- Run unit tests for SFTP URL parsing: `go test -v ./pkg/util/sftp -run TestParseFTPUploadUrl`

Made with [Cursor](https://cursor.com)