### PR TITLE
Fix error message in host-local IPAM GC

### DIFF
--- a/pkg/agent/cniserver/ipam/hostlocal/gc.go
+++ b/pkg/agent/cniserver/ipam/hostlocal/gc.go
@@ -50,7 +50,7 @@ func GarbageCollectContainerIPs(network string, desiredIPs sets.Set[string]) err
 		return err
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("path '%s' is not a directory: %w", dir, err)
+		return fmt.Errorf("path '%s' is not a directory", dir)
 	}
 
 	lk, err := disk.NewFileLock(dir)
@@ -58,6 +58,13 @@ func GarbageCollectContainerIPs(network string, desiredIPs sets.Set[string]) err
 		return err
 	}
 	defer lk.Close()
+	// We ignore the error returned by Lock(), to stay consistent with the host-local plugin
+	// itself, which ignores it at every call site (IPAllocator.Get, IPAllocator.Release,
+	// Store.FindByID). Checking it here would not restore mutual exclusion: if the flock ever
+	// failed, the plugin's own allocation path would keep running unlocked anyway. It is also
+	// hard to reach in practice, as Lock() blocks when the lock is held by someone else,
+	// instead of returning an error. We may want to revisit this if the plugin starts handling
+	// these errors.
 	lk.Lock()
 	defer lk.Unlock()
 

--- a/pkg/agent/cniserver/ipam/hostlocal/gc_test.go
+++ b/pkg/agent/cniserver/ipam/hostlocal/gc_test.go
@@ -216,7 +216,7 @@ func TestGarbageCollectContainerIPs(t *testing.T) {
 		_, err := os.Create(netDir)
 		require.NoError(t, err)
 		defer os.Remove(netDir)
-		assert.ErrorContains(t, GarbageCollectContainerIPs(network, ips), "not a directory")
+		assert.EqualError(t, GarbageCollectContainerIPs(network, ips), fmt.Sprintf("path '%s' is not a directory", netDir))
 	})
 
 	t.Run("lock file created", func(t *testing.T) {


### PR DESCRIPTION
Two small changes to `GarbageCollectContainerIPs`, both cosmetic / documentation.

**1. Error formatter.** The `!info.IsDir()` branch is only reachable when `os.Stat` succeeded, so the `%w` verb always wrapped a `nil` error:

```
path '/var/lib/cni/networks/antrea' is not a directory: %!w(<nil>)
```

The verb is dropped, and the existing test now asserts on the exact message rather than a substring, so this cannot regress.

**2. Comment on the ignored `Lock()` error.** `disk.FileLock.Lock()` returns an `error` which we discard. That looks like an oversight on a code path that deletes IP reservation files, and it is worth documenting why it is deliberate instead of leaving the next reader (or reviewer, or static analyzer) to redo the analysis:

* The host-local plugin ignores this same error at every one of its own call sites: `IPAllocator.Get`, `IPAllocator.Release` (`backend/allocator/allocator.go`) and `Store.FindByID` (`backend/disk/backend.go`). `backend.Store` even declares `Lock() error` in its interface with no caller checking it. So returning an error here would not restore mutual exclusion — if the `flock` ever failed, the plugin's own allocation path would keep running unlocked regardless.
* `Lock()` is `flock(fd, LOCK_EX)` with no `LOCK_NB`, so it blocks when the lock is held by someone else rather than returning an error. The remaining errnos are close to unreachable: `EBADF`/`EINVAL` are ruled out by the successful `open()`, `EINTR` does not surface because Go sets `SA_RESTART` and `flock()` is restartable, leaving `ENOLCK` on a Node already out of memory.

I did prototype the stricter version (returning an error on lock failure), but it makes antrea-agent crash-loop on Nodes where host-local IPAM itself would keep working, which is not a good trade for an unreachable error. The comment notes we may want to revisit if upstream starts handling these.

No functional change.