### PR TITLE
Fix lost update when programming iptables chains

### DIFF
--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -195,6 +195,12 @@ type Client struct {
 	nodeNeighbors sync.Map
 	// markToSNATIP caches marks to SNAT IPs. It's used in Egress feature.
 	markToSNATIP sync.Map
+	// iptablesMutex serializes the writers of the Antrea-managed iptables chains, so that reading the
+	// state they are rebuilt from and programming them is atomic. syncIPTables snapshots iptablesCache
+	// and markToSNATIP, then programs the chains from that snapshot with iptables-restore, which flushes
+	// them; a writer running in between would have its rules programmed and then flushed back out by the
+	// stale snapshot, and they would stay missing until the next periodic sync.
+	iptablesMutex sync.Mutex
 	// iptablesInitialized is used to notify when iptables initialization is done.
 	iptablesInitialized chan struct{}
 	proxyAll            bool
@@ -1042,6 +1048,12 @@ func (c *Client) syncIPTables(cleanupStaleJumpRules bool) error {
 			}
 		}
 	}
+
+	// The lock is taken here rather than at the top of the function because the jump rules above are
+	// programmed one by one and idempotently, they are not rebuilt from a snapshot. It is held until the
+	// function returns, so that no other writer can program rules which the restores below would flush.
+	c.iptablesMutex.Lock()
+	defer c.iptablesMutex.Unlock()
 
 	snatMarkToIPv4 := map[uint32]net.IP{}
 	snatMarkToIPv6 := map[uint32]net.IP{}
