### PR TITLE
Compare PodCIDRs in NodeRouteController's addNodeRoute fast path

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"sync"
 	"time"
 
@@ -555,21 +556,32 @@ func (c *Controller) addNodeRoute(nodeName string, node *corev1.Node) error {
 		return err
 	}
 	peerWireGuardPublicKey := node.Annotations[types.NodeWireGuardPublicAnnotationKey]
-
-	nrInfo, installed, _ := c.installedNodes.GetByKey(nodeName)
-	// Route is already added for this Node and Node MAC, transport IP
-	// and WireGuard public key are not changed.
-	if installed && nrInfo.(*nodeRouteInfo).nodeMAC.String() == peerNodeMAC.String() &&
-		peerNodeIPs.Equal(*nrInfo.(*nodeRouteInfo).nodeIPs) &&
-		nrInfo.(*nodeRouteInfo).wireGuardPublicKey == peerWireGuardPublicKey {
-		return nil
-	}
-
 	podCIDRStrs := getPodCIDRsOnNode(node)
 	if len(podCIDRStrs) == 0 {
 		// If no valid PodCIDR is configured in Node.Spec, return immediately.
 		return nil
 	}
+
+	nrInfo, installed, _ := c.installedNodes.GetByKey(nodeName)
+	samePodCIDRs := func(podCIDRs []*net.IPNet) bool {
+		// There is no reason to worry about the ordering of the CIDRs here. In a dual-stack
+		// cluster, the CIDRs should always be ordered consistently by IP family. Even if
+		// this was not true, samePodCIDRs would just return false and we would end up
+		// re-installing the same routes (and the podCIDRs field in nodeRouteInfo would be
+		// updated).
+		return slices.EqualFunc(podCIDRStrs, podCIDRs, func(cidrStr string, cidr *net.IPNet) bool {
+			return cidr.String() == cidrStr
+		})
+	}
+	// Route is already added for this Node and Node MAC, transport IP, podCIDRs and WireGuard
+	// public key are not changed.
+	if installed && nrInfo.(*nodeRouteInfo).nodeMAC.String() == peerNodeMAC.String() &&
+		peerNodeIPs.Equal(*nrInfo.(*nodeRouteInfo).nodeIPs) &&
+		samePodCIDRs(nrInfo.(*nodeRouteInfo).podCIDRs) &&
+		nrInfo.(*nodeRouteInfo).wireGuardPublicKey == peerWireGuardPublicKey {
+		return nil
+	}
+
 	klog.InfoS("Adding routes and flows to Node", "Node", nodeName, "podCIDRs", podCIDRStrs,
 		"addresses", node.Status.Addresses)
 

