### PR TITLE
Skip export of aggregated records with no new data

### DIFF
--- a/build/charts/flow-aggregator/conf/flow-aggregator.conf
+++ b/build/charts/flow-aggregator/conf/flow-aggregator.conf
@@ -9,14 +9,23 @@ mode: {{ .Values.mode }}
 # collector. Thus, for flows with a continuous stream of packets, a flow record
 # will be exported to the collector once the elapsed time since the last export
 # event in the flow aggregator is equal to the value of this timeout.
+# Note that a record is only exported if a matching flow record has been
+# received from an Antrea Agent since the last export, hence this timeout is
+# only honored as long as it is not smaller than the Agent's
+# activeFlowExportTimeout ("5s" by default), which is the case with the
+# default configuration.
 # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 # Values under 1s are not supported; they will be rounded up to 1s.
 activeFlowRecordTimeout: {{ .Values.activeFlowRecordTimeout }}
 
 # Provide the inactive flow record timeout as a duration string. This determines
-# how often the flow aggregator exports the inactive flow records to the flow
-# collector. A flow record is considered to be inactive if no matching record
-# has been received by the flow aggregator in the specified interval.
+# how long the flow aggregator retains the aggregated record for a flow after the
+# last matching record was received: once this timeout expires, the aggregated
+# record is deleted, and a subsequent record for the same flow starts a new
+# aggregation. When this timeout is greater than activeFlowRecordTimeout (which is
+# the case by default), the deletion never causes a record to be exported, as any
+# new data has already been exported when the active flow record timeout last
+# expired.
 # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 # Values under 1s are not supported; they will be rounded up to 1s.
 inactiveFlowRecordTimeout: {{ .Values.inactiveFlowRecordTimeout }}

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -63,14 +63,23 @@ data:
     # collector. Thus, for flows with a continuous stream of packets, a flow record
     # will be exported to the collector once the elapsed time since the last export
     # event in the flow aggregator is equal to the value of this timeout.
+    # Note that a record is only exported if a matching flow record has been
+    # received from an Antrea Agent since the last export, hence this timeout is
+    # only honored as long as it is not smaller than the Agent's
+    # activeFlowExportTimeout ("5s" by default), which is the case with the
+    # default configuration.
     # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
     # Values under 1s are not supported; they will be rounded up to 1s.
     activeFlowRecordTimeout: 60s
 
     # Provide the inactive flow record timeout as a duration string. This determines
-    # how often the flow aggregator exports the inactive flow records to the flow
-    # collector. A flow record is considered to be inactive if no matching record
-    # has been received by the flow aggregator in the specified interval.
+    # how long the flow aggregator retains the aggregated record for a flow after the
+    # last matching record was received: once this timeout expires, the aggregated
+    # record is deleted, and a subsequent record for the same flow starts a new
+    # aggregation. When this timeout is greater than activeFlowRecordTimeout (which is
+    # the case by default), the deletion never causes a record to be exported, as any
+    # new data has already been exported when the active flow record timeout last
+    # expired.
     # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
     # Values under 1s are not supported; they will be rounded up to 1s.
     inactiveFlowRecordTimeout: 90s
@@ -502,7 +511,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: ed62168da05afbc792870d32ef80dcab8c1828ff45a1e0b538b80a0a728abf28
+        checksum/config: f71fbd0d92fc3b25611d5c783f34b6b0da759525e303c3be24571a1bea95f0b4
       labels:
         app: flow-aggregator
     spec:

--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -374,13 +374,22 @@ flow-aggregator.conf: |
   # collector. Thus, for flows with a continuous stream of packets, a flow record
   # will be exported to the collector once the elapsed time since the last export
   # event in the flow aggregator is equal to the value of this timeout.
+  # Note that a record is only exported if a matching flow record has been
+  # received from an Antrea Agent since the last export, hence this timeout is
+  # only honored as long as it is not smaller than the Agent's
+  # activeFlowExportTimeout ("5s" by default), which is the case with the
+  # default configuration.
   # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
   activeFlowRecordTimeout: 60s
 
   # Provide the inactive flow record timeout as a duration string. This determines