@@ -2245,6 +2257,9 @@ func (c *Client) snatRuleSpec(snatIP net.IP, snatMark uint32) []string {
 }
 
 func (c *Client) AddSNATRule(snatIP net.IP, mark uint32) error {
+	c.iptablesMutex.Lock()
+	defer c.iptablesMutex.Unlock()
+
 	protocol := iptables.ProtocolIPv4
 	if snatIP.To4() == nil {
 		protocol = iptables.ProtocolIPv6
@@ -2254,6 +2269,9 @@ func (c *Client) AddSNATRule(snatIP net.IP, mark uint32) error {
 }
 
 func (c *Client) DeleteSNATRule(mark uint32) error {
+	c.iptablesMutex.Lock()
+	defer c.iptablesMutex.Unlock()
+
 	value, ok := c.markToSNATIP.Load(mark)
 	if !ok {
 		klog.InfoS("Didn't find SNAT rule with mark", "mark", fmt.Sprintf("%#x", mark))
@@ -2878,6 +2896,9 @@ func (c *Client) DeleteNodeNetworkPolicyIPSet(ipsetName string, isIPv6 bool) err
 }
 
 func (c *Client) AddOrUpdateNodeNetworkPolicyIPTables(iptablesChains []string, iptablesRules [][]string, isIPv6 bool) error {
+	c.iptablesMutex.Lock()
+	defer c.iptablesMutex.Unlock()
+
 	iptablesData := bytes.NewBuffer(nil)
 
 	writeLine(iptablesData, "*filter")
@@ -2906,6 +2927,9 @@ func (c *Client) AddOrUpdateNodeNetworkPolicyIPTables(iptablesChains []string, i
 }
 
 func (c *Client) DeleteNodeNetworkPolicyIPTables(iptablesChains []string, isIPv6 bool) error {
+	c.iptablesMutex.Lock()
+	defer c.iptablesMutex.Unlock()
+
 	ipProtocol := iptables.ProtocolIPv4
 	if isIPv6 {
 		ipProtocol = iptables.ProtocolIPv6

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1244,6 +1245,92 @@ COMMIT
 			assert.NoError(t, c.syncIPTables(true))
 		})
 	}
+}
+
+// TestSyncIPTablesDoesNotRevertConcurrentNodeNetworkPolicyUpdate covers the lost update which is
+// possible when the writers of the Antrea-managed chains are not serialized. syncIPTables reads
+// iptablesCache and only programs the chains afterwards, with an iptables-restore which flushes the
+// chains it declares, so rules programmed by another writer in between would be flushed back out and
+// would stay missing until the next periodic sync.
+//
+// The test holds syncIPTables inside its restore, which is where that window is, and runs a
+// NodeNetworkPolicy update while it is held there. Whichever restore completes last decides what is left
+// in the kernel, so it must be the one carrying the rules from the update.
+//
+// The test cannot fail while the writers are serialized, whatever the scheduling: the update goroutine
+// cannot reach its own restore before syncIPTables has released the lock, which it only does once it has
+// returned, so the two restores always complete in that order. The sleep below is therefore not load
+// bearing for a passing run; it only widens the window in which an unserialized update can slip through,
+// so a regression is reported rather than missed. Waiting for the update goroutine to actually block
+// instead of sleeping is not possible: testing/synctest, which exists for that, explicitly does not treat
+// locking a mutex as durably blocking, so a bubble containing that goroutine never quiesces.
+func TestSyncIPTablesDoesNotRevertConcurrentNodeNetworkPolicyUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockIPTables := iptablestest.NewMockInterface(ctrl)
+
+	ingressRulesChain := config.NodeNetworkPolicyIngressRulesChain
+	ruleA := fmt.Sprintf(`-A %s -j ACCEPT -m comment --comment "ruleA"`, ingressRulesChain)
+	ruleB := fmt.Sprintf(`-A %s -j ACCEPT -m comment --comment "ruleB"`, ingressRulesChain)
+
+	var restoredDataMutex sync.Mutex
+	var restoredData []string
+	syncRestoreStarted := make(chan struct{})
+	releaseSyncRestore := make(chan struct{})
+	var firstRestore sync.Once
+
+	mockIPTables.EXPECT().EnsureChain(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockIPTables.EXPECT().AppendRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockIPTables.EXPECT().Restore(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(data string, flush, useIPv6 bool) error {
+			// The first restore is always the one from syncIPTables, as the update is only started
+			// once this has been reached. Hold it here, so that the update runs while the state
+			// syncIPTables is about to program has already gone stale.
+			isFirstRestore := false
+			firstRestore.Do(func() { isFirstRestore = true })
+			if isFirstRestore {
+				close(syncRestoreStarted)
+				<-releaseSyncRestore
+			}
+			restoredDataMutex.Lock()
+			defer restoredDataMutex.Unlock()
+			restoredData = append(restoredData, data)
+			return nil
+		}).AnyTimes()
+
+	c := &Client{
+		networkConfig: &config.NetworkConfig{IPv4Enabled: true},
+		nodeConfig: &config.NodeConfig{
+			GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"},
+			PodIPv4CIDR:   ip.MustParseCIDR("192.168.0.0/24"),
+		},
+		nodeNetworkPolicyEnabled: true,
+		iptables:                 mockIPTables,
+		iptablesCache:            newIPTablesCache(),
+		deterministic:            true,
+	}
+	c.iptablesCache.ipv4[featureNodeNetworkPolicy].Store(ingressRulesChain, []string{ruleA})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, c.syncIPTables(false))
+	}()
+	<-syncRestoreStarted
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, c.AddOrUpdateNodeNetworkPolicyIPTables([]string{ingressRulesChain}, [][]string{{ruleA, ruleB}}, false))
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	close(releaseSyncRestore)
+	wg.Wait()
+
+	require.NotEmpty(t, restoredData)
+	assert.Contains(t, restoredData[len(restoredData)-1], ruleB,
+		"the rules programmed last must be the ones from the NodeNetworkPolicy update, otherwise the update was flushed by state read before it")
 }
 
 func TestInitIPRoutes(t *testing.T) {


### PR DESCRIPTION
Fixes #8285

`syncIPTables` reads `iptablesCache` and `markToSNATIP`, then programs the Antrea-managed chains from that snapshot with `iptables-restore`, which flushes the chains it declares. The writers of those chains were not serialized against it, so a rule programmed in that window was flushed back out by the stale snapshot and stayed missing until the next periodic sync, up to `SyncInterval` (60s) later. A writer removing rules had them resurrected the same way.

The two orders that conflict:

- `syncIPTables` snapshots first, restores second (`route_linux.go:1059-1080` then `1097`).
- `AddOrUpdateNodeNetworkPolicyIPTables` restores first, updates the cache second (`route_linux.go:2894` then `2898-2904`). `DeleteNodeNetworkPolicyIPTables`, `AddSNATRule` and `DeleteSNATRule` have the same shape.

The writes are not on disjoint chains: `ANTREA-POL-{INGRESS,EGRESS}-RULES` are seeded into the cache at init, so they are always keys of the snapshot, and `restoreIptablesData` emits a `:CHAIN - [0:0]` line for every key. `--noflush` only prevents flushing the *table* — a chain declaration still flushes that chain, as documented on `iptables.Restore` itself.

This adds an `iptablesMutex` to the route `Client`, held across the read-and-program sequence in `syncIPTables` and across the program-and-cache sequence in the four writers. The jump rules at the top of `syncIPTables` are deliberately left outside the critical section: they are programmed one by one and idempotently, not rebuilt from a snapshot.

Contention is negligible — the sync runs once a minute and policy and SNAT updates are occasional.

### Scope

The race predates #7803 and is independent of it. #7803 adds a third caller of `syncIPTables` (the Antrea Service `EndpointResolver` worker), which is one more way to reach this, but the periodic sync alone already opens roughly 60 windows an hour. Keeping the fix separate so it can be backported on its own.

### Testing

`TestSyncIPTablesDoesNotRevertConcurrentNodeNetworkPolicyUpdate` holds `syncIPTables` inside its restore and runs a NodeNetworkPolicy update while it is held there, then asserts the rules programmed last are the ones from the update. It fails on the unfixed code and passes with the fix.

The test cannot go red on correct code, whatever the scheduling: the update goroutine cannot reach its own restore before `syncIPTables` has released the lock, which only happens once it has returned, so the two restores always complete in that order. The sleep only widens the window in which an unserialized update can slip through, so a regression is reported rather than missed. Verified over 50 runs under `-race` and 25 runs at each of `GOMAXPROCS` 1, 2 and 8.

Waiting for the update goroutine to block instead of sleeping is not possible: `testing/synctest`, which exists for that, explicitly does not treat locking a mutex as durably blocking, so a bubble containing that goroutine never quiesces. The race detector does not help either — every access is internally synchronized by `sync.Map`, so there is no data race to report, only a lost update.