--- a/pkg/agent/controller/noderoute/node_route_controller_test.go
+++ b/pkg/agent/controller/noderoute/node_route_controller_test.go
@@ -50,11 +50,13 @@ var (
 	// podCIDRs of "local" Node
 	_, podCIDR, _   = net.ParseCIDR("1.1.0.0/24")
 	_, podCIDRv6, _ = net.ParseCIDR("2001:4860:0000::/48")
-	// podCIDRs of "remote" Node
+	// podCIDRs of "remote" Nodes
 	_, podCIDR1, _    = net.ParseCIDR("1.1.1.0/24")
 	_, podCIDR1v6, _  = net.ParseCIDR("2001:4860:0001::/48")
+	_, podCIDR2, _    = net.ParseCIDR("1.1.2.0/24")
 	podCIDR1Gateway   = util.GetGatewayIPForPodCIDR(podCIDR1)
 	podCIDR1v6Gateway = util.GetGatewayIPForPodCIDR(podCIDR1v6)
+	podCIDR2Gateway   = util.GetGatewayIPForPodCIDR(podCIDR2)
 	nodeIP1           = net.ParseIP("10.10.10.10")
 	dsIPs1            = utilip.DualStackIPs{IPv4: nodeIP1}
 	nodeIP2           = net.ParseIP("10.10.10.11")
@@ -197,6 +199,51 @@ func TestControllerWithDuplicatePodCIDR(t *testing.T) {
 		t.Errorf("Test didn't finish in time")
 	case <-finishCh:
 	}
+}
+
+func TestNodeRecreateNewPodCIDR(t *testing.T) {
+	c := newController(t, &config.NetworkConfig{})
+	defer c.queue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+	c.informerFactory.WaitForCacheSync(stopCh)
+
+	// Remove IPv6 Pod CIDR to simplify test.
+	oldNode := node1.DeepCopy()
+	oldNode.UID = "old-uid"
+	oldNode.Spec.PodCIDR = podCIDR1.String()
+	oldNode.Spec.PodCIDRs = []string{podCIDR1.String()}
+
+	newNode := node1.DeepCopy()
+	newNode.UID = "new-uid"
+	newNode.Spec.PodCIDR = podCIDR2.String()
+	newNode.Spec.PodCIDRs = []string{podCIDR2.String()}
+
+	c.clientset.CoreV1().Nodes().Create(context.TODO(), oldNode, metav1.CreateOptions{})
+	c.ofClient.EXPECT().InstallNodeFlows("node1", gomock.Any(), &dsIPs1, uint32(0), nil).Times(1)
+	c.routeClient.EXPECT().AddRoutes(podCIDR1, "node1", nodeIP1, podCIDR1Gateway).Times(1)
+	c.processNextWorkItem()
+
+	// Node is deleted, then shortly after is "recreated" (same name) with a different PodCIDR.
+	c.clientset.CoreV1().Nodes().Delete(context.TODO(), oldNode.Name, metav1.DeleteOptions{})
+	// The sleep is for illustration purposes. The duration does not really matter. What matters
+	// is that by the time we call processNextWorkItem below, the informer store has been
+	// updated with the new Node.
+	time.Sleep(10 * time.Millisecond)
+	c.clientset.CoreV1().Nodes().Create(context.TODO(), newNode, metav1.CreateOptions{})
+
+	c.ofClient.EXPECT().InstallNodeFlows("node1", gomock.Any(), &dsIPs1, uint32(0), nil).Times(1)
+	c.routeClient.EXPECT().AddRoutes(podCIDR2, "node1", nodeIP1, podCIDR2Gateway).Times(1)
+
+	require.Eventually(t, func() bool {
+		node, err := c.nodeLister.Get("node1")
+		return err == nil && node.UID == "new-uid"
+	}, 1*time.Second, 10*time.Millisecond)
+
+	// The workqueue may still be empty by the time this is called, but processNextWorkItem will block.
+	c.processNextWorkItem()
 }
 
 func TestLookupIPInPodSubnets(t *testing.T) {


### PR DESCRIPTION
Motivation:
Node.Spec.PodCIDR is immutable once set, but NodeRouteController
processes Node events through a workqueue keyed by Node name. This
means addNodeRoute can observe the same Node name with a different
PodCIDR in the following narrow, timing-dependent sequence:

1) Node "foo" with PodCIDR A is created and its routes/flows are
   installed.
2) Node "foo" is deleted.
3) A new Node "foo" (same name, same Node IPs) with PodCIDR B is
   created shortly after.

If the Delete and Create events are coalesced in the workqueue,
syncNodeRoute runs once, fetches the new Node "foo" from the lister,
and calls addNodeRoute. The "already installed" fast path only
compared Node MAC, Node IPs, and the WireGuard public key against the
previously installed nodeRouteInfo, so it did not notice that the
PodCIDR had changed and skipped reinstalling routes/flows, leaving
the datapath with stale routes for PodCIDR A instead of B.

Because this additionally requires the new Node to reuse the same
Node IPs as the old one, the trigger conditions are narrow, but the
missing comparison is a real correctness gap in the fast path.

Approach:
Add a samePodCIDRs comparison (using slices.EqualFunc against the
podCIDRs recorded in the installed nodeRouteInfo) to the "already
installed" fast-path condition in addNodeRoute, alongside the
existing Node MAC, Node IP, and WireGuard public key checks. The
podCIDRStrs computation (and its associated empty-PodCIDR early
return) is moved earlier in the function so it is available for this
comparison.

Validation:
Ran `go build ./pkg/agent/controller/noderoute/...` and
`go vet ./pkg/agent/controller/noderoute/...`: both clean.

Added TestNodeRecreateNewPodCIDR, which creates a Node with PodCIDR
A, processes it, then deletes it and creates a same-named Node with
PodCIDR B before the next queue item is processed (simulating the
coalesced Delete+Create). Verified this test fails without the fix
(missing calls to InstallNodeFlows/AddRoutes for PodCIDR B) and
passes with it, by temporarily reverting only the non-test source
file and rerunning:
  go test ./pkg/agent/controller/noderoute/... -run TestNodeRecreateNewPodCIDR -v

Ran the full package suite with the fix applied and confirmed no
regressions:
  go test ./pkg/agent/controller/noderoute/...
  ok  antrea.io/antrea/v2/pkg/agent/controller/noderoute  3.260s

Also ran `gofmt -l` on both changed files (no output) and
`golangci-lint run ./pkg/agent/controller/noderoute/...` (0 issues).
This is a controller unit-logic fix; no live-cluster or e2e
reproduction was performed, and CONTRIBUTING.md does not require one
for this class of change (`make test-unit` is the documented bar).

Report: https://github.com/antrea-io/antrea/issues/6965
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #6965