### PR TITLE
Check error returned by file lock acquisition in host-local GC

### DIFF
--- a/pkg/agent/cniserver/ipam/hostlocal/gc.go
+++ b/pkg/agent/cniserver/ipam/hostlocal/gc.go
@@ -35,6 +35,19 @@ func networkDir(network string) string {
 	return filepath.Join(dataDir, network)
 }
 
+// fileLock is the subset of *disk.FileLock used to synchronize access to the host-local IPAM data
+// directory. It is defined as an interface so that it can be faked by tests.
+type fileLock interface {
+	Lock() error
+	Unlock() error
+	Close() error
+}
+
+// newFileLock is a variable so it can be overridden by tests if needed
+var newFileLock = func(dir string) (fileLock, error) {
+	return disk.NewFileLock(dir)
+}
+
 // This is a hacky approach as we access the internals of the host-local plugin,
 // instead of using the CNI interface. However, crafting a CNI DEL request from
 // scratch would also be hacky.
@@ -50,15 +63,20 @@ func GarbageCollectContainerIPs(network string, desiredIPs sets.Set[string]) err
 		return err
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("path '%s' is not a directory: %w", dir, err)
+		return fmt.Errorf("path '%s' is not a directory", dir)
 	}
 
-	lk, err := disk.NewFileLock(dir)
+	lk, err := newFileLock(dir)
 	if err != nil {
 		return err
 	}
 	defer lk.Close()
-	lk.Lock()
+	// If we cannot acquire the lock, we must not proceed: without mutual exclusion, we could
+	// delete a reservation file for an IP which is being allocated concurrently by the
+	// host-local plugin, and the same IP could then be assigned to a second Pod.
+	if err := lk.Lock(); err != nil {
+		return fmt.Errorf("failed to acquire lock on host-local IPAM data directory '%s': %w", dir, err)
+	}
 	defer lk.Unlock()
 
 	fs := afero.NewOsFs()

--- a/pkg/agent/cniserver/ipam/hostlocal/gc_test.go
+++ b/pkg/agent/cniserver/ipam/hostlocal/gc_test.go
@@ -61,6 +61,26 @@ func (fs *testFs) removedIPs() sets.Set[string] {
 	return s
 }
 
+type fakeFileLock struct {
+	lockError error
+	unlocked  bool
+	closed    bool
+}
+
+func (l *fakeFileLock) Lock() error {
+	return l.lockError
+}
+
+func (l *fakeFileLock) Unlock() error {
+	l.unlocked = true
+	return nil
+}
+
+func (l *fakeFileLock) Close() error {
+	l.closed = true
+	return nil
+}
+
 // from https://github.com/containernetworking/plugins/blob/38f18d26ecfef550b8bac02656cc11103fd7cff1/plugins/ipam/host-local/backend/disk/backend.go#L197
 func getEscapedPath(dir string, fname string) string {
 	if runtime.GOOS == "windows" {
@@ -227,5 +247,32 @@ func TestGarbageCollectContainerIPs(t *testing.T) {
 		// make sure that the lock file is created in the right place
 		require.NoError(t, GarbageCollectContainerIPs(network, ips))
 		assert.FileExists(t, lockFile(network))
+	})
+
+	t.Run("lock acquisition error", func(t *testing.T) {
+		network := networkName()
+		netDir := filepath.Join(tempDir, network)
+		require.NoError(t, os.Mkdir(netDir, 0o755))
+		defer os.RemoveAll(netDir)
+		fs := afero.NewOsFs()
+		// this IP is not in desiredIPs, so it would be released if GC ran
+		allocateIPs(t, fs, netDir, "10.0.0.1")
+
+		savedNewFileLock := newFileLock
+		defer func() {
+			newFileLock = savedNewFileLock
+		}()
+		lk := &fakeFileLock{lockError: fmt.Errorf("bad file descriptor")}
+		newFileLock = func(dir string) (fileLock, error) {
+			return lk, nil
+		}
+
+		// GC must not run without the lock, otherwise it could release an IP which is
+		// being allocated concurrently by the host-local plugin.
+		assert.ErrorContains(t, GarbageCollectContainerIPs(network, ips), "failed to acquire lock")
+		assert.FileExists(t, getEscapedPath(netDir, "10.0.0.1"))
+		// we should never release a lock that we failed to acquire
+		assert.False(t, lk.unlocked, "Unlock should not be called when Lock fails")
+		assert.True(t, lk.closed, "Close should always be called")
 	})
 }


### PR DESCRIPTION
`GarbageCollectContainerIPs` discarded the `error` returned by `FileLock.Lock()`, so a failure to acquire the lock on the host-local IPAM data directory was indistinguishable from success, and GC would go on to delete IP reservation files without mutual exclusion against a concurrent host-local allocation. We now return an error in that case, and no longer release a lock we never acquired.

I want to be upfront that this is hardening, not a fix for something users are hitting:

* `FileLock.Lock()` is `flock(fd, LOCK_EX)` with no `LOCK_NB`, so contention **blocks** rather than failing. A concurrent holder can never trigger the discarded error.
* The remaining errnos are essentially unreachable on a healthy Node: `EBADF`/`EINVAL` are ruled out because the fd comes from a successful `open()`, and `EINTR` does not surface because Go installs its signal handlers with `SA_RESTART` and `flock()` is restartable. That leaves `ENOLCK` (kernel out of lock records) on a Node already in severe memory exhaustion.
* Even then, GC runs from `CNIServer.Initialize`, which completes before `Run` binds the CNI socket, so no CNI ADD is being served by the process at that point.

### Note on upstream behavior

Our locking code follows the upstream host-local plugin, and upstream discards this same error at every call site: `IPAllocator.Get` and `IPAllocator.Release` (`backend/allocator/allocator.go`), and `Store.FindByID` (`backend/disk/backend.go`). `backend.Store` declares `Lock() error` in its interface and no caller checks it.

That means this change cannot actually restore mutual exclusion: if `flock` ever genuinely failed, host-local's own allocation path would proceed unlocked regardless. What it does is make our side fail closed. Of the two racers, ours is the destructive one — it deletes reservation files — so it seems like the right one to abort, which is the trade-off documented in #8240: an IP kept while unused is reclaimed later, while an IP released while in-use leaves 2 Pods sharing an address until an operator intervenes.

Reviewers may reasonably prefer to keep matching upstream instead, or to log the failure and continue rather than returning an error. Happy to go either way.

### Behavior change

On a Node where the filesystem backing `/var/lib/cni` does not support `flock` (some FUSE mounts return `EOPNOTSUPP`), the agent will now fail `Initialize` and crash-loop, where previously it would silently GC without the lock. Note that host-local IPAM itself would keep working on such a Node, so this makes antrea-agent stricter than the plugin it delegates to.

### Misc

Also drops a `%w` verb that always wrapped a `nil` error (that branch is only reachable when `os.Stat` succeeded), which rendered as `path '...' is not a directory: %!w(<nil>)`.

Since `flock` failures cannot be provoked from a test, a small `fileLock` interface and a `newFileLock` variable were introduced so the test can inject an acquisition failure, following the existing `dataDir` override idiom in this file. The new test verifies that the error is surfaced, that the reservation file is left in place, and that `Unlock` is not called.