-  # how often the flow aggregator exports the inactive flow records to the flow
-  # collector. A flow record is considered to be inactive if no matching record
-  # has been received by the flow aggregator in the specified interval.
+  # how long the flow aggregator retains the aggregated record for a flow after the
+  # last matching record was received: once this timeout expires, the aggregated
+  # record is deleted, and a subsequent record for the same flow starts a new
+  # aggregation. When this timeout is greater than activeFlowRecordTimeout (which is
+  # the case by default), the deletion never causes a record to be exported, as any
+  # new data has already been exported when the active flow record timeout last
+  # expired.
   # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
   inactiveFlowRecordTimeout: 90s
 

--- a/pkg/config/flowaggregator/config.go
+++ b/pkg/config/flowaggregator/config.go
@@ -42,13 +42,22 @@ type FlowAggregatorConfig struct {
 	// collector. Thus, for flows with a continuous stream of packets, a flow record
 	// will be exported to the collector once the elapsed time since the last export
 	// event in the flow aggregator is equal to the value of this timeout.
+	// Note that a record is only exported if a matching flow record has been
+	// received from an Antrea Agent since the last export, hence this timeout is
+	// only honored as long as it is not smaller than the Agent's
+	// activeFlowExportTimeout ("5s" by default), which is the case with the
+	// default configuration.
 	// Defaults to "60s". Valid time units are "ns", "us" (or "µs"), "ms", "s",
 	// "m", "h". Values under 1s are not supported; they will be rounded up to 1s.
 	ActiveFlowRecordTimeout string `yaml:"activeFlowRecordTimeout,omitempty"`
 	// Provide the inactive flow record timeout as a duration string. This determines
-	// how often the flow aggregator exports the inactive flow records to the flow
-	// collector. A flow record is considered to be inactive if no matching record
-	// has been received by the flow aggregator in the specified interval.
+	// how long the flow aggregator retains the aggregated record for a flow after the
+	// last matching record was received: once this timeout expires, the aggregated
+	// record is deleted, and a subsequent record for the same flow starts a new
+	// aggregation. When this timeout is greater than activeFlowRecordTimeout (which is
+	// the case by default), the deletion never causes a record to be exported, as any
+	// new data has already been exported when the active flow record timeout last
+	// expired.
 	// Defaults to "90s". Valid time units are "ns", "us" (or "µs"), "ms", "s",
 	// "m", "h". Values under 1s are not supported; they will be rounded up to 1s.
 	InactiveFlowRecordTimeout string `yaml:"inactiveFlowRecordTimeout,omitempty"`

--- a/pkg/flowaggregator/intermediate/aggregate.go
+++ b/pkg/flowaggregator/intermediate/aggregate.go
@@ -275,9 +275,25 @@ func (a *aggregationProcess) ForAllExpiredFlowRecordsDo(callback FlowKeyRecordMa
 			}
 			continue
 		}
-		err := callback(*pqItem.flowKey, pqItem.flowRecord)
-		if err != nil {
-			return fmt.Errorf("callback execution failed for popped flow record with key: %v, record: %v, error: %v", pqItem.flowKey, pqItem.flowRecord, err)
+		// Only export the record if we have received at least one flow record for this flow
+		// since the last export. Otherwise, the aggregated record is identical to the one we
+		// exported last time, except that all delta counters and throughput values have been
+		// zeroed, so exporting it again would only add noise for consumers. Note that we still
+		// need to run the expiry logic below (re-push or delete), even when the export is
+		// skipped, or the record would be leaked: it would no longer be in the priority queue,
+		// hence it would never be deleted from flowKeyRecordMap.
+		// Note that the flag is set for every received flow record, including one which is
+		// ignored by aggregateRecords because it does not have the latest flowEndSeconds for
+		// its Node (e.g. the last record for a connection, for which flowEndSeconds is the
+		// conntrack stop time, and can predate the last periodic poll). Such a record can
+		// therefore still cause the export of an aggregated record with no new data. We accept
+		// this, as it is a rare occurrence, and detecting it would require aggregateRecords to
+		// report whether it actually updated the aggregated record.
+		if pqItem.flowRecord.updatedSinceLastExport {
+			if err := callback(*pqItem.flowKey, pqItem.flowRecord); err != nil {
+				return fmt.Errorf("callback execution failed for popped flow record with key: %v, record: %v, error: %v", pqItem.flowKey, pqItem.flowRecord, err)
+			}
+			pqItem.flowRecord.updatedSinceLastExport = false
 		}
 
 		// We need to use !expireTime.After(currTime) and not expireTime.Before(currTime) to account for the
@@ -286,7 +302,7 @@ func (a *aggregationProcess) ForAllExpiredFlowRecordsDo(callback FlowKeyRecordMa
 
 		// Delete the flow record if it is expired because of inactive expiry timeout.
 		if !pqItem.inactiveExpireTime.After(currTime) {
-			if err = a.deleteFlowKeyFromMapWithoutLock(*pqItem.flowKey); err != nil {
+			if err := a.deleteFlowKeyFromMapWithoutLock(*pqItem.flowKey); err != nil {
 				return fmt.Errorf("error while deleting flow record after inactive expiry: %v", err)
 			}
 			continue
@@ -359,6 +375,7 @@ func (a *aggregationProcess) addOrUpdateRecordInMap(flowKey *FlowKey, record *fl
 			// flow record with existing record by updating the stats and flow timestamps.
 			a.aggregateRecords(record, aggregationRecord.Record, true, true)
 		}
+		aggregationRecord.updatedSinceLastExport = true
 		// Reset the inactive expiry time in the queue item with updated aggregate record.
 		// If this is the first time we have a "complete" record (ReadyToSend becomes true),
 		// export it right away by setting activeExpireTime to now.
@@ -386,6 +403,7 @@ func (a *aggregationProcess) addOrUpdateRecordInMap(flowKey *FlowKey, record *fl
 			Record:                    record,
 			ReadyToSend:               false,
 			waitForReadyToSendRetries: 0,
+			updatedSinceLastExport:    true,
 			isIPv4:                    isIPv4,
 		}
 

--- a/pkg/flowaggregator/intermediate/aggregate_test.go
+++ b/pkg/flowaggregator/intermediate/aggregate_test.go
@@ -871,6 +871,67 @@ func TestForAllExpiredFlowRecordsDo(t *testing.T) {
 	}
 }
 
+// TestForAllExpiredFlowRecordsDoNoNewRecords verifies that we do not export an aggregation record
+// again when no new flow record has been received for that flow since the last export. Such a
+// record would carry no new information: all delta counters and throughput values are zeroed by
+// ResetStatAndThroughputElementsInRecord after each export. It also verifies that skipping the
+// export does not prevent the record from being expired: it must still be pushed back into the
+// priority queue after active expiry, and deleted from the map after inactive expiry.
+func TestForAllExpiredFlowRecordsDoNoNewRecords(t *testing.T) {
+	input := AggregationInput{
+		RecordChan:            make(chan *flowpb.Flow),
+		WorkerNum:             2,
+		ActiveExpiryTimeout:   testActiveExpiry,
+		InactiveExpiryTimeout: testInactiveExpiry,
+	}
+	startTime := time.Now()
+	clock := clocktesting.NewFakeClock(startTime)
+	ap, err := initAggregationProcessWithClock(input, clock)
+	require.NoError(t, err)
+
+	numExecutions := 0
+	testCallback := func(key FlowKey, record *AggregationFlowRecord) error {
+		numExecutions += 1
+		return nil
+	}
+	addRecord := func(record *flowpb.Flow) {
+		flowKey, isIPv4 := getFlowKeyFromRecord(record)
+		ap.addOrUpdateRecordInMap(flowKey, record, isIPv4)
+	}
+	// runExpiry advances the clock to the provided time and returns the number of records which
+	// were exported.
+	runExpiry := func(t *testing.T, at time.Time) int {
+		clock.SetTime(at)
+		numExecutions = 0
+		require.NoError(t, ap.ForAllExpiredFlowRecordsDo(testCallback))
+		return numExecutions
+	}
+
+	// An intra-Node flow does not require correlation, so the record is ready to send - and is
+	// therefore exported - as soon as it is received.
+	addRecord(createFlowRecordForSrc(false, flowpb.FlowType_FLOW_TYPE_INTRA_NODE, false, flowpb.NetworkPolicyRuleAction_NETWORK_POLICY_RULE_ACTION_NO_ACTION))
+	assert.Equal(t, 1, runExpiry(t, startTime), "record should be exported as soon as it is ready to send")
+
+	// Active expiry, with no record received since the last export: no record should be
+	// exported, but the aggregation record should be pushed back into the priority queue so that
+	// it can be expired later.
+	assert.Equal(t, 0, runExpiry(t, startTime.Add(testActiveExpiry)), "record should not be exported again when there is no new data")
+	assert.Equal(t, 1, ap.expirePriorityQueue.Len())
+	assert.Equal(t, int64(1), ap.GetNumFlows())
+
+	// A new record is received for the same flow, so the next active expiry should export the
+	// aggregation record again.
+	addRecord(createFlowRecordForSrc(false, flowpb.FlowType_FLOW_TYPE_INTRA_NODE, true, flowpb.NetworkPolicyRuleAction_NETWORK_POLICY_RULE_ACTION_NO_ACTION))
+	assert.Equal(t, 1, runExpiry(t, startTime.Add(2*testActiveExpiry)), "record should be exported after receiving new data")
+
+	// Inactive expiry, with no record received since the last export: no record should be
+	// exported, and the aggregation record should be deleted.
+	// Note that the inactive expiry time was reset when the second record was received above.
+	assert.Equal(t, 0, runExpiry(t, startTime.Add(testActiveExpiry+testInactiveExpiry)), "record should not be exported again when there is no new data")
+	assert.Equal(t, 0, ap.expirePriorityQueue.Len())
+	assert.Equal(t, int64(0), ap.GetNumFlows())
+}
+
 func runCorrelationAndCheckResult(t *testing.T, ap *aggregationProcess, clock *clocktesting.FakeClock, record1, record2 *flowpb.Flow, isIPv6 bool, flowType flowpb.FlowType, needsCorrelation bool) {
 	const recordDelay = 10 * time.Millisecond
 	flowKey1, isIPv4 := getFlowKeyFromRecord(record1)

--- a/pkg/flowaggregator/intermediate/types.go
+++ b/pkg/flowaggregator/intermediate/types.go
@@ -35,6 +35,13 @@ type AggregationFlowRecord struct {
 	// inter-node flow and record from the node for the case of intra-node flow.
 	ReadyToSend               bool
 	waitForReadyToSendRetries int
+	// updatedSinceLastExport indicates whether at least one flow record has been received for
+	// this flow since the last time the aggregated record was exported. When it is false, the
+	// aggregated record carries no new information (all delta counters and throughput values
+	// were zeroed by ResetStatAndThroughputElementsInRecord after the last export), so we skip
+	// the export when the record expires. It is set to true when the record is created, as the
+	// record has never been exported at that point.
+	updatedSinceLastExport bool
 	// areCorrelatedFieldsFilled is an indicator for IPFIX Mediator to check whether K8s
 	// metadata are filled for flow record. It is always true for Intra-Node
 	// and ToExternal flows and only applicable for Inter-Node flows that are


### PR DESCRIPTION
In Aggregate mode, the Flow Aggregator exports about two extra records for every flow:

1. one at `last export + activeFlowRecordTimeout` (60s by default), and
2. one at `last record received + inactiveFlowRecordTimeout` (90s by default), just before the flow is deleted from the aggregation map.

These extra records carry no new information: all delta counters and throughput values are zeroed by `ResetStatAndThroughputElementsInRecord` after each export, and the timestamps are unchanged. For consumers displaying flows in tabular form (e.g. through the FlowStreamService), they look like real events for flows which are actually idle.

We now keep track of whether a flow record has been received since the last export, and skip the export when none has. Expiry itself is unchanged: the aggregation record is still pushed back into the priority queue after active expiry, and still deleted after inactive expiry. That part is load-bearing - a skipped record which is not pushed back would never be expired again, and would leak in `flowKeyRecordMap`.

Note that a flag is more precise than checking for zero delta counters: a record can be received with no new bytes but a real change, e.g. a TCP state transition or an updated `flowEndReason`.

Flows with continuous traffic are unaffected, as delta counters are non-zero at every active expiry. Proxy mode is unaffected as it does not use the aggregation process.

The description of `inactiveFlowRecordTimeout` is updated accordingly: as long as it is greater than `activeFlowRecordTimeout` (the case by default), inactive expiry only deletes the aggregated record, and never exports one.

This does not change IPFIX semantics: nothing in RFC 7011 / 7015 requires exporting a record for an interval during which no packet was observed, and the sum of the exported `octetDeltaCount` values for a flow is unchanged, as the suppressed records contributed 0.

One user-visible consequence worth noting: `numRecordsExported` will report lower values, and queries computing an average throughput over the records of a flow will return different results, as the suppressed records contributed a synthetic 0 at a duplicate `flowEndSeconds`. Sums and counters are unaffected.
