### PR TITLE
Automated cherry pick of #8206: Retry AntreaProxy Service sync on transient failures (#8206)

### DIFF
--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -182,41 +182,67 @@ func (p *proxier) isInitialized() bool {
 }
 
 // removeStaleServices removes all the configurations of expired Services and their associated Endpoints.
-func (p *proxier) removeStaleServices() {
+// It returns false if any stale Service could not be fully removed. Like installServices, each failure is
+// already logged by the step that hit it, and a failed Service stays in serviceInstalledMap so it is
+// retried on the next sync; the returned flag lets syncProxyRules ask the runner to retry soon rather than
+// waiting for the next event or the maxInterval resync.
+func (p *proxier) removeStaleServices() bool {
+	removalSuccess := true
 	for svcPortName, svcPort := range p.serviceInstalledMap {
-		if _, ok := p.serviceMap[svcPortName]; ok {
-			continue
+		if !p.removeStaleService(svcPortName, svcPort) {
+			removalSuccess = false
 		}
-		svcInfo := svcPort.(*types.ServiceInfo)
-		svcInfoStr := svcInfo.String()
-		klog.V(2).InfoS("Removing stale Service", "ServicePortName", svcPortName, "ServiceInfo", svcInfoStr)
-		if !p.removeServiceFlows(svcInfo) {
-			continue
-		}
-		// Remove Service group which has only local Endpoints.
-		if !p.removeServiceGroup(svcPortName, true) {
-			continue
-		}
-		// Remove Service group which has all Endpoints.
-		if !p.removeServiceGroup(svcPortName, false) {
-			continue
-		}
-		// Remove associated Endpoints flows.
-		if endpoints, ok := p.endpointsInstalledMap[svcPortName]; ok {
-			if !p.removeStaleEndpoints(svcPortName, svcInfo.OFProtocol, endpoints) {
-				continue
-			}
-			delete(p.endpointsInstalledMap, svcPortName)
-		}
-		if p.cleanupStaleUDPSvcConntrack && needClearConntrackEntries(svcInfo.OFProtocol) {
-			if !p.removeStaleServiceConntrackEntries(svcPortName, svcInfo) {
-				continue
-			}
-		}
-
-		delete(p.serviceInstalledMap, svcPortName)
-		p.ipToServiceMap.delete(svcInfo)
 	}
+	return removalSuccess
+}
+
+// removeStaleService removes the data path configuration of a single expired Service. It returns false if
+// the Service could not be fully removed, in which case it stays in serviceInstalledMap and the next sync
+// retries. A Service that is not stale (still present in serviceMap) is a no-op and returns true.
+func (p *proxier) removeStaleService(svcPortName k8sproxy.ServicePortName, svcPort k8sproxy.ServicePort) bool {
+	if _, ok := p.serviceMap[svcPortName]; ok {
+		// Not a stale Service, nothing to remove.
+		return true
+	}
+	svcInfo := svcPort.(*types.ServiceInfo)
+	svcInfoStr := svcInfo.String()
+	klog.V(2).InfoS("Removing stale Service", "ServicePortName", svcPortName, "ServiceInfo", svcInfoStr)
+	if !p.removeServiceFlows(svcInfo) {
+		return false
+	}
+	// Remove Service group which has only local Endpoints.
+	if !p.removeServiceGroup(svcPortName, true) {
+		return false
+	}
+	// Remove Service group which has all Endpoints.
+	if !p.removeServiceGroup(svcPortName, false) {
+		return false
+	}
+	// Uninstall the Service's Endpoint flows. The installed-Endpoint state is not updated here but at the
+	// end, together with serviceInstalledMap, so that a failure in a later step leaves both maps consistent
+	// (the Service stays fully recorded) and the next sync retries from a clean state.
+	endpoints, hasEndpoints := p.endpointsInstalledMap[svcPortName]
+	if hasEndpoints {
+		if !p.removeStaleEndpoints(svcPortName, svcInfo.OFProtocol, endpoints) {
+			return false
+		}
+	}
+
+	if p.cleanupStaleUDPSvcConntrack && needClearConntrackEntries(svcInfo.OFProtocol) {
+		if !p.removeStaleServiceConntrackEntries(svcPortName, svcInfo) {
+			return false
+		}
+	}
+
+	// The Service has been fully torn down in OVS. Commit the removal: release the Endpoints' reference
+	// counters and drop the installed-Endpoint and installed-Service entries together.
+	if hasEndpoints {
+		p.releaseEndpointsReferences(svcInfo.OFProtocol, endpoints)
+		delete(p.endpointsInstalledMap, svcPortName)
+	}
+	delete(p.serviceInstalledMap, svcPortName)
+	p.ipToServiceMap.delete(svcInfo)
+	return true
 }
 
 func (p *proxier) removeServiceFlows(svcInfo *types.ServiceInfo) bool {
@@ -285,16 +311,17 @@ func (p *proxier) removeServiceGroup(svcPortName k8sproxy.ServicePortName, local
 	return true
 }
 
-// removeStaleEndpoints removes flows for the given Endpoints from the data path if these flows are no longer
-// needed by any Service. Endpoints from different Services can have the same characteristics and thus
-// can share the same flows. removeStaleEndpoints must be called whenever Endpoints are no longer used by a
-// given Service. If the Endpoints are still referenced by any other Services, no flow will be removed.
-// The method only returns an error if a data path operation fails. If the flows are successfully
-// removed from the data path, the method returns nil.
+// removeStaleEndpoints uninstalls the data path flows for the given stale Endpoints. Endpoints from
+// different Services can share the same flows, so a flow is only removed once no Service references the
+// Endpoint any more (reference count 1). It only touches OVS and returns false if a data path operation
+// fails; the caller updates the installed-Endpoint state via updateEndpointsStates after the Service's
+// data path changes have all succeeded.
 func (p *proxier) removeStaleEndpoints(svcPortName k8sproxy.ServicePortName, protocol binding.Protocol, staleEndpoints map[string]k8sproxy.Endpoint) bool {
 	var endpointsToRemove []k8sproxy.Endpoint
 
-	// Get all Endpoints whose reference counter is 1, and these Endpoints should be removed.
+	// Get all Endpoints whose reference counter is 1, and these Endpoints should be removed. If the
+	// flows were already uninstalled by a failed sync, repeating the call is a no-op as the OpenFlow
+	// client skips flows absent from its cache.
 	for _, endpoint := range staleEndpoints {
 		key := endpointKey(endpoint, protocol)
 		count := p.endpointReferenceCounter[key]
@@ -312,8 +339,34 @@ func (p *proxier) removeStaleEndpoints(svcPortName k8sproxy.ServicePortName, pro
 		}
 	}
 
-	// Update the reference counter of Endpoints and remove them from the installed Endpoints of the ServicePortName.
-	for _, endpoint := range staleEndpoints {
+	return true
+}
+
+// updateEndpointsStates records the result of a successful Endpoint change into the in-memory state: it
+// adds the given Endpoints to, and removes the given ones from, endpointsInstalledMap, and updates their
+// shared reference counters accordingly.
+//
+// It must only be called after all of the Service's data path changes have succeeded, at the end of
+// installService. If the state were committed early, a failure in a later step would leave it "converged"
+// while OVS stayed stale, and the next sync would compute an empty diff and never retry the failed step.
+// The teardown path (removeStaleService) instead calls releaseEndpointsReferences and drops the Service's
+// whole endpointsInstalledMap entry, without deleting the Endpoint keys one by one.
+func (p *proxier) updateEndpointsStates(svcPortName k8sproxy.ServicePortName, protocol binding.Protocol, added, removed map[string]k8sproxy.Endpoint) {
+	for _, endpoint := range added {
+		p.endpointsInstalledMap[svcPortName][endpoint.String()] = endpoint
+		key := endpointKey(endpoint, protocol)
+		p.endpointReferenceCounter[key] = p.endpointReferenceCounter[key] + 1
+	}
+	p.releaseEndpointsReferences(protocol, removed)
+	for _, endpoint := range removed {
+		delete(p.endpointsInstalledMap[svcPortName], endpoint.String())
+	}
+}
+
+// releaseEndpointsReferences decrements the shared reference counters of the given Endpoints, dropping a
+// counter entirely when this was its last reference.
+func (p *proxier) releaseEndpointsReferences(protocol binding.Protocol, endpoints map[string]k8sproxy.Endpoint) {
+	for _, endpoint := range endpoints {
 		key := endpointKey(endpoint, protocol)
 		count := p.endpointReferenceCounter[key]
 		if count == 1 {
@@ -323,10 +376,7 @@ func (p *proxier) removeStaleEndpoints(svcPortName k8sproxy.ServicePortName, pro
 			p.endpointReferenceCounter[key] = count - 1
 			klog.V(2).InfoS("Stale Endpoint is still referenced by other Services, decrementing reference count by 1", "Endpoint", endpoint.String(), "Protocol", protocol)
 		}
-		delete(p.endpointsInstalledMap[svcPortName], endpoint.String())
 	}
-
-	return true
 }
 
 func (p *proxier) removeStaleServiceConntrackEntries(svcPortName k8sproxy.ServicePortName, svcInfo *types.ServiceInfo) bool {
@@ -460,32 +510,26 @@ func (p *proxier) removeStaleConntrackEntries(svcPortName k8sproxy.ServicePortNa
 	return true
 }
 
+// addNewEndpoints installs the data path flows for the given new Endpoints. It only touches OVS and
+// returns false if a data path operation fails; the caller updates the installed-Endpoint state via
+// updateEndpointsStates after the Service's data path changes have all succeeded.
+//
+// The Endpoints are passed to the OpenFlow client as-is, which skips the ones whose flows are already
+// installed based on its flow cache. Don't filter by endpointReferenceCounter here: it is only
+// committed after a Service's whole sync succeeds, so a stale count could make a needed installation
+// be skipped.
 func (p *proxier) addNewEndpoints(svcPortName k8sproxy.ServicePortName, protocol binding.Protocol, newEndpoints map[string]k8sproxy.Endpoint) bool {
-	var endpointsToAdd []k8sproxy.Endpoint
-
-	// Get all Endpoints whose reference counter is 0, and these Endpoints should be added.
-	for _, endpoint := range newEndpoints {
-		key := endpointKey(endpoint, protocol)
-		count := p.endpointReferenceCounter[key]
-		if count == 0 {
-			endpointsToAdd = append(endpointsToAdd, endpoint)
-			klog.V(2).InfoS("Endpoint will be added", "Endpoint", endpoint.String(), "Protocol", protocol)
-		}
+	if len(newEndpoints) == 0 {
+		return true
 	}
-
-	// Add flows for these Endpoints.
-	if len(endpointsToAdd) != 0 {
-		if err := p.ofClient.InstallEndpointFlows(protocol, endpointsToAdd); err != nil {
-			klog.ErrorS(err, "Error when installing Endpoints flows for Service", "ServicePortName", svcPortName)
-			return false
-		}
-	}
-
-	// Update the reference counter of Endpoints.
+	endpointsToAdd := make([]k8sproxy.Endpoint, 0, len(newEndpoints))
 	for _, endpoint := range newEndpoints {
-		p.endpointsInstalledMap[svcPortName][endpoint.String()] = endpoint
-		key := endpointKey(endpoint, protocol)
-		p.endpointReferenceCounter[key] = p.endpointReferenceCounter[key] + 1
+		endpointsToAdd = append(endpointsToAdd, endpoint)
+		klog.V(2).InfoS("Endpoint will be added", "Endpoint", endpoint.String(), "Protocol", protocol)
+	}
+	if err := p.ofClient.InstallEndpointFlows(protocol, endpointsToAdd); err != nil {
+		klog.ErrorS(err, "Error when installing Endpoints flows for Service", "ServicePortName", svcPortName)
+		return false
 	}
 	return true
 }
@@ -677,132 +721,154 @@ func (p *proxier) uninstallLoadBalancerService(svcInfoStr string, loadBalancerIP
 	return nil
 }
 
-func (p *proxier) installServices() {
+// installServices installs/updates the data path for all Services. It returns false if any Service could
+// not be fully installed. The details of each failure are already logged by the step that hit it; the
+// returned flag is only a signal for syncProxyRules to ask the runner to retry soon.
+func (p *proxier) installServices() bool {
+	installSuccess := true
 	for svcPortName, svcPort := range p.serviceMap {
-		svcInfo := svcPort.(*types.ServiceInfo)
-		p.ipToServiceMap.add(svcInfo, svcPortName)
-		endpointsInstalled, ok := p.endpointsInstalledMap[svcPortName]
-		if !ok {
-			endpointsInstalled = map[string]k8sproxy.Endpoint{}
-			p.endpointsInstalledMap[svcPortName] = endpointsInstalled
+		if !p.installService(svcPortName, svcPort) {
+			installSuccess = false
 		}
-		endpointsToInstall := p.endpointsMap[svcPortName]
-
-		installedSvcPort, ok := p.serviceInstalledMap[svcPortName]
-		var pSvcInfo *types.ServiceInfo
-		var needUpdateServiceExternalAddresses, needUpdateService, needUpdateEndpoints bool
-		var needCleanupStaleUDPServiceConntrack bool
-		if ok { // Need to update.
-			pSvcInfo = installedSvcPort.(*types.ServiceInfo)
-			// The changes to serviceIdentity, session affinity config, and traffic policies affect all Service
-			// flows while the changes to external addresses (NodePort and LoadBalancerIPs) affect external Service
-			// flows only.
-			needUpdateService = serviceIdentityChanged(svcInfo, pSvcInfo) ||
-				svcInfo.SessionAffinityType() != pSvcInfo.SessionAffinityType() || // All Service flows use it.
-				svcInfo.StickyMaxAgeSeconds() != pSvcInfo.StickyMaxAgeSeconds() || // All Service flows use it.
-				svcInfo.ExternalPolicyLocal() != pSvcInfo.ExternalPolicyLocal() || // It affects the group ID used by external Service flows.
-				svcInfo.InternalPolicyLocal() != pSvcInfo.InternalPolicyLocal() || // It affects the group ID used by internal Service flows.
-				svcInfo.LoadBalancerMode != pSvcInfo.LoadBalancerMode
-			needUpdateServiceExternalAddresses = serviceExternalAddressesChanged(svcInfo, pSvcInfo)
-			needUpdateEndpoints = pSvcInfo.SessionAffinityType() != svcInfo.SessionAffinityType() ||
-				pSvcInfo.ExternalPolicyLocal() != svcInfo.ExternalPolicyLocal() ||
-				pSvcInfo.InternalPolicyLocal() != svcInfo.InternalPolicyLocal()
-			if p.cleanupStaleUDPSvcConntrack && needClearConntrackEntries(pSvcInfo.OFProtocol) {
-				// We clean the UDP conntrack entries for the following Service update cases:
-				// - Service port changed, clean the conntrack entries matched by each of the current clusterIP / externalIPs
-				//   / loadBalancerIPs and the stale Service port.
-				// - ClusterIP changed, clean the conntrack entries matched by the clusterIP and the Service port.
-				// - Some externalIPs / loadBalancerIPs are removed, clean the conntrack entries matched by each of the
-				//   removed Service IPs and the current Service port.
-				// - Service nodePort changed, clean the conntrack entries matched by each of the Node IPs / the virtual
-				//   NodePort DNAT IP and the stale Service nodePort.
-				// However, we DO NOT clean the UDP conntrack entries related to remote Endpoints that are still
-				// referenced by the Service but are no longer selectable Endpoints for the corresponding Service IPs
-				// (for externalTrafficPolicy, these IPs are loadBalancerIPs, externalIPs and NodeIPs; for
-				// internalTrafficPolicy, these IPs clusterIPs) when externalTrafficPolicy or internalTrafficPolicy is
-				// changed from Cluster to Local. Consequently, the connections, which are supposed to select local
-				// Endpoints, will continue to send packets to remote Endpoints due to the existing UDP conntrack entries
-				// until timeout.
-				needCleanupStaleUDPServiceConntrack = svcInfo.Port() != pSvcInfo.Port() ||
-					svcInfo.ClusterIP().String() != pSvcInfo.ClusterIP().String() ||
-					needUpdateServiceExternalAddresses
-			}
-		} else { // Need to install.
-			needUpdateService = true
-			// We need to ensure a group is created for a new Service even if there is no available Endpoints,
-			// otherwise it would fail to install Service flows because the group doesn't exist.
-			needUpdateEndpoints = true
-		}
-
-		clusterEndpoints, localEndpoints, allReachableEndpoints := p.categorizeEndpoints(endpointsToInstall, svcInfo, p.hostname, p.topologyLabels)
-		// Get the stale Endpoints and new Endpoints based on the diff of endpointsInstalled and allReachableEndpoints.
-		staleEndpoints, newEndpoints := compareEndpoints(endpointsInstalled, allReachableEndpoints)
-		if len(staleEndpoints) > 0 || len(newEndpoints) > 0 {
-			needUpdateEndpoints = true
-		}
-		// We also clean the conntrack entries related to the stale Endpoints for a UDP Service. Conntrack entries
-		// matched by each of stale Endpoint IPs and each of the remaining Service IPs and ports will be deleted.
-		if len(staleEndpoints) > 0 && needClearConntrackEntries(svcInfo.OFProtocol) {
-			needCleanupStaleUDPServiceConntrack = true
-		}
-
-		if needUpdateEndpoints {
-			if !p.addNewEndpoints(svcPortName, svcInfo.OFProtocol, newEndpoints) {
-				continue
-			}
-			if !p.removeStaleEndpoints(svcPortName, svcInfo.OFProtocol, staleEndpoints) {
-				continue
-			}
-		}
-
-		withSessionAffinity := svcInfo.SessionAffinityType() == corev1.ServiceAffinityClientIP
-		var localGroupID, clusterGroupID binding.GroupIDType
-		// categorizeEndpoints has checked if localGroup and clusterGroup should exist. We just create the group if its
-		// Endpoints is not nil.
-		// Note that nil represents the group should not exist and empty represents the group should exist but there is
-		// no available Endpoints.
-		if localEndpoints != nil {
-			if localGroupID, ok = p.installServiceGroup(svcPortName, needUpdateEndpoints, true, withSessionAffinity, localEndpoints); !ok {
-				continue
-			}
-		} else {
-			if !p.removeServiceGroup(svcPortName, true) {
-				continue
-			}
-		}
-		if clusterEndpoints != nil {
-			if clusterGroupID, ok = p.installServiceGroup(svcPortName, needUpdateEndpoints, false, withSessionAffinity, clusterEndpoints); !ok {
-				continue
-			}
-		} else {
-			if !p.removeServiceGroup(svcPortName, false) {
-				continue
-			}
-		}
-
-		if needUpdateService {
-			// Delete previous flows.
-			if pSvcInfo != nil {
-				if !p.removeServiceFlows(pSvcInfo) {
-					continue
-				}
-			}
-			if !p.installServiceFlows(svcInfo, localGroupID, clusterGroupID) {
-				continue
-			}
-		} else if needUpdateServiceExternalAddresses {
-			if !p.updateServiceExternalAddresses(pSvcInfo, svcInfo, localGroupID, clusterGroupID) {
-				continue
-			}
-		}
-		if needCleanupStaleUDPServiceConntrack {
-			if !p.removeStaleConntrackEntries(svcPortName, pSvcInfo, svcInfo, staleEndpoints) {
-				continue
-			}
-		}
-
-		p.serviceInstalledMap[svcPortName] = svcPort
 	}
+	return installSuccess
+}
+
+// installService installs/updates the data path for a single Service. It returns false if the Service
+// could not be fully installed, in which case none of the installed-Endpoint/Service state is updated, so
+// the next sync recomputes the diff and retries. Each failure is logged by the step that hit it.
+func (p *proxier) installService(svcPortName k8sproxy.ServicePortName, svcPort k8sproxy.ServicePort) bool {
+	svcInfo := svcPort.(*types.ServiceInfo)
+	p.ipToServiceMap.add(svcInfo, svcPortName)
+	endpointsInstalled, ok := p.endpointsInstalledMap[svcPortName]
+	if !ok {
+		endpointsInstalled = map[string]k8sproxy.Endpoint{}
+		p.endpointsInstalledMap[svcPortName] = endpointsInstalled
+	}
+	endpointsToInstall := p.endpointsMap[svcPortName]
+
+	installedSvcPort, ok := p.serviceInstalledMap[svcPortName]
+	var pSvcInfo *types.ServiceInfo
+	var needUpdateServiceExternalAddresses, needUpdateService, needUpdateEndpoints bool
+	var needCleanupStaleUDPServiceConntrack bool
+	if ok { // Need to update.
+		pSvcInfo = installedSvcPort.(*types.ServiceInfo)
+		// The changes to serviceIdentity, session affinity config, and traffic policies affect all Service
+		// flows while the changes to external addresses (NodePort and LoadBalancerIPs) affect external Service
+		// flows only.
+		needUpdateService = serviceIdentityChanged(svcInfo, pSvcInfo) ||
+			svcInfo.SessionAffinityType() != pSvcInfo.SessionAffinityType() || // All Service flows use it.
+			svcInfo.StickyMaxAgeSeconds() != pSvcInfo.StickyMaxAgeSeconds() || // All Service flows use it.
+			svcInfo.ExternalPolicyLocal() != pSvcInfo.ExternalPolicyLocal() || // It affects the group ID used by external Service flows.
+			svcInfo.InternalPolicyLocal() != pSvcInfo.InternalPolicyLocal() || // It affects the group ID used by internal Service flows.
+			svcInfo.LoadBalancerMode != pSvcInfo.LoadBalancerMode
+		needUpdateServiceExternalAddresses = serviceExternalAddressesChanged(svcInfo, pSvcInfo)
+		needUpdateEndpoints = pSvcInfo.SessionAffinityType() != svcInfo.SessionAffinityType() ||
+			pSvcInfo.ExternalPolicyLocal() != svcInfo.ExternalPolicyLocal() ||
+			pSvcInfo.InternalPolicyLocal() != svcInfo.InternalPolicyLocal()
+		if p.cleanupStaleUDPSvcConntrack && needClearConntrackEntries(pSvcInfo.OFProtocol) {
+			// We clean the UDP conntrack entries for the following Service update cases:
+			// - Service port changed, clean the conntrack entries matched by each of the current clusterIP / externalIPs
+			//   / loadBalancerIPs and the stale Service port.
+			// - ClusterIP changed, clean the conntrack entries matched by the clusterIP and the Service port.
+			// - Some externalIPs / loadBalancerIPs are removed, clean the conntrack entries matched by each of the
+			//   removed Service IPs and the current Service port.
+			// - Service nodePort changed, clean the conntrack entries matched by each of the Node IPs / the virtual
+			//   NodePort DNAT IP and the stale Service nodePort.
+			// However, we DO NOT clean the UDP conntrack entries related to remote Endpoints that are still
+			// referenced by the Service but are no longer selectable Endpoints for the corresponding Service IPs
+			// (for externalTrafficPolicy, these IPs are loadBalancerIPs, externalIPs and NodeIPs; for
+			// internalTrafficPolicy, these IPs clusterIPs) when externalTrafficPolicy or internalTrafficPolicy is
+			// changed from Cluster to Local. Consequently, the connections, which are supposed to select local
+			// Endpoints, will continue to send packets to remote Endpoints due to the existing UDP conntrack entries
+			// until timeout.
+			needCleanupStaleUDPServiceConntrack = svcInfo.Port() != pSvcInfo.Port() ||
+				svcInfo.ClusterIP().String() != pSvcInfo.ClusterIP().String() ||
+				needUpdateServiceExternalAddresses
+		}
+	} else { // Need to install.
+		needUpdateService = true
+		// We need to ensure a group is created for a new Service even if there is no available Endpoints,
+		// otherwise it would fail to install Service flows because the group doesn't exist.
+		needUpdateEndpoints = true
+	}
+
+	clusterEndpoints, localEndpoints, allReachableEndpoints := p.categorizeEndpoints(endpointsToInstall, svcInfo, p.hostname, p.topologyLabels)
+	// Get the stale Endpoints and new Endpoints based on the diff of endpointsInstalled and allReachableEndpoints.
+	staleEndpoints, newEndpoints := compareEndpoints(endpointsInstalled, allReachableEndpoints)
+	if len(staleEndpoints) > 0 || len(newEndpoints) > 0 {
+		needUpdateEndpoints = true
+	}
+	// We also clean the conntrack entries related to the stale Endpoints for a UDP Service. Conntrack entries
+	// matched by each of stale Endpoint IPs and each of the remaining Service IPs and ports will be deleted.
+	if len(staleEndpoints) > 0 && needClearConntrackEntries(svcInfo.OFProtocol) {
+		needCleanupStaleUDPServiceConntrack = true
+	}
+
+	if needUpdateEndpoints {
+		// These only program OVS; the installed-Endpoint state is updated once at the end of this function,
+		// so a failure in the groups/flows below leaves it untouched and the next sync retries.
+		if !p.addNewEndpoints(svcPortName, svcInfo.OFProtocol, newEndpoints) {
+			return false
+		}
+		if !p.removeStaleEndpoints(svcPortName, svcInfo.OFProtocol, staleEndpoints) {
+			return false
+		}
+	}
+
+	withSessionAffinity := svcInfo.SessionAffinityType() == corev1.ServiceAffinityClientIP
+	var localGroupID, clusterGroupID binding.GroupIDType
+	// categorizeEndpoints has checked if localGroup and clusterGroup should exist. We just create the group if its
+	// Endpoints is not nil.
+	// Note that nil represents the group should not exist and empty represents the group should exist but there is
+	// no available Endpoints.
+	if localEndpoints != nil {
+		if localGroupID, ok = p.installServiceGroup(svcPortName, needUpdateEndpoints, true, withSessionAffinity, localEndpoints); !ok {
+			return false
+		}
+	} else {
+		if !p.removeServiceGroup(svcPortName, true) {
+			return false
+		}
+	}
+	if clusterEndpoints != nil {
+		if clusterGroupID, ok = p.installServiceGroup(svcPortName, needUpdateEndpoints, false, withSessionAffinity, clusterEndpoints); !ok {
+			return false
+		}
+	} else {
+		if !p.removeServiceGroup(svcPortName, false) {
+			return false
+		}
+	}
+
+	if needUpdateService {
+		// Delete previous flows.
+		if pSvcInfo != nil {
+			if !p.removeServiceFlows(pSvcInfo) {
+				return false
+			}
+		}
+		if !p.installServiceFlows(svcInfo, localGroupID, clusterGroupID) {
+			return false
+		}
+	} else if needUpdateServiceExternalAddresses {
+		if !p.updateServiceExternalAddresses(pSvcInfo, svcInfo, localGroupID, clusterGroupID) {
+			return false
+		}
+	}
+	if needCleanupStaleUDPServiceConntrack {
+		if !p.removeStaleConntrackEntries(svcPortName, pSvcInfo, svcInfo, staleEndpoints) {
+			return false
+		}
+	}
+
+	// The Service and all of its Endpoints, groups and flows have been installed successfully. Update the
+	// installed Endpoints and Service together, at this single point, so the recorded state never runs
+	// ahead of OVS: if any step above had failed and returned false, none of it is recorded and the next
+	// sync recomputes the diff and retries.
+	p.updateEndpointsStates(svcPortName, svcInfo.OFProtocol, newEndpoints, staleEndpoints)
+	p.serviceInstalledMap[svcPortName] = svcPort
+	return true
 }
 
 // getLoadBalancerMode returns the default load balancer mode if the Service doesn't have the annotation overriding it.
@@ -1001,8 +1067,14 @@ func (p *proxier) syncProxyRules() error {
 	p.endpointsChanges.Update(p.endpointsMap)
 	p.serviceChanges.Update(p.serviceMap)
 
-	p.removeStaleServices()
-	p.installServices()
+	// Both steps program the OVS data path and can fail transiently (e.g. a bundle reply timing out). Each
+	// reports whether any Service could not be fully synced; we aggregate that and turn it into an error at
+	// the end of syncProxyRules so the runner retries sooner (retryInterval), instead of leaving the
+	// affected Services stale until the next Service/Endpoint event or the maxInterval resync. Both are
+	// always run; a failure in one must not skip the other.
+	removalSuccess := p.removeStaleServices()
+	installSuccess := p.installServices()
+	syncSuccess := removalSuccess && installSuccess
 
 	if p.healthzServer != nil {
 		p.healthzServer.Updated(p.ipFamily)
@@ -1028,10 +1100,20 @@ func (p *proxier) syncProxyRules() error {
 		metrics.EndpointsInstalledTotal.Set(float64(counter))
 	}
 
+	// syncedOnce is a best-effort readiness signal, set once a sync pass has run, even if some Services
+	// failed. It only means "the proxier has made its first attempt", not "every Service is programmed":
+	// the agent uses it to gate Service-dependent components at startup, and gating that on every Service
+	// succeeding would let a single persistently-failing Service block agent startup indefinitely. Any
+	// Service that failed here is retried by the runner via the error returned below.
 	p.syncedOnceMutex.Lock()
 	defer p.syncedOnceMutex.Unlock()
 	p.syncedOnce = true
 
+	if !syncSuccess {
+		// The specific failures were already logged by removeStaleServices/installServices; this only
+		// triggers the retry.
+		return fmt.Errorf("one or more Services could not be fully synced")
+	}
 	return nil
 }
 

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -3359,7 +3359,9 @@ func TestServicesWithSameEndpoints(t *testing.T) {
 	mockOFClient.EXPECT().InstallServiceGroup(groupID1, false, gomock.Any())
 	mockOFClient.EXPECT().InstallServiceGroup(groupID2, false, gomock.Any())
 	protocol := binding.ProtocolTCP
-	mockOFClient.EXPECT().InstallEndpointFlows(protocol, gomock.Any())
+	// Both Services pass the shared Endpoint to the OpenFlow client, which deduplicates the actual
+	// flow installation based on its own flow cache.
+	mockOFClient.EXPECT().InstallEndpointFlows(protocol, gomock.Any()).Times(2)
 	mockOFClient.EXPECT().InstallServiceFlows(&antreatypes.ServiceConfig{
 		ServiceIP:      svc1IPv4,
 		ServicePort:    uint16(svcPort),
@@ -4119,4 +4121,181 @@ func TestIPToServiceMap(t *testing.T) {
 
 	m.delete(serviceInfo)
 	assert.Len(t, m.serviceStringMap, 0)
+}
+
+func TestServiceSyncRetriesAfterTransientFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockOFClient, mockRouteClient := getMockClients(ctrl)
+	groupAllocator := openflow.NewGroupAllocator()
+	fp := newFakeProxier(mockRouteClient, mockOFClient, nil, groupAllocator, false)
+
+	svcIP := svc1IP(false)
+	ep1 := ep1IP(false)
+	ep2 := ep2IP(false)
+	// endpointsInstalledMap is keyed by Endpoint.String(), which is "IP:port".
+	epKey := func(ip net.IP) string { return fmt.Sprintf("%s:%d", ip.String(), svcPort) }
+	internalTrafficPolicy := corev1.ServiceInternalTrafficPolicyCluster
+	svc := makeTestClusterIPService(&svcPortName, svcIP, nil, int32(svcPort), corev1.ProtocolTCP, nil, &internalTrafficPolicy, false, nil)
+	makeServiceMap(fp, svc)
+
+	ep1EP, epPort := makeTestEndpointSliceEndpointAndPort(&svcPortName, ep1, int32(svcPort), corev1.ProtocolTCP, false)
+	ep2EP, _ := makeTestEndpointSliceEndpointAndPort(&svcPortName, ep2, int32(svcPort), corev1.ProtocolTCP, false)
+	// Reuse the same EndpointSlice (same name) so the second update replaces ep1 with ep2 instead of
+	// being treated as a separate slice (makeTestEndpointSlice randomizes the name).
+	slice := makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, []discovery.Endpoint{*ep1EP}, []discovery.EndpointPort{*epPort}, false)
+	sliceEp2 := slice.DeepCopy()
+	sliceEp2.Endpoints = []discovery.Endpoint{*ep2EP}
+
+	// The Endpoint flows and Service flows are not the subject of this test; allow them freely.
+	mockOFClient.EXPECT().InstallEndpointFlows(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockOFClient.EXPECT().UninstallEndpointFlows(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockOFClient.EXPECT().InstallServiceFlows(gomock.Any()).Return(nil).AnyTimes()
+	// The cluster group is (re)installed on every sync; the second one (the update to ep2) fails.
+	gomock.InOrder(
+		mockOFClient.EXPECT().InstallServiceGroup(binding.GroupIDType(1), false, gomock.Any()).Return(nil),                                   // initial install with ep1
+		mockOFClient.EXPECT().InstallServiceGroup(binding.GroupIDType(1), false, gomock.Any()).Return(fmt.Errorf("bundle reply is timeout")), // update to ep2 fails
+		mockOFClient.EXPECT().InstallServiceGroup(binding.GroupIDType(1), false, gomock.Any()).Return(nil),                                   // retry succeeds
+	)
+
+	// Initial install with ep1 succeeds.
+	makeEndpointSliceMap(fp, slice)
+	require.NoError(t, fp.syncProxyRules())
+	require.Contains(t, fp.endpointsInstalledMap[svcPortName], epKey(ep1))
+
+	// Endpoints change ep1 -> ep2, but the group update fails. syncProxyRules must report the error, and
+	// the installed-Endpoint state must NOT advance (still ep1), so the next sync recomputes the diff.
+	fp.endpointsChanges.OnEndpointSliceUpdate(sliceEp2, false)
+	err := fp.syncProxyRules()
+	assert.Error(t, err, "a transient group failure must be reported so the runner retries")
+	assert.Contains(t, fp.endpointsInstalledMap[svcPortName], epKey(ep1), "installed state must not advance on failure")
+	assert.NotContains(t, fp.endpointsInstalledMap[svcPortName], epKey(ep2), "installed state must not advance on failure")
+
+	// Next sync (OVS recovered): the persisted diff is retried and the Service converges to ep2.
+	err = fp.syncProxyRules()
+	assert.NoError(t, err)
+	assert.Contains(t, fp.endpointsInstalledMap[svcPortName], epKey(ep2), "the Service must converge to the new Endpoint after recovery")
+	assert.NotContains(t, fp.endpointsInstalledMap[svcPortName], epKey(ep1))
+}
+
+// TestStaleServiceRemovalRetriesAfterTransientFailure verifies the mirror case: when uninstalling an
+// expired Service transiently fails, syncProxyRules reports the error and the Service stays recorded so it
+// is retried, then is fully removed once the operation succeeds.
+func TestStaleServiceRemovalRetriesAfterTransientFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockOFClient, mockRouteClient := getMockClients(ctrl)
+	groupAllocator := openflow.NewGroupAllocator()
+	fp := newFakeProxier(mockRouteClient, mockOFClient, nil, groupAllocator, false)
+
+	svcIP := svc1IP(false)
+	epIP := ep1IP(false)
+	internalTrafficPolicy := corev1.ServiceInternalTrafficPolicyCluster
+	svc := makeTestClusterIPService(&svcPortName, svcIP, nil, int32(svcPort), corev1.ProtocolTCP, nil, &internalTrafficPolicy, false, nil)
+	makeServiceMap(fp, svc)
+	ep, port := makeTestEndpointSliceEndpointAndPort(&svcPortName, epIP, int32(svcPort), corev1.ProtocolTCP, false)
+	eps := makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, []discovery.Endpoint{*ep}, []discovery.EndpointPort{*port}, false)
+	makeEndpointSliceMap(fp, eps)
+
+	mockOFClient.EXPECT().InstallEndpointFlows(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockOFClient.EXPECT().InstallServiceGroup(gomock.Any(), false, gomock.Any()).Return(nil).AnyTimes()
+	mockOFClient.EXPECT().InstallServiceFlows(gomock.Any()).Return(nil).AnyTimes()
+	mockOFClient.EXPECT().UninstallEndpointFlows(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Return(nil).AnyTimes()
+	// The ClusterIP flow uninstall fails the first time, then succeeds.
+	gomock.InOrder(
+		mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), gomock.Any()).Return(fmt.Errorf("bundle reply is timeout")),
+		mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), gomock.Any()).Return(nil),
+	)
+
+	// Install the Service.
+	require.NoError(t, fp.syncProxyRules())
+	require.Contains(t, fp.serviceInstalledMap, svcPortName)
+
+	// Delete the Service, but the removal transiently fails. The error must be reported, and the Service
+	// must stay in serviceInstalledMap so removeStaleServices retries it.
+	fp.serviceChanges.OnServiceUpdate(svc, nil)
+	fp.endpointsChanges.OnEndpointSliceUpdate(eps, true)
+	err := fp.syncProxyRules()
+	assert.Error(t, err, "a transient removal failure must be reported so the runner retries")
+	assert.Contains(t, fp.serviceInstalledMap, svcPortName, "a Service that failed to be removed must stay recorded for retry")
+
+	// Next sync: the removal is retried and succeeds.
+	err = fp.syncProxyRules()
+	assert.NoError(t, err)
+	assert.NotContains(t, fp.serviceInstalledMap, svcPortName, "the Service must be fully removed after recovery")
+	assert.NotContains(t, fp.endpointsInstalledMap, svcPortName)
+}
+
+// TestSharedEndpointReinstalledAfterPeerServiceFailure verifies that when two Services share an Endpoint,
+// a failed sync of one Service cannot make the other Service skip a needed Endpoint flow installation.
+// Scenario: Service A is the only user of the Endpoint and uninstalls its flows, then fails in a later
+// step, so its reference count is not committed and stays 1. Service B then adds the same Endpoint; it
+// must reinstall the flows even though the stale count suggests they exist.
+func TestSharedEndpointReinstalledAfterPeerServiceFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockOFClient, mockRouteClient := getMockClients(ctrl)
+	groupAllocator := openflow.NewGroupAllocator()
+	fp := newFakeProxier(mockRouteClient, mockOFClient, nil, groupAllocator, false)
+
+	epIP := ep1IP(false)
+	internalTrafficPolicy := corev1.ServiceInternalTrafficPolicyCluster
+	svcAPortName := svcPortName
+	svcBPortName := makeSvcPortName("ns", "svc2", strconv.Itoa(svcPort), corev1.ProtocolTCP)
+	svcA := makeTestClusterIPService(&svcAPortName, svc1IP(false), nil, int32(svcPort), corev1.ProtocolTCP, nil, &internalTrafficPolicy, false, nil)
+	svcB := makeTestClusterIPService(&svcBPortName, net.ParseIP("10.20.30.42"), nil, int32(svcPort), corev1.ProtocolTCP, nil, &internalTrafficPolicy, false, nil)
+
+	epA, portA := makeTestEndpointSliceEndpointAndPort(&svcAPortName, epIP, int32(svcPort), corev1.ProtocolTCP, false)
+	sliceA := makeTestEndpointSlice(svcAPortName.Namespace, svcAPortName.Name, []discovery.Endpoint{*epA}, []discovery.EndpointPort{*portA}, false)
+	sliceAEmpty := sliceA.DeepCopy()
+	sliceAEmpty.Endpoints = nil
+	epB, portB := makeTestEndpointSliceEndpointAndPort(&svcBPortName, epIP, int32(svcPort), corev1.ProtocolTCP, false)
+	sliceB := makeTestEndpointSlice(svcBPortName.Namespace, svcBPortName.Name, []discovery.Endpoint{*epB}, []discovery.EndpointPort{*portB}, false)
+
+	mockOFClient.EXPECT().InstallServiceFlows(gomock.Any()).Return(nil).AnyTimes()
+	// The shared Endpoint flows must be passed to the OpenFlow client exactly twice: once for Service A,
+	// and once more for Service B after Service A's failed sync had uninstalled them without committing
+	// its state. If the decision were made on the stale reference count (1), Service B would skip the
+	// second installation and reference absent flows.
+	mockOFClient.EXPECT().InstallEndpointFlows(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	// The uninstallation happens in the failed sync, and may be repeated by Service A's retry before
+	// Service B is processed, which the real OpenFlow client skips based on its flow cache.
+	mockOFClient.EXPECT().UninstallEndpointFlows(gomock.Any(), gomock.Any()).Return(nil).MinTimes(1).MaxTimes(2)
+	// Service A's group (ID 1): initial install succeeds, then the update after dropping the Endpoint
+	// keeps failing for two syncs, and finally succeeds.
+	gomock.InOrder(
+		mockOFClient.EXPECT().InstallServiceGroup(binding.GroupIDType(1), false, gomock.Any()).Return(nil),
+		mockOFClient.EXPECT().InstallServiceGroup(binding.GroupIDType(1), false, gomock.Any()).Return(fmt.Errorf("bundle reply is timeout")),
+		mockOFClient.EXPECT().InstallServiceGroup(binding.GroupIDType(1), false, gomock.Any()).Return(fmt.Errorf("bundle reply is timeout")),
+		mockOFClient.EXPECT().InstallServiceGroup(binding.GroupIDType(1), false, gomock.Any()).Return(nil),
+	)
+	// Service B's group (ID 2).
+	mockOFClient.EXPECT().InstallServiceGroup(binding.GroupIDType(2), false, gomock.Any()).Return(nil).AnyTimes()
+
+	epKey := fmt.Sprintf("%s:%d", epIP.String(), svcPort)
+	ovsKey := endpointKey(makeTestEndpointInfo(epIP.String(), svcPort, false, true, true, false, nil, nil), binding.ProtocolTCP)
+
+	// Sync 1: Service A with the Endpoint is installed.
+	makeServiceMap(fp, svcA)
+	makeEndpointSliceMap(fp, sliceA)
+	require.NoError(t, fp.syncProxyRules())
+	require.Contains(t, fp.endpointsInstalledMap[svcAPortName], epKey)
+
+	// Sync 2: Service A drops the Endpoint. The flows are uninstalled (count is 1), but the group update
+	// fails, so Service A's state is not committed and the count stays 1.
+	fp.endpointsChanges.OnEndpointSliceUpdate(sliceAEmpty, false)
+	require.Error(t, fp.syncProxyRules())
+	assert.Equal(t, 1, fp.endpointReferenceCounter[ovsKey], "the count must not be committed on failure")
+
+	// Sync 3: Service B is added with the same Endpoint while Service A is still failing. Service B must
+	// reinstall the Endpoint flows (the second InstallEndpointFlows call expected above).
+	fp.serviceChanges.OnServiceUpdate(nil, svcB)
+	makeEndpointSliceMap(fp, sliceB)
+	require.Error(t, fp.syncProxyRules(), "Service A is still failing")
+	assert.Contains(t, fp.endpointsInstalledMap[svcBPortName], epKey)
+
+	// Sync 4: Service A recovers and commits its removal. The count must end at 1 (Service B), and the
+	// flows must remain installed.
+	require.NoError(t, fp.syncProxyRules())
+	assert.NotContains(t, fp.endpointsInstalledMap[svcAPortName], epKey)
+	assert.Contains(t, fp.endpointsInstalledMap[svcBPortName], epKey)
+	assert.Equal(t, 1, fp.endpointReferenceCounter[ovsKey])
 }


### PR DESCRIPTION
Cherry pick of #8206 on release-2.5.

#8206: Retry AntreaProxy Service sync on transient failures (#8206)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.