### PR TITLE
antctl observe command

### DIFF
--- a/build/charts/antrea/templates/antctl/clusterrole.yaml
+++ b/build/charts/antrea/templates/antctl/clusterrole.yaml
@@ -84,6 +84,14 @@ rules:
       - pods
     verbs:
       - list
+  # "antctl observe" tunnels to the Flow Aggregator Pod through the API server's /portforward
+  # subresource when it has no direct network route to the Pod (see pkg/antctl/raw/observe).
+  - apiGroups:
+      - ""
+    resources:
+      - pods/portforward
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:
@@ -95,9 +103,18 @@ rules:
       - apps
     resources:
       - daemonsets
-      - deployments
       - replicasets
     verbs:
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      # "get" is needed by "antctl observe --flow-aggregator <namespace>/<deployment-name>" (see
+      # findFlowAggregatorByName in pkg/antctl/raw/observe/discovery.go), which resolves a specific
+      # instance by Deployment name rather than by listing and filtering.
+      - get
       - list
   - apiGroups:
       - ""
@@ -108,5 +125,8 @@ rules:
       - antrea-ca
       - antrea-ipsec-ca
       - antrea-cluster-identity
+      # Read by "antctl observe" to verify the Flow Aggregator's TLS certificate (see
+      # pkg/antctl/raw/observe/connect.go).
+      - flow-aggregator-ca
     verbs:
       - get

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -5415,6 +5415,14 @@ rules:
       - pods
     verbs:
       - list
+  # "antctl observe" tunnels to the Flow Aggregator Pod through the API server's /portforward
+  # subresource when it has no direct network route to the Pod (see pkg/antctl/raw/observe).
+  - apiGroups:
+      - ""
+    resources:
+      - pods/portforward
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:
@@ -5426,9 +5434,18 @@ rules:
       - apps
     resources:
       - daemonsets
-      - deployments
       - replicasets
     verbs:
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      # "get" is needed by "antctl observe --flow-aggregator <namespace>/<deployment-name>" (see
+      # findFlowAggregatorByName in pkg/antctl/raw/observe/discovery.go), which resolves a specific
+      # instance by Deployment name rather than by listing and filtering.
+      - get
       - list
   - apiGroups:
       - ""
@@ -5439,6 +5456,9 @@ rules:
       - antrea-ca
       - antrea-ipsec-ca
       - antrea-cluster-identity
+      # Read by "antctl observe" to verify the Flow Aggregator's TLS certificate (see
+      # pkg/antctl/raw/observe/connect.go).
+      - flow-aggregator-ca
     verbs:
       - get
 ---

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -5411,6 +5411,14 @@ rules:
       - pods
     verbs:
       - list
+  # "antctl observe" tunnels to the Flow Aggregator Pod through the API server's /portforward
+  # subresource when it has no direct network route to the Pod (see pkg/antctl/raw/observe).
+  - apiGroups:
+      - ""
+    resources:
+      - pods/portforward
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:
@@ -5422,9 +5430,18 @@ rules:
       - apps
     resources:
       - daemonsets
-      - deployments
       - replicasets
     verbs:
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      # "get" is needed by "antctl observe --flow-aggregator <namespace>/<deployment-name>" (see
+      # findFlowAggregatorByName in pkg/antctl/raw/observe/discovery.go), which resolves a specific
+      # instance by Deployment name rather than by listing and filtering.
+      - get
       - list
   - apiGroups:
       - ""
@@ -5435,6 +5452,9 @@ rules:
       - antrea-ca
       - antrea-ipsec-ca
       - antrea-cluster-identity
+      # Read by "antctl observe" to verify the Flow Aggregator's TLS certificate (see
+      # pkg/antctl/raw/observe/connect.go).
+      - flow-aggregator-ca
     verbs:
       - get
 ---

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -5402,6 +5402,14 @@ rules:
       - pods
     verbs:
       - list
+  # "antctl observe" tunnels to the Flow Aggregator Pod through the API server's /portforward
+  # subresource when it has no direct network route to the Pod (see pkg/antctl/raw/observe).
+  - apiGroups:
+      - ""
+    resources:
+      - pods/portforward
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:
@@ -5413,9 +5421,18 @@ rules:
       - apps
     resources:
       - daemonsets
-      - deployments
       - replicasets
     verbs:
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      # "get" is needed by "antctl observe --flow-aggregator <namespace>/<deployment-name>" (see
+      # findFlowAggregatorByName in pkg/antctl/raw/observe/discovery.go), which resolves a specific
+      # instance by Deployment name rather than by listing and filtering.
+      - get
       - list
   - apiGroups:
       - ""
@@ -5426,6 +5443,9 @@ rules:
       - antrea-ca
       - antrea-ipsec-ca
       - antrea-cluster-identity
+      # Read by "antctl observe" to verify the Flow Aggregator's TLS certificate (see
+      # pkg/antctl/raw/observe/connect.go).
+      - flow-aggregator-ca
     verbs:
       - get
 ---

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -5415,6 +5415,14 @@ rules:
       - pods
     verbs:
       - list
+  # "antctl observe" tunnels to the Flow Aggregator Pod through the API server's /portforward
+  # subresource when it has no direct network route to the Pod (see pkg/antctl/raw/observe).
+  - apiGroups:
+      - ""
+    resources:
+      - pods/portforward
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:
@@ -5426,9 +5434,18 @@ rules:
       - apps
     resources:
       - daemonsets
-      - deployments
       - replicasets
     verbs:
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      # "get" is needed by "antctl observe --flow-aggregator <namespace>/<deployment-name>" (see
+      # findFlowAggregatorByName in pkg/antctl/raw/observe/discovery.go), which resolves a specific
+      # instance by Deployment name rather than by listing and filtering.
+      - get
       - list
   - apiGroups:
       - ""
@@ -5439,6 +5456,9 @@ rules:
       - antrea-ca
       - antrea-ipsec-ca
       - antrea-cluster-identity
+      # Read by "antctl observe" to verify the Flow Aggregator's TLS certificate (see
+      # pkg/antctl/raw/observe/connect.go).
+      - flow-aggregator-ca
     verbs:
       - get
 ---

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -5402,6 +5402,14 @@ rules:
       - pods
     verbs:
       - list
+  # "antctl observe" tunnels to the Flow Aggregator Pod through the API server's /portforward
+  # subresource when it has no direct network route to the Pod (see pkg/antctl/raw/observe).
+  - apiGroups:
+      - ""
+    resources:
+      - pods/portforward
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:
@@ -5413,9 +5421,18 @@ rules:
       - apps
     resources:
       - daemonsets
-      - deployments
       - replicasets
     verbs:
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      # "get" is needed by "antctl observe --flow-aggregator <namespace>/<deployment-name>" (see
+      # findFlowAggregatorByName in pkg/antctl/raw/observe/discovery.go), which resolves a specific
+      # instance by Deployment name rather than by listing and filtering.
+      - get
       - list
   - apiGroups:
       - ""
@@ -5426,6 +5443,9 @@ rules:
       - antrea-ca
       - antrea-ipsec-ca
       - antrea-cluster-identity
+      # Read by "antctl observe" to verify the Flow Aggregator's TLS certificate (see
+      # pkg/antctl/raw/observe/connect.go).
+      - flow-aggregator-ca
     verbs:
       - get
 ---

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -435,7 +435,8 @@ function run_test {
 
   if $flow_visibility; then
       timeout="60m"
-      flow_visibility_args="-run=^(TestFlowExporter|TestFlowAggregator) --flow-visibility --flow-visibility-protocol=$flow_visibility_protocol"
+      #flow_visibility_args="-run=^(TestFlowExporter|TestFlowAggregator) --flow-visibility --flow-visibility-protocol=$flow_visibility_protocol"
+      flow_visibility_args="-run=^(TestFlowExporter|TestFlowAggregator|TestAntctlObserve) --flow-visibility --flow-visibility-protocol=$flow_visibility_protocol"
       # This is needed so that the FlowAggregator is already configured to mount the Secrets
       # necessary for (m)TLS testing. The Secret names must match the ones expected by the e2e tests.
       coverage_flag=""
@@ -444,9 +445,12 @@ function run_test {
       fi
       flow_visibility_manifest_default_args=("--extra-helm-values" "flowCollector.tls.clientSecretName=ipfix-client-cert,flowCollector.tls.caSecretName=ipfix-server-ca")
       $FLOWAGGREGATOR_YML_CMD "${flow_visibility_manifest_default_args[@]}" ${coverage_flag} | docker exec -i kind-control-plane dd of=/root/flow-aggregator.yml
-      # We are generating flow-aggregators for two separate namespaces so we can test forwarding connection details to different destinations
-      $FLOWAGGREGATOR_YML_CMD "${flow_visibility_manifest_default_args[@]}" -n 'flow-aggregator-1' ${coverage_flag} | docker exec -i kind-control-plane dd of=/root/flow-aggregator-1.yml
-      $FLOWAGGREGATOR_YML_CMD "${flow_visibility_manifest_default_args[@]}" -n 'flow-aggregator-2' ${coverage_flag} | docker exec -i kind-control-plane dd of=/root/flow-aggregator-2.yml
+      # We are generating flow-aggregators for two separate namespaces so we can test forwarding connection details to different destinations.
+      # Both use a distinct --release-name: cluster-scoped RBAC object names (ClusterRole/ClusterRoleBinding) are derived from the Helm
+      # release name, not the Namespace, so leaving any two instances (including the single, unnumbered instance above) at the same
+      # release name would make the later manifest overwrite the earlier one's ClusterRoleBinding subjects on apply.
+      $FLOWAGGREGATOR_YML_CMD "${flow_visibility_manifest_default_args[@]}" -n 'flow-aggregator-1' --release-name 'flow-aggregator-1' ${coverage_flag} | docker exec -i kind-control-plane dd of=/root/flow-aggregator-1.yml
+      $FLOWAGGREGATOR_YML_CMD "${flow_visibility_manifest_default_args[@]}" -n 'flow-aggregator-2' --release-name 'flow-aggregator-2' ${coverage_flag} | docker exec -i kind-control-plane dd of=/root/flow-aggregator-2.yml
 
       $HELM template "$FLOW_VISIBILITY_CHART"  | docker exec -i kind-control-plane dd of=/root/flow-visibility.yml
       $HELM template "$FLOW_VISIBILITY_CHART" --set "secureConnection.enable=true" | docker exec -i kind-control-plane dd of=/root/flow-visibility-tls.yml

--- a/cmd/flow-aggregator/flow-aggregator.go
+++ b/cmd/flow-aggregator/flow-aggregator.go
@@ -51,7 +51,7 @@ func run(configFile string) error {
 
 	log.StartLogFileNumberMonitor(stopCh)
 
-	k8sClient, err := createK8sClient()
+	k8sClient, restConfig, err := createK8sClient()
 	if err != nil {
 		return fmt.Errorf("error when creating K8s client: %w", err)
 	}
@@ -73,6 +73,7 @@ func run(configFile string) error {
 
 	flowAggregator, err := aggregator.NewFlowAggregator(
 		k8sClient,
+		restConfig,
 		clusterUUID,
 		podStore,
 		nodeStore,
@@ -116,14 +117,14 @@ func run(configFile string) error {
 	return nil
 }
 
-func createK8sClient() (kubernetes.Interface, error) {
+func createK8sClient() (kubernetes.Interface, *rest.Config, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	k8sClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return k8sClient, nil
+	return k8sClient, config, nil
 }

--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -38,6 +38,9 @@ running in three different modes:
   - [Flow Aggregator commands](#flow-aggregator-commands)
     - [Dumping flow records](#dumping-flow-records)
     - [Record metrics](#record-metrics)
+  - [Observing live flows](#observing-live-flows)
+    - [Discovery and connectivity](#discovery-and-connectivity)
+    - [Running in-Pod](#running-in-pod)
   - [Multi-cluster commands](#multi-cluster-commands)
   - [Multicast commands](#multicast-commands)
   - [Showing memberlist state](#showing-memberlist-state)
@@ -810,6 +813,109 @@ Example outputs of record metrics:
 RECORDS-EXPORTED RECORDS-RECEIVED RECORDS-DROPPED FLOWS EXPORTERS-CONNECTED
 46               118              0               7     2
 ```
+
+### Observing live flows
+
+`antctl observe` streams live flow records from a Flow Aggregator's
+`FlowStreamService`, filtered by Namespace, Pod, label selector, Service,
+flow type, or IP/CIDR. It supports two modes:
+
+* **Remote** (the common case): runs in controller (remote) mode, the same
+  mode used when running `antctl` outside the cluster for other commands.
+  Unlike the [Flow Aggregator commands](#flow-aggregator-commands) above, it
+  does not require exec-ing into the Flow Aggregator Pod — see
+  [Discovery and connectivity](#discovery-and-connectivity) below.
+* **In-Pod**: when run from inside the Flow Aggregator's own Pod (e.g. via
+  `kubectl exec`), it connects directly to that instance's own
+  `FlowStreamService` on `localhost`, using the Pod's own ServiceAccount
+  credentials — see [Running in-Pod](#running-in-pod) below.
+
+```bash
+# Stream all flows involving Namespace "default"
+antctl observe -n default
+# Stream flows to/from Pods matching a label selector, as JSON
+antctl observe -l app=frontend -o json
+# Show flows from the last 5 minutes, then keep streaming new ones
+antctl observe --since 5m --follow
+# Connect to a specific Flow Aggregator instance when more than one exists
+antctl observe --flow-aggregator flow-aggregator-2/flow-aggregator
+# From inside the Flow Aggregator Pod itself, observing its own flows
+antctl observe
+```
+
+#### Discovery and connectivity
+
+By default, `antctl observe` discovers the Flow Aggregator automatically: it
+looks for a Flow Aggregator Deployment cluster-wide (or in a single Namespace
+if `--flow-aggregator-namespace` is provided) and connects to it directly if
+reachable. If a direct connection is not possible — for example when running
+somewhere with no network route to the cluster's Pods, such as a local `kind`
+cluster on macOS — it transparently falls back to tunneling through the
+Kubernetes API server's `/portforward` subresource, the same mechanism
+`kubectl port-forward` relies on. This behavior can be controlled with
+`--connection-mode`:
+
+* `auto` (default): try a direct connection first, fall back to a tunnel.
+* `direct`: only ever attempt a direct connection; fail if it does not
+  succeed, rather than silently falling back.
+* `tunnel`: always tunnel through the API server, skipping the direct
+  connection attempt.
+
+If more than one Flow Aggregator instance is found, `antctl observe` will
+not pick one on your behalf: each instance runs its own independent
+`FlowStreamService` (for example, one instance may serve an external NetOps
+integration while another serves in-cluster visibility), so guessing would be
+actively misleading. Disambiguate with either `--flow-aggregator-address
+<host:port>` (connect directly, bypassing discovery and the tunnel fallback
+entirely) or `--flow-aggregator <namespace>/<deployment-name>` (bypass only
+the discovery search).
+
+Like `antctl proxy` and `antctl supportbundle`, this command authenticates
+using the caller's own kubeconfig credential (a bearer token or a client
+certificate, whichever the kubeconfig provides), forwarded to the Flow
+Aggregator so it can resolve the caller's real identity. The Flow
+Aggregator's TLS certificate is verified using its `flow-aggregator-ca`
+ConfigMap; use `--insecure-skip-tls-verify` to skip this check (development
+and testing only).
+
+The `antctl` ClusterRole (see [Collecting support information](#collecting-support-information)
+for the equivalent requirement for `antctl supportbundle`) grants the
+permissions `antctl observe` needs: `list` on Pods for discovery, `get` and
+`list` on Deployments (`get` for resolving a specific instance via
+`--flow-aggregator <namespace>/<deployment-name>`), `create` on the
+`pods/portforward` subresource for the tunnel fallback, and `get` on the
+`flow-aggregator-ca` ConfigMap. A kubeconfig authorized only for narrower,
+Namespace-scoped access may need an equivalent Role/RoleBinding instead,
+scoped to the Flow Aggregator's Namespace.
+
+#### Running in-Pod
+
+Running `antctl observe` from inside the Flow Aggregator's own Pod (e.g.
+`kubectl exec -it deploy/flow-aggregator -n flow-aggregator -- antctl observe`)
+skips discovery and tunneling entirely: it connects straight to
+`localhost:14740`, since there is nothing to discover or tunnel to but its own
+`FlowStreamService`. Because of this, the discovery/connection flags —
+`--flow-aggregator-address`, `--flow-aggregator`, `--flow-aggregator-namespace`,
+`--connection-mode` — are rejected in-Pod rather than silently ignored. All
+filtering flags (`-n`, `--pod`, `-l`, `--service`, `--ip`, `--direction`,
+`--flow-type`, `--since`, `--max-count`, `-f`/`--follow`, `-o`,
+`--human-readable`) work the same as in remote mode.
+
+Authentication uses the Pod's own ServiceAccount token directly — the same
+`credentialForFlowAggregator` logic remote mode uses, since the in-cluster
+config's bearer token file takes precedence over any kubeconfig resolution,
+so there is no separate code path and no identity substitution involved.
+TLS verification reads the `flow-aggregator-ca` ConfigMap from the Pod's own
+Namespace, which its ServiceAccount is already permitted to `get` for its own
+certificate management — no additional RBAC is required beyond what the Flow
+Aggregator chart already grants its own ServiceAccount.
+
+`antctl observe` always prints how it discovered the Flow Aggregator and how
+it connected to it — for example which instance was found, and whether the
+connection was direct or tunneled — to stderr, not stdout, so this status
+output never mixes with flow records even when piping `-o json` to a file.
+
+To see the full list of supported options, run `antctl observe --help`.
 
 ### Multi-cluster commands
 

--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -272,6 +272,8 @@ seconds for each verb, dry run value, group, version, resource, subresource,
 scope and component.
 - **apiserver_request_filter_duration_seconds:** Request filter latency
 distribution in seconds, for each filter type
+- **apiserver_request_post_timeout_total:** Tracks the activity of the request
+handlers after the associated requests have been timed out by the apiserver
 - **apiserver_request_sli_duration_seconds:** Response latency distribution
 (not counting webhook duration and priority & fairness queue wait times) in
 seconds for each verb, group, version, resource, subresource, scope and
@@ -280,6 +282,8 @@ component.
 (not counting webhook duration and priority & fairness queue wait times) in
 seconds for each verb, group, version, resource, subresource, scope and
 component.
+- **apiserver_request_terminations_total:** Number of requests which apiserver
+terminated in self-defense.
 - **apiserver_request_total:** Counter of apiserver requests broken out for
 each verb, dry run value, group, version, resource, scope, component, and HTTP
 response code.

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -23,6 +23,7 @@ import (
 	checkinstallation "antrea.io/antrea/v2/pkg/antctl/raw/check/installation"
 	"antrea.io/antrea/v2/pkg/antctl/raw/featuregates"
 	"antrea.io/antrea/v2/pkg/antctl/raw/multicluster"
+	"antrea.io/antrea/v2/pkg/antctl/raw/observe"
 	"antrea.io/antrea/v2/pkg/antctl/raw/packetcapture"
 	"antrea.io/antrea/v2/pkg/antctl/raw/proxy"
 	"antrea.io/antrea/v2/pkg/antctl/raw/set"
@@ -786,6 +787,12 @@ $ antctl get podmulticaststats pod -n namespace`,
 			cobraCommand:      proxy.Command,
 			supportAgent:      false,
 			supportController: true,
+		},
+		{
+			cobraCommand:          observe.Command,
+			supportAgent:          false,
+			supportController:     true,
+			supportFlowAggregator: true,
 		},
 		{
 			cobraCommand:      featuregates.Command,

--- a/pkg/antctl/command_list_test.go
+++ b/pkg/antctl/command_list_test.go
@@ -64,7 +64,7 @@ func TestGetDebugCommands(t *testing.T) {
 		{
 			name:     "Antctl running against controller mode",
 			mode:     "controller",
-			expected: [][]string{{"version"}, {"get", "networkpolicy"}, {"get", "appliedtogroup"}, {"get", "addressgroup"}, {"get", "controllerinfo"}, {"supportbundle"}, {"traceflow"}, {"get", "featuregates"}},
+			expected: [][]string{{"version"}, {"get", "networkpolicy"}, {"get", "appliedtogroup"}, {"get", "addressgroup"}, {"get", "controllerinfo"}, {"supportbundle"}, {"traceflow"}, {"observe"}, {"get", "featuregates"}},
 		},
 		{
 			name:     "Antctl running against agent mode",

--- a/pkg/antctl/raw/observe/auth.go
+++ b/pkg/antctl/raw/observe/auth.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+
+	"google.golang.org/grpc/metadata"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// authorizationMetadataKey, clientCertMetadataKey and clientKeyMetadataKey must match the gRPC
+// metadata keys FlowStreamService's StreamServerAuthenticator reads, in
+// pkg/flowaggregator/flowstreamservice/authenticator.go (PR #8191).
+const (
+	authorizationMetadataKey = "authorization"
+	bearerTokenPrefix        = "Bearer "
+	clientCertMetadataKey    = "client-cert-bin"
+	clientKeyMetadataKey     = "client-key-bin"
+)
+
+// credentialForFlowAggregator derives the gRPC metadata observe presents to FlowStreamService, by
+// reusing whatever credential the caller's own kubeconfig already resolves to for talking to the
+// Kubernetes API server, rather than minting a new one. This deliberately forwards the caller's
+// own identity end to end, so the server's TokenReview/SelfSubjectReview resolves who they really
+// are — the opposite choice from pkg/antctl/raw/token.go's ServiceAccountTokenSource, which exists
+// specifically to avoid forwarding a caller's real credentials to an Agent. Here, forwarding the
+// caller's real identity is the point.
+func credentialForFlowAggregator(ctx context.Context, cfg *rest.Config) (metadata.MD, error) {
+	switch {
+	case cfg.BearerToken != "":
+		return metadata.Pairs(authorizationMetadataKey, bearerTokenPrefix+cfg.BearerToken), nil
+	case cfg.BearerTokenFile != "":
+		tok, err := os.ReadFile(cfg.BearerTokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read bearer token file %s: %w", cfg.BearerTokenFile, err)
+		}
+		return metadata.Pairs(authorizationMetadataKey, bearerTokenPrefix+strings.TrimSpace(string(tok))), nil
+	case len(cfg.CertData) > 0 || cfg.CertFile != "":
+		certPEM, keyPEM, err := loadCertAndKey(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return metadata.Pairs(clientCertMetadataKey, string(certPEM), clientKeyMetadataKey, string(keyPEM)), nil
+	default:
+		// NOTE: This code path at the moment is not exercised by any e2e test due to lack of test
+		// harness lacking the ability of specifying exec-plugins for authentication
+		// exec/auth-provider kubeconfig (OIDC via kubelogin, cloud IAM, etc.): there is no
+		// static credential to read directly off cfg. Build the same transport client-go would
+		// use for a real API server call, capture the Authorization header it attaches to one
+		// lightweight authenticated request, and forward that token instead. This generalizes to
+		// any auth mode client-go supports, without observe needing to special-case each one.
+		token, err := capturedBearerToken(ctx, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to obtain a bearer token from the configured kubeconfig credential: %w", err)
+		}
+		return metadata.Pairs(authorizationMetadataKey, bearerTokenPrefix+token), nil
+	}
+}
+
+func loadCertAndKey(cfg *rest.Config) ([]byte, []byte, error) {
+	certPEM := cfg.CertData
+	if len(certPEM) == 0 {
+		data, err := os.ReadFile(cfg.CertFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read client certificate file %s: %w", cfg.CertFile, err)
+		}
+		certPEM = data
+	}
+	keyPEM := cfg.KeyData
+	if len(keyPEM) == 0 {
+		data, err := os.ReadFile(cfg.KeyFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read client key file %s: %w", cfg.KeyFile, err)
+		}
+		keyPEM = data
+	}
+	return certPEM, keyPEM, nil
+}
+
+// tokenCapturingRoundTripper records the bearer token from the Authorization header of the first
+// request it sees, then forwards the request unmodified. It never sets or replays a header
+// itself; it only observes what an outer, already-configured auth/exec transport wrapper attached
+// before the request reached this, the innermost transport.
+type tokenCapturingRoundTripper struct {
+	rt    http.RoundTripper
+	mu    sync.Mutex
+	token string
+}
+
+func (t *tokenCapturingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if auth := req.Header.Get("Authorization"); auth != "" {
+		t.mu.Lock()
+		t.token = strings.TrimPrefix(auth, bearerTokenPrefix)
+		t.mu.Unlock()
+	}
+	return t.rt.RoundTrip(req)
+}
+
+// capturedBearerToken exercises the real transport built from cfg against the API server it
+// points at, capturing whatever bearer token client-go's exec/auth-provider plugin attaches. A
+// SelfSubjectReview create is used as the "lightweight authenticated request": it is always
+// permitted for any authenticated identity (via the built-in system:basic-user ClusterRole), has
+// no side effects, and its response is irrelevant — only that the request was sent with a token
+// attached.
+func capturedBearerToken(ctx context.Context, cfg *rest.Config) (string, error) {
+	capture := &tokenCapturingRoundTripper{}
+	wrapped := rest.CopyConfig(cfg)
+	wrapped.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		capture.rt = rt
+		return capture
+	}
+	clientset, err := kubernetes.NewForConfig(wrapped)
+	if err != nil {
+		return "", err
+	}
+	_, _ = clientset.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	if capture.token == "" {
+		return "", fmt.Errorf("no bearer token observed on an authenticated API server request; the configured credential type is not supported")
+	}
+	return capture.token, nil
+}

--- a/pkg/antctl/raw/observe/auth_test.go
+++ b/pkg/antctl/raw/observe/auth_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestCredentialForFlowAggregator_BearerToken(t *testing.T) {
+	md, err := credentialForFlowAggregator(context.Background(), &rest.Config{BearerToken: "tok-abc"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Bearer tok-abc"}, md.Get(authorizationMetadataKey))
+}
+
+func TestCredentialForFlowAggregator_BearerTokenFile(t *testing.T) {
+	t.Run("valid file, whitespace is trimmed", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(path, []byte("tok-from-file\n"), 0o600))
+		md, err := credentialForFlowAggregator(context.Background(), &rest.Config{BearerTokenFile: path})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"Bearer tok-from-file"}, md.Get(authorizationMetadataKey))
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := credentialForFlowAggregator(context.Background(), &rest.Config{BearerTokenFile: filepath.Join(t.TempDir(), "missing")})
+		require.Error(t, err)
+	})
+}
+
+func TestCredentialForFlowAggregator_ClientCert(t *testing.T) {
+	t.Run("CertData/KeyData provided directly", func(t *testing.T) {
+		md, err := credentialForFlowAggregator(context.Background(), &rest.Config{
+			TLSClientConfig: rest.TLSClientConfig{
+				CertData: []byte("cert-bytes"),
+				KeyData:  []byte("key-bytes"),
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cert-bytes"}, md.Get(clientCertMetadataKey))
+		assert.Equal(t, []string{"key-bytes"}, md.Get(clientKeyMetadataKey))
+	})
+
+	t.Run("CertFile/KeyFile read from disk", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath := filepath.Join(dir, "cert.pem")
+		keyPath := filepath.Join(dir, "key.pem")
+		require.NoError(t, os.WriteFile(certPath, []byte("cert-from-file"), 0o600))
+		require.NoError(t, os.WriteFile(keyPath, []byte("key-from-file"), 0o600))
+		md, err := credentialForFlowAggregator(context.Background(), &rest.Config{
+			TLSClientConfig: rest.TLSClientConfig{CertFile: certPath, KeyFile: keyPath},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cert-from-file"}, md.Get(clientCertMetadataKey))
+		assert.Equal(t, []string{"key-from-file"}, md.Get(clientKeyMetadataKey))
+	})
+
+	t.Run("missing cert file", func(t *testing.T) {
+		_, err := credentialForFlowAggregator(context.Background(), &rest.Config{
+			TLSClientConfig: rest.TLSClientConfig{CertFile: filepath.Join(t.TempDir(), "missing")},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("missing key file", func(t *testing.T) {
+		certPath := filepath.Join(t.TempDir(), "cert.pem")
+		require.NoError(t, os.WriteFile(certPath, []byte("cert-from-file"), 0o600))
+		_, err := credentialForFlowAggregator(context.Background(), &rest.Config{
+			TLSClientConfig: rest.TLSClientConfig{
+				CertFile: certPath,
+				KeyFile:  filepath.Join(t.TempDir(), "missing-key"),
+			},
+		})
+		require.Error(t, err)
+	})
+}
+
+// TestCredentialForFlowAggregator_Default exercises the fallback branch (capturedBearerToken):
+// no BearerToken/BearerTokenFile/CertData/CertFile is set, so credentialForFlowAggregator must
+// build a real client from cfg and observe whatever auth header client-go's own transport
+// attaches. Basic auth (Username/Password) stands in for a real exec/auth-provider plugin here —
+// this test harness cannot configure one (same limitation the code's own comment notes) — but it
+// exercises the exact same mechanism: an auth wrapper client-go installs outside of observe's own
+// control attaches a header, and capturedBearerToken's RoundTripper must see it.
+func TestCredentialForFlowAggregator_Default(t *testing.T) {
+	t.Run("captures whatever Authorization header client-go's transport attaches", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		md, err := credentialForFlowAggregator(context.Background(), &rest.Config{
+			Host:     server.URL,
+			Username: "user",
+			Password: "pass",
+		})
+		require.NoError(t, err)
+		// Basic auth is not a bearer token, but credentialForFlowAggregator's default branch
+		// forwards whatever it captured under the same "Bearer <token>" framing regardless of the
+		// underlying auth mode; the point of this branch is generality across auth types.
+		got := md.Get(authorizationMetadataKey)
+		require.Len(t, got, 1)
+		assert.Contains(t, got[0], "Basic ")
+	})
+
+	t.Run("no auth mechanism attaches any header at all", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		_, err := credentialForFlowAggregator(context.Background(), &rest.Config{Host: server.URL})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no bearer token observed")
+	})
+}
+
+func TestTokenCapturingRoundTripper(t *testing.T) {
+	t.Run("captures the token and forwards the request unmodified", func(t *testing.T) {
+		var seenAuth string
+		inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			seenAuth = req.Header.Get("Authorization")
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		})
+		rt := &tokenCapturingRoundTripper{rt: inner}
+		req, err := http.NewRequest(http.MethodGet, "http://example.invalid", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", bearerTokenPrefix+"secret-token")
+
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "secret-token", rt.token)
+		assert.Equal(t, bearerTokenPrefix+"secret-token", seenAuth, "the request must reach the inner transport unmodified")
+	})
+
+	t.Run("no Authorization header, nothing captured", func(t *testing.T) {
+		inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		})
+		rt := &tokenCapturingRoundTripper{rt: inner}
+		req, err := http.NewRequest(http.MethodGet, "http://example.invalid", nil)
+		require.NoError(t, err)
+
+		_, err = rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Empty(t, rt.token)
+	})
+
+	t.Run("propagates the inner transport's error", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		inner := roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, wantErr })
+		rt := &tokenCapturingRoundTripper{rt: inner}
+		req, err := http.NewRequest(http.MethodGet, "http://example.invalid", nil)
+		require.NoError(t, err)
+
+		_, err = rt.RoundTrip(req)
+		assert.ErrorIs(t, err, wantErr)
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/pkg/antctl/raw/observe/command.go
+++ b/pkg/antctl/raw/observe/command.go
@@ -1,0 +1,364 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/metadata"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"antrea.io/antrea/v2/pkg/antctl/raw"
+	"antrea.io/antrea/v2/pkg/antctl/runtime"
+	flowpb "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
+	"antrea.io/antrea/v2/pkg/util/env"
+)
+
+// Command is the observe command implementation.
+var Command *cobra.Command
+
+// flowStreamKeepaliveTime is how often the client sends an HTTP/2 keepalive ping while connected
+// to the Flow Aggregator's FlowStreamService.
+//
+// This value is set as low as it safely can be, not as low as would be ideal: the FlowStreamService
+// gRPC server (pkg/flowaggregator/flowstreamservice/service.go) never configures its own
+// grpc.KeepaliveEnforcementPolicy, so it runs on grpc-go's built-in default of
+// EnforcementPolicy{MinTime: 5 * time.Minute} (google.golang.org/grpc/internal/transport/defaults.go,
+// defaultKeepalivePolicyMinTime). Pinging more often than that trips the server's ping-abuse
+// protection after a couple of strikes: GOAWAY(ENHANCE_YOUR_CALM, "too_many_pings"), which tears
+// down the connection outright — confirmed live, not just from reading the default. 30 seconds of
+// margin above the 5-minute floor absorbs timer/scheduling jitter without meaningfully slowing
+// detection further.
+//
+// TODO: this is a stopgap, not the intended value. It was chosen to fit an enforcement policy the
+// server never deliberately set with any real client's needs in mind, rather than one sized for
+// what observe (or any liveness-conscious client) actually needs. The real fix is most likely an
+// explicit, intentional grpc.KeepaliveEnforcementPolicy on the FlowStreamService server itself,
+// sized to accommodate a short client-side interval — see the "Termination behavior" section of the
+// antctl observe design doc for the original ~10s value this replaces and why prompt disconnect
+// detection matters here. That's a change to shared server behavior affecting every FlowStreamService
+// client, not just antctl, so it needs review beyond this package before making it. Until then, a
+// Flow Aggregator that disappears without a clean TCP close (e.g. a genuine silent network
+// partition, as opposed to a normal Pod deletion — which the OS reports as an ordinary
+// connection-closed error well before this ever fires) can leave antctl observe hanging for up to
+// this long before it notices and exits.
+const flowStreamKeepaliveTime = 5*time.Minute + 30*time.Second
+
+type options struct {
+	namespaces []string
+	podNames   []string
+	selector   string
+	services   []string
+	flowTypes  []string
+	ips        []string
+	direction  string
+
+	since    string
+	maxCount uint32
+	follow   bool
+
+	output        string
+	humanReadable bool
+
+	// flowAggregatorAddress, when set, bypasses discovery and the tunnel fallback entirely: the
+	// user is asserting they already have a reachable address (e.g. their own port-forward, or a
+	// NodePort/LoadBalancer they exposed themselves) and takes responsibility for that being
+	// true. It is not named --server to avoid colliding with antctl's existing persistent
+	// -s/--server flag, which overrides the Kubernetes API server address, not the Flow
+	// Aggregator's.
+	flowAggregatorAddress string
+	// flowAggregator, when set as "<namespace>/<deployment-name>", skips only the discovery
+	// search, not the direct-dial/tunnel connection logic.
+	flowAggregator          string
+	flowAggregatorNamespace string
+	connectionMode          string
+	insecureSkipTLSVerify   bool
+}
+
+var o = &options{}
+
+func init() {
+	Command = &cobra.Command{
+		Use:   "observe",
+		Short: "Stream live flow records from a Flow Aggregator",
+		Long: "Stream live flow records from a Flow Aggregator's FlowStreamService. " +
+			"Supports two modes: remote (the common case), which runs out-of-cluster, " +
+			"discovering and connecting to the Flow Aggregator through the Kubernetes API " +
+			"server rather than requiring a direct network route to its Pod; and in-Pod, when " +
+			"run from inside the Flow Aggregator's own Pod, which connects directly to its own " +
+			"FlowStreamService using the Pod's own ServiceAccount credentials, with no " +
+			"discovery or tunneling involved. Discovery-related flags " +
+			"(--flow-aggregator-address, --flow-aggregator, --flow-aggregator-namespace, " +
+			"--connection-mode) are rejected in-Pod: there is nothing to discover or connect " +
+			"to but this instance's own FlowStreamService.",
+		Example: strings.Trim(`
+  Stream all flows involving Namespace "default"
+  $ antctl observe -n default
+  Stream flows to/from Pods matching a label selector, as JSON
+  $ antctl observe -l app=frontend -o json
+  Show flows from the last 5 minutes, then keep streaming new ones
+  $ antctl observe --since 5m --follow
+  Connect to a specific Flow Aggregator instance when more than one exists
+  $ antctl observe --flow-aggregator flow-aggregator-2/flow-aggregator
+  From inside the Flow Aggregator Pod itself, observing its own flows
+  $ antctl observe
+`, "\n"),
+		RunE: runE,
+		Args: cobra.NoArgs,
+	}
+
+	Command.Flags().StringSliceVarP(&o.namespaces, "namespace", "n", nil, "Match flows where the source or destination Pod Namespace is in this list")
+	Command.Flags().StringSliceVar(&o.podNames, "pod", nil, "Match flows where the source or destination Pod name is in this list")
+	Command.Flags().StringVarP(&o.selector, "selector", "l", "", "Match flows where the source or destination Pod labels match this selector")
+	Command.Flags().StringSliceVar(&o.services, "service", nil, "Match flows where the destination Service name is in this list")
+	Command.Flags().StringSliceVar(&o.flowTypes, "flow-type", nil, "Match flows of this type: intra-node, inter-node, to-external, from-external")
+	Command.Flags().StringSliceVar(&o.ips, "ip", nil, "Match flows where the source or destination IP is in this list (CIDR notation supported)")
+	Command.Flags().StringVar(&o.direction, "direction", "both", "Which side of a flow the other filters are matched against: both, from, to")
+
+	Command.Flags().StringVar(&o.since, "since", "", "Only show flows ending after this time: a duration (e.g. \"5m\") or an RFC3339 timestamp")
+	Command.Flags().Uint32Var(&o.maxCount, "max-count", 0, "Maximum number of flows to show in total (0 means unlimited)")
+	Command.Flags().BoolVarP(&o.follow, "follow", "f", false, "Keep streaming new flows after historical flows are shown, like \"kubectl logs -f\" (default: exit once historical flows are shown)")
+
+	Command.Flags().StringVarP(&o.output, "output", "o", "text", "Output format: text, json")
+	Command.Flags().BoolVar(&o.humanReadable, "human-readable", false, "Show the TOTAL BYTES column in text output using KB/MB/GB/... units instead of raw bytes (text output only; ignored with -o json)")
+
+	Command.Flags().StringVar(&o.flowAggregatorAddress, "flow-aggregator-address", "", "Connect directly to this address (host:port), bypassing discovery and the tunnel fallback")
+	Command.Flags().StringVar(&o.flowAggregator, "flow-aggregator", "", "Connect to this Flow Aggregator instance, as <namespace>/<deployment-name>, bypassing discovery")
+	Command.Flags().StringVar(&o.flowAggregatorNamespace, "flow-aggregator-namespace", "", "Namespace to search for a Flow Aggregator instance (default: search cluster-wide); also used to read its CA certificate from when combined with --flow-aggregator-address")
+	Command.Flags().StringVar(&o.connectionMode, "connection-mode", string(connectionModeAuto), "How to connect to the Flow Aggregator: auto, direct, tunnel")
+	Command.Flags().BoolVar(&o.insecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip verification of the Flow Aggregator's TLS certificate (dev/test only)")
+}
+
+// inFlowAggregatorPod is true when observe is running as the Flow Aggregator itself would run
+// antctl in-Pod (POD_NAME prefixed "flow-aggregator", see pkg/antctl/runtime): observing its own
+// FlowStreamService, not someone else's. This is the only in-Pod case this command supports —
+// running from inside an Agent or Controller Pod has no co-located FlowStreamService to observe,
+// so remote mode (discovery + tunnel/direct-dial) remains the only option there.
+func inFlowAggregatorPod() bool {
+	return runtime.Mode == runtime.ModeFlowAggregator && runtime.InPod
+}
+
+func runE(cmd *cobra.Command, _ []string) error {
+	inPod := inFlowAggregatorPod()
+	if !inPod && (runtime.Mode != runtime.ModeController || runtime.InPod) {
+		return fmt.Errorf("observe only supports remote mode, or running inside the Flow Aggregator Pod")
+	}
+	mode := connectionMode(o.connectionMode)
+	if inPod {
+		// None of these mean anything once there is nothing to discover and nowhere to tunnel
+		// to: silently ignoring them would be more surprising than rejecting them outright.
+		for _, flag := range []string{"flow-aggregator-address", "flow-aggregator", "flow-aggregator-namespace", "connection-mode"} {
+			if cmd.Flags().Changed(flag) {
+				return fmt.Errorf("--%s cannot be used when running inside the Flow Aggregator Pod: "+
+					"there is nothing to discover or connect to but this instance's own FlowStreamService", flag)
+			}
+		}
+	} else {
+		if o.flowAggregatorAddress != "" && o.flowAggregator != "" {
+			return fmt.Errorf("--flow-aggregator-address and --flow-aggregator are mutually exclusive")
+		}
+		if o.flowAggregatorAddress != "" && mode == connectionModeTunnel {
+			return fmt.Errorf("--connection-mode=tunnel cannot be used with --flow-aggregator-address: there is no Pod to tunnel to; " +
+				"omit --flow-aggregator-address, or use --flow-aggregator <namespace>/<deployment-name> instead")
+		}
+	}
+	switch outputFormat(o.output) {
+	case outputText, outputJSON:
+	default:
+		return fmt.Errorf("invalid --output %q, must be one of text, json", o.output)
+	}
+
+	ctx := cmd.Context()
+
+	// In-Pod, use the Pod's own ServiceAccount identity directly rather than resolving a
+	// kubeconfig (there is no kubeconfig file to find, and none should be looked for): this is
+	// also what makes credentialForFlowAggregator's BearerTokenFile branch the one that fires
+	// below, forwarding this Pod's own token as-is rather than laundering any other credential
+	// through it.
+	var kubeconfig *rest.Config
+	var err error
+	if inPod {
+		kubeconfig, err = rest.InClusterConfig()
+		if err != nil {
+			return fmt.Errorf("failed to load in-cluster config: %w", err)
+		}
+	} else {
+		kubeconfig, err = raw.ResolveKubeconfig(cmd)
+		if err != nil {
+			return err
+		}
+	}
+	k8sClientset, _, err := raw.SetupClients(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	req, err := buildRequest(o)
+	if err != nil {
+		return err
+	}
+
+	var addr, tlsNamespace string
+	var closeConn func()
+	if inPod {
+		addr = net.JoinHostPort("127.0.0.1", fmt.Sprint(flowStreamPort))
+		// The CA ConfigMap and the server certificate's SAN both live in/name this Pod's own
+		// Namespace (see getFlowAggregatorServerNames in pkg/flowaggregator/certificate/provider.go,
+		// which reads the same POD_NAMESPACE env var env.GetPodNamespace does) — there is no
+		// discovery step here to have found it another way.
+		tlsNamespace = env.GetPodNamespace()
+		closeConn = func() {}
+		fmt.Fprintf(cmd.ErrOrStderr(), "Running inside the Flow Aggregator Pod; connecting to its own FlowStreamService at %s\n", addr)
+	} else {
+		addr, tlsNamespace, closeConn, err = connect(ctx, k8sClientset, kubeconfig, mode, cmd.ErrOrStderr())
+		if err != nil {
+			return fmt.Errorf("failed to connect to the Flow Aggregator: %w", err)
+		}
+	}
+	defer closeConn()
+
+	tlsConfig, err := buildTLSConfig(ctx, configMapCAReader{client: k8sClientset}, tlsNamespace,
+		fmt.Sprintf("flow-aggregator.%s.svc", tlsNamespace), o.insecureSkipTLSVerify)
+	if err != nil {
+		return err
+	}
+
+	creds, err := credentialForFlowAggregator(ctx, kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	// Keepalives matter here specifically because observe must exit promptly on disconnect (§6 of
+	// the design doc), not hang waiting for the Flow Aggregator to come back. Without them, a
+	// peer that disappears without a clean TCP close (e.g. its Pod is deleted outright, rather
+	// than given time to send a FIN) can leave this connection looking alive indefinitely: with
+	// no data flowing and no keepalive probes, nothing tells the client the peer is gone. PermitWithoutStream
+	// is required because between historical-flow batches (or with a static --since/--max-count
+	// query already answered) there may be no active stream for seconds at a time.
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                flowStreamKeepaliveTime,
+			Timeout:             5 * time.Second,
+			PermitWithoutStream: true,
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC client: %w", err)
+	}
+	defer conn.Close()
+
+	client := flowpb.NewFlowStreamServiceClient(conn)
+	stream, err := client.GetFlows(metadata.NewOutgoingContext(ctx, creds), req)
+	if err != nil {
+		return fmt.Errorf("failed to start flow stream: %w", err)
+	}
+
+	out := newRenderer(outputFormat(o.output), cmd.OutOrStdout(), o.humanReadable)
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			// io.EOF: the server closed the stream on its own (e.g. --follow was omitted so
+			// draining history finished, or --max-count was reached) — a normal, successful exit.
+			// Anything else, including the connection dropping mid-stream, is surfaced as an
+			// error: observe exits promptly rather than trying to reconnect and resume from the
+			// ring buffer's current tail on its own. Retrying, if wanted, is left to the caller.
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("flow stream ended unexpectedly: %w", err)
+		}
+		if err := out.render(resp.GetFlows(), resp.GetDroppedCount()); err != nil {
+			return err
+		}
+	}
+}
+
+// connect resolves how to reach the Flow Aggregator's FlowStreamService and, when a tunnel is
+// needed, opens it. It returns the address to dial, the Namespace to use when fetching the CA
+// certificate for TLS verification, and a function to release any tunnel that was opened.
+func connect(ctx context.Context, k8sClientset kubernetes.Interface, kubeconfig *rest.Config, mode connectionMode, stderr io.Writer) (addr, tlsNamespace string, closeFn func(), err error) {
+	if o.flowAggregatorAddress != "" {
+		// The user asserted a directly-reachable address; there is no discovered Pod to tunnel
+		// to, so this always behaves like connectionModeDirect regardless of --connection-mode
+		fmt.Fprintf(stderr, "Connecting to %s (specified via --flow-aggregator-address, bypassing discovery)...\n", o.flowAggregatorAddress)
+		if err := defaultDirectDialer(ctx, o.flowAggregatorAddress); err != nil {
+			return "", "", nil, fmt.Errorf("direct connection to %s failed: %w", o.flowAggregatorAddress, err)
+		}
+		fmt.Fprintf(stderr, "Connected to %s\n", o.flowAggregatorAddress)
+		tlsNamespace := o.flowAggregatorNamespace
+		if tlsNamespace == "" {
+			// Unlike discovery, there is no cluster-wide search happening here to accidentally
+			// narrow, so falling back to the conventional Namespace name is safe and just
+			// saves typing it in the common case.
+			tlsNamespace = defaultFlowAggregatorNamespace
+		}
+		return o.flowAggregatorAddress, tlsNamespace, func() {}, nil
+	}
+
+	target, err := resolveTarget(ctx, k8sClientset, stderr)
+	if err != nil {
+		return "", "", nil, err
+	}
+	directAddr := net.JoinHostPort(target.podIP, fmt.Sprint(flowStreamPort))
+	fmt.Fprintf(stderr, "Connecting to Flow Aggregator Pod %s/%s (connection mode: %s)\n", target.namespace, target.podName, mode)
+	addr, closeFn, err = resolveAddress(ctx, mode, directAddr, defaultDirectDialer, spdyTunnel, kubeconfig, target.namespace, target.podName, stderr)
+	if err != nil {
+		return "", "", nil, err
+	}
+	return addr, target.namespace, closeFn, nil
+}
+
+func resolveTarget(ctx context.Context, k8sClientset kubernetes.Interface, stderr io.Writer) (*flowAggregatorTarget, error) {
+	if o.flowAggregator != "" {
+		parts := strings.SplitN(o.flowAggregator, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return nil, fmt.Errorf("invalid --flow-aggregator %q, must be <namespace>/<deployment-name>", o.flowAggregator)
+		}
+		fmt.Fprintf(stderr, "Looking up Flow Aggregator %s/%s (specified via --flow-aggregator)...\n", parts[0], parts[1])
+		target, err := findFlowAggregatorByName(ctx, k8sClientset, parts[0], parts[1])
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(stderr, "Found Flow Aggregator Pod %s/%s (%s)\n", target.namespace, target.podName, target.podIP)
+		return target, nil
+	}
+	fmt.Fprintf(stderr, "Discovering Flow Aggregator instance (searching %s)...\n", describeSearchScope(o.flowAggregatorNamespace))
+	target, err := discoverFlowAggregator(ctx, k8sClientset, o.flowAggregatorNamespace)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintf(stderr, "Discovered Flow Aggregator Pod %s/%s (%s)\n", target.namespace, target.podName, target.podIP)
+	return target, nil
+}
+
+// describeSearchScope renders o.flowAggregatorNamespace for the "Discovering..." status message.
+func describeSearchScope(namespace string) string {
+	if namespace == "" {
+		return "cluster-wide"
+	}
+	return fmt.Sprintf("Namespace %q", namespace)
+}

--- a/pkg/antctl/raw/observe/command_test.go
+++ b/pkg/antctl/raw/observe/command_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"antrea.io/antrea/v2/pkg/antctl/runtime"
+)
+
+// deploymentWithSelector builds a minimal Deployment matching Pods labeled app=flow-aggregator,
+// for findFlowAggregatorByName (exercised here indirectly through resolveTarget).
+func deploymentWithSelector(namespace, name string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "flow-aggregator"}},
+		},
+	}
+}
+
+// withRuntimeMode temporarily overrides the antctl runtime package's Mode/InPod globals for the
+// duration of a test, restoring them afterward: inFlowAggregatorPod derives its answer entirely
+// from that shared package-level state.
+func withRuntimeMode(t *testing.T, mode string, inPod bool) {
+	t.Helper()
+	origMode, origInPod := runtime.Mode, runtime.InPod
+	runtime.Mode, runtime.InPod = mode, inPod
+	t.Cleanup(func() { runtime.Mode, runtime.InPod = origMode, origInPod })
+}
+
+func TestInFlowAggregatorPod(t *testing.T) {
+	cases := []struct {
+		name  string
+		mode  string
+		inPod bool
+		want  bool
+	}{
+		{"flow-aggregator mode, in-Pod", runtime.ModeFlowAggregator, true, true},
+		{"flow-aggregator mode, not in-Pod", runtime.ModeFlowAggregator, false, false},
+		{"controller mode, in-Pod", runtime.ModeController, true, false},
+		{"agent mode, in-Pod", runtime.ModeAgent, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withRuntimeMode(t, tc.mode, tc.inPod)
+			assert.Equal(t, tc.want, inFlowAggregatorPod())
+		})
+	}
+}
+
+func TestDescribeSearchScope(t *testing.T) {
+	assert.Equal(t, "cluster-wide", describeSearchScope(""))
+	assert.Equal(t, `Namespace "flow-aggregator"`, describeSearchScope("flow-aggregator"))
+}
+
+func TestResolveTarget(t *testing.T) {
+	t.Run("by name via --flow-aggregator", func(t *testing.T) {
+		origFlowAggregator := o.flowAggregator
+		o.flowAggregator = "flow-aggregator/flow-aggregator"
+		t.Cleanup(func() { o.flowAggregator = origFlowAggregator })
+
+		deployment := deploymentWithSelector("flow-aggregator", "flow-aggregator")
+		pod := flowAggregatorPod("flow-aggregator", "flow-aggregator-abc", "10.0.0.5", true)
+		client := fake.NewSimpleClientset(deployment, pod)
+
+		target, err := resolveTarget(context.Background(), client, io.Discard)
+		require.NoError(t, err)
+		assert.Equal(t, "flow-aggregator-abc", target.podName)
+	})
+
+	t.Run("invalid --flow-aggregator format", func(t *testing.T) {
+		origFlowAggregator := o.flowAggregator
+		o.flowAggregator = "not-namespace-slash-name"
+		t.Cleanup(func() { o.flowAggregator = origFlowAggregator })
+
+		_, err := resolveTarget(context.Background(), fake.NewSimpleClientset(), io.Discard)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --flow-aggregator")
+	})
+
+	t.Run("falls back to discovery when --flow-aggregator is unset", func(t *testing.T) {
+		origFlowAggregator, origNamespace := o.flowAggregator, o.flowAggregatorNamespace
+		o.flowAggregator, o.flowAggregatorNamespace = "", ""
+		t.Cleanup(func() { o.flowAggregator, o.flowAggregatorNamespace = origFlowAggregator, origNamespace })
+
+		client := fake.NewSimpleClientset(flowAggregatorPod("flow-aggregator", "flow-aggregator-abc", "10.0.0.5", true))
+		target, err := resolveTarget(context.Background(), client, io.Discard)
+		require.NoError(t, err)
+		assert.Equal(t, "flow-aggregator-abc", target.podName)
+	})
+}
+
+func TestConnect_FlowAggregatorAddress(t *testing.T) {
+	t.Run("reachable address, default Namespace used for TLS", func(t *testing.T) {
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer lis.Close()
+		go func() {
+			conn, err := lis.Accept()
+			if err == nil {
+				conn.Close()
+			}
+		}()
+
+		origAddr, origNamespace := o.flowAggregatorAddress, o.flowAggregatorNamespace
+		o.flowAggregatorAddress, o.flowAggregatorNamespace = lis.Addr().String(), ""
+		t.Cleanup(func() { o.flowAggregatorAddress, o.flowAggregatorNamespace = origAddr, origNamespace })
+
+		addr, tlsNamespace, closeFn, err := connect(context.Background(), fake.NewSimpleClientset(), &rest.Config{}, connectionModeAuto, io.Discard)
+		require.NoError(t, err)
+		defer closeFn()
+		assert.Equal(t, lis.Addr().String(), addr)
+		assert.Equal(t, defaultFlowAggregatorNamespace, tlsNamespace)
+	})
+
+	t.Run("explicit --flow-aggregator-namespace overrides the default", func(t *testing.T) {
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer lis.Close()
+		go func() {
+			conn, err := lis.Accept()
+			if err == nil {
+				conn.Close()
+			}
+		}()
+
+		origAddr, origNamespace := o.flowAggregatorAddress, o.flowAggregatorNamespace
+		o.flowAggregatorAddress, o.flowAggregatorNamespace = lis.Addr().String(), "flow-aggregator-2"
+		t.Cleanup(func() { o.flowAggregatorAddress, o.flowAggregatorNamespace = origAddr, origNamespace })
+
+		_, tlsNamespace, closeFn, err := connect(context.Background(), fake.NewSimpleClientset(), &rest.Config{}, connectionModeAuto, io.Discard)
+		require.NoError(t, err)
+		defer closeFn()
+		assert.Equal(t, "flow-aggregator-2", tlsNamespace)
+	})
+
+	t.Run("unreachable address fails outright", func(t *testing.T) {
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		addr := lis.Addr().String()
+		require.NoError(t, lis.Close())
+
+		origAddr := o.flowAggregatorAddress
+		o.flowAggregatorAddress = addr
+		t.Cleanup(func() { o.flowAggregatorAddress = origAddr })
+
+		_, _, _, err = connect(context.Background(), fake.NewSimpleClientset(), &rest.Config{}, connectionModeAuto, io.Discard)
+		require.Error(t, err)
+	})
+}

--- a/pkg/antctl/raw/observe/connect.go
+++ b/pkg/antctl/raw/observe/connect.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// flowStreamPort is the port on which every Flow Aggregator instance serves FlowStreamService.
+// See pkg/flowaggregator/flowstreamservice/service.go.
+const flowStreamPort = 14740
+
+// connectionMode controls how observe reaches the Flow Aggregator's FlowStreamService.
+type connectionMode string
+
+const (
+	// connectionModeAuto tries a direct connection first and falls back to a tunnel through the
+	// API server only if that fails. This is the default: it is free when observe happens to run
+	// somewhere with real network access to the Pod (e.g. a debug Pod, a bastion host with routed
+	// Pod CIDRs), and it degrades gracefully everywhere else.
+	connectionModeAuto connectionMode = "auto"
+	// connectionModeDirect never tunnels: a failed direct connection is a hard error, not a
+	// silent fallback. Useful for diagnosing connectivity issues.
+	connectionModeDirect connectionMode = "direct"
+	// connectionModeTunnel always tunnels through the API server's /portforward subresource,
+	// skipping the direct-connection attempt entirely.
+	connectionModeTunnel connectionMode = "tunnel"
+)
+
+// directDialTimeout bounds how long "auto" mode waits for a direct connection to succeed before
+// falling back to a tunnel. It only needs to distinguish "actively unreachable" from "reachable";
+// a real connection to a Pod IP on a shared network completes far faster than this.
+const directDialTimeout = 2 * time.Second
+
+// directDialer abstracts "is addr reachable" so that tests can force either branch of
+// resolveAddress deterministically, without depending on the real network topology the test
+// happens to run under.
+type directDialer func(ctx context.Context, addr string) error
+
+func defaultDirectDialer(ctx context.Context, addr string) error {
+	dialCtx, cancel := context.WithTimeout(ctx, directDialTimeout)
+	defer cancel()
+	conn, err := (&net.Dialer{}).DialContext(dialCtx, "tcp", addr)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+// tunneler abstracts opening a tunnel to a Pod's port, returning a local address to dial instead
+// and a function to close the tunnel. Tests can substitute a fake implementation.
+type tunneler func(ctx context.Context, restConfig *rest.Config, namespace, podName string, targetPort int) (localAddr string, closeFn func(), err error)
+
+// resolveAddress decides, and if needed opens, how to reach the Flow Aggregator, implementing the
+// three connectionMode values. It deliberately never mixes direct and tunnel within a single
+// mode: "direct" fails outright rather than silently tunneling, so connectivity problems remain
+// visible instead of being papered over.
+func resolveAddress(
+	ctx context.Context,
+	mode connectionMode,
+	directAddr string,
+	dial directDialer,
+	tunnel tunneler,
+	restConfig *rest.Config,
+	namespace, podName string,
+	stderr io.Writer,
+) (addr string, closeFn func(), err error) {
+	switch mode {
+	case connectionModeDirect:
+		fmt.Fprintf(stderr, "Connecting directly to %s...\n", directAddr)
+		if err := dial(ctx, directAddr); err != nil {
+			return "", nil, fmt.Errorf("direct connection to %s failed: %w", directAddr, err)
+		}
+		fmt.Fprintf(stderr, "Connected directly to %s\n", directAddr)
+		return directAddr, func() {}, nil
+	case connectionModeTunnel:
+		return openTunnel(ctx, tunnel, restConfig, namespace, podName, stderr)
+	case connectionModeAuto, "":
+		fmt.Fprintf(stderr, "Attempting a direct connection to %s...\n", directAddr)
+		if err := dial(ctx, directAddr); err == nil {
+			fmt.Fprintf(stderr, "Connected directly to %s\n", directAddr)
+			return directAddr, func() {}, nil
+		}
+		fmt.Fprintf(stderr, "Direct connection to %s failed, falling back to a tunnel through the API server\n", directAddr)
+		return openTunnel(ctx, tunnel, restConfig, namespace, podName, stderr)
+	default:
+		return "", nil, fmt.Errorf("invalid connection mode %q, must be one of auto, direct, tunnel", mode)
+	}
+}
+
+func openTunnel(ctx context.Context, tunnel tunneler, restConfig *rest.Config, namespace, podName string, stderr io.Writer) (string, func(), error) {
+	fmt.Fprintf(stderr, "Tunneling to %s/%s through the API server...\n", namespace, podName)
+	addr, closeFn, err := tunnel(ctx, restConfig, namespace, podName, flowStreamPort)
+	if err != nil {
+		return "", nil, err
+	}
+	fmt.Fprintf(stderr, "Connected via tunnel (local address %s)\n", addr)
+	return addr, closeFn, nil
+}
+
+// spdyTunnel is the production tunneler. It goes through the API server's /portforward
+// subresource rather than dialing the Pod IP directly, so it works even when the caller has no
+// route to the cluster's Pod network at all. It mirrors
+// test/e2e/utils/portforwarder/portforwarder.go, trimmed to a single ephemeral local port.
+func spdyTunnel(ctx context.Context, restConfig *rest.Config, namespace, podName string, targetPort int) (string, func(), error) {
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	reqURL := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(podName).
+		SubResource("portforward").URL()
+
+	transport, upgrader, err := spdy.RoundTripperFor(restConfig)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create SPDY dialer: %w", err)
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", reqURL)
+
+	stopCh := make(chan struct{})
+	readyCh := make(chan struct{})
+	errCh := make(chan error, 1)
+
+	// Port 0 asks the forwarder to pick a free local port; the actual port is read back via
+	// GetPorts() once ForwardPorts() signals readiness.
+	ports := []string{fmt.Sprintf("0:%d", targetPort)}
+	pf, err := portforward.NewOnAddresses(dialer, []string{"127.0.0.1"}, ports, stopCh, readyCh, io.Discard, io.Discard)
+	if err != nil {
+		close(stopCh)
+		return "", nil, fmt.Errorf("failed to set up port forwarding to %s/%s: %w", namespace, podName, err)
+	}
+
+	go func() { errCh <- pf.ForwardPorts() }()
+
+	select {
+	case err := <-errCh:
+		return "", nil, fmt.Errorf("port forwarding to %s/%s failed: %w", namespace, podName, err)
+	case <-readyCh:
+	case <-ctx.Done():
+		close(stopCh)
+		return "", nil, ctx.Err()
+	}
+
+	forwardedPorts, err := pf.GetPorts()
+	if err != nil || len(forwardedPorts) == 0 {
+		close(stopCh)
+		return "", nil, fmt.Errorf("failed to determine the forwarded local port for %s/%s: %w", namespace, podName, err)
+	}
+
+	localAddr := net.JoinHostPort("127.0.0.1", fmt.Sprint(forwardedPorts[0].Local))
+	closed := false
+	closeFn := func() {
+		if !closed {
+			closed = true
+			close(stopCh)
+		}
+	}
+	return localAddr, closeFn, nil
+}
+
+// buildTLSConfig builds the client-side TLS configuration used to verify the Flow Aggregator's
+// server certificate. FlowStreamService uses server-side TLS only (see PR #8191 and
+// pkg/flowaggregator/flowstreamservice/service.go): there is no client certificate to present at
+// the TLS layer, so this only ever configures server-verification material, never a client cert.
+// Caller identity is instead carried as gRPC metadata (see auth.go) and validated by the server
+// itself against the Kubernetes API.
+func buildTLSConfig(ctx context.Context, k8sClient interface {
+	ConfigMapCA(ctx context.Context, namespace string) ([]byte, error)
+}, namespace string, serverName string, insecureSkipVerify bool) (*tls.Config, error) {
+	if insecureSkipVerify {
+		//nolint:gosec // explicit user opt-in via --insecure-skip-tls-verify, documented as dev/test only.
+		return &tls.Config{InsecureSkipVerify: true, ServerName: serverName}, nil
+	}
+	caPEM, err := k8sClient.ConfigMapCA(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to retrieve the Flow Aggregator's CA certificate (needed to verify its identity): %w\n"+
+				"You can try running the command again with --insecure-skip-tls-verify", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("failed to parse the Flow Aggregator's CA certificate")
+	}
+	return &tls.Config{RootCAs: pool, ServerName: serverName, MinVersion: tls.VersionTLS12}, nil
+}
+
+// configMapCAReader fetches the flow-aggregator-ca ConfigMap's "ca.crt" key, the same ConfigMap
+// and key antrea-ui's backend reads for the same purpose (see build/charts/antrea-ui's
+// flowAggregator.caConfigMap value).
+type configMapCAReader struct {
+	client kubernetes.Interface
+}
+
+const (
+	flowAggregatorCAConfigMapName = "flow-aggregator-ca"
+	flowAggregatorCAConfigMapKey  = "ca.crt"
+)
+
+func (r configMapCAReader) ConfigMapCA(ctx context.Context, namespace string) ([]byte, error) {
+	cm, err := r.client.CoreV1().ConfigMaps(namespace).Get(ctx, flowAggregatorCAConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	ca, ok := cm.Data[flowAggregatorCAConfigMapKey]
+	if !ok {
+		return nil, fmt.Errorf("missing key %q in ConfigMap %s/%s", flowAggregatorCAConfigMapKey, namespace, flowAggregatorCAConfigMapName)
+	}
+	return []byte(ca), nil
+}

--- a/pkg/antctl/raw/observe/connect_test.go
+++ b/pkg/antctl/raw/observe/connect_test.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+
+	"antrea.io/antrea/v2/pkg/util/tlstest"
+)
+
+func alwaysReachable(context.Context, string) error { return nil }
+func alwaysUnreachable(context.Context, string) error {
+	return errors.New("connection refused")
+}
+
+func fakeTunnel(t *testing.T, localAddr string) (tunneler, *bool) {
+	t.Helper()
+	called := false
+	return func(_ context.Context, _ *rest.Config, namespace, podName string, targetPort int) (string, func(), error) {
+		called = true
+		assert.Equal(t, "flow-aggregator", namespace)
+		assert.Equal(t, "flow-aggregator-abc", podName)
+		assert.Equal(t, flowStreamPort, targetPort)
+		return localAddr, func() {}, nil
+	}, &called
+}
+
+func TestResolveAddress_Auto(t *testing.T) {
+	t.Run("direct connection succeeds, tunnel is never opened", func(t *testing.T) {
+		tunnel, tunnelCalled := fakeTunnel(t, "127.0.0.1:9999")
+		addr, closeFn, err := resolveAddress(context.Background(), connectionModeAuto, "10.0.0.5:14740",
+			alwaysReachable, tunnel, &rest.Config{}, "flow-aggregator", "flow-aggregator-abc", io.Discard)
+		require.NoError(t, err)
+		defer closeFn()
+		assert.Equal(t, "10.0.0.5:14740", addr)
+		assert.False(t, *tunnelCalled, "tunnel should not be opened when the direct connection succeeds")
+	})
+
+	t.Run("direct connection fails, falls back to tunnel", func(t *testing.T) {
+		tunnel, tunnelCalled := fakeTunnel(t, "127.0.0.1:54321")
+		addr, closeFn, err := resolveAddress(context.Background(), connectionModeAuto, "10.0.0.5:14740",
+			alwaysUnreachable, tunnel, &rest.Config{}, "flow-aggregator", "flow-aggregator-abc", io.Discard)
+		require.NoError(t, err)
+		defer closeFn()
+		assert.Equal(t, "127.0.0.1:54321", addr)
+		assert.True(t, *tunnelCalled, "tunnel should be opened when the direct connection fails")
+	})
+}
+
+func TestResolveAddress_Direct(t *testing.T) {
+	t.Run("succeeds without ever considering a tunnel", func(t *testing.T) {
+		tunnel, tunnelCalled := fakeTunnel(t, "127.0.0.1:9999")
+		addr, _, err := resolveAddress(context.Background(), connectionModeDirect, "10.0.0.5:14740",
+			alwaysReachable, tunnel, &rest.Config{}, "flow-aggregator", "flow-aggregator-abc", io.Discard)
+		require.NoError(t, err)
+		assert.Equal(t, "10.0.0.5:14740", addr)
+		assert.False(t, *tunnelCalled)
+	})
+
+	t.Run("fails outright, never silently falls back to a tunnel", func(t *testing.T) {
+		tunnel, tunnelCalled := fakeTunnel(t, "127.0.0.1:9999")
+		_, _, err := resolveAddress(context.Background(), connectionModeDirect, "10.0.0.5:14740",
+			alwaysUnreachable, tunnel, &rest.Config{}, "flow-aggregator", "flow-aggregator-abc", io.Discard)
+		require.Error(t, err)
+		assert.False(t, *tunnelCalled, "connectionModeDirect must never fall back to a tunnel")
+	})
+}
+
+func TestResolveAddress_Tunnel(t *testing.T) {
+	t.Run("always tunnels, even though direct would have succeeded", func(t *testing.T) {
+		tunnel, tunnelCalled := fakeTunnel(t, "127.0.0.1:54321")
+		addr, _, err := resolveAddress(context.Background(), connectionModeTunnel, "10.0.0.5:14740",
+			alwaysReachable, tunnel, &rest.Config{}, "flow-aggregator", "flow-aggregator-abc", io.Discard)
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1:54321", addr)
+		assert.True(t, *tunnelCalled)
+	})
+}
+
+func TestResolveAddress_InvalidMode(t *testing.T) {
+	tunnel, _ := fakeTunnel(t, "127.0.0.1:9999")
+	_, _, err := resolveAddress(context.Background(), connectionMode("bogus"), "10.0.0.5:14740",
+		alwaysReachable, tunnel, &rest.Config{}, "flow-aggregator", "flow-aggregator-abc", io.Discard)
+	require.Error(t, err)
+}
+
+func TestDefaultDirectDialer(t *testing.T) {
+	t.Run("reachable address", func(t *testing.T) {
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer lis.Close()
+		go func() {
+			conn, err := lis.Accept()
+			if err == nil {
+				conn.Close()
+			}
+		}()
+		assert.NoError(t, defaultDirectDialer(context.Background(), lis.Addr().String()))
+	})
+
+	t.Run("unreachable address", func(t *testing.T) {
+		// Open and immediately close a listener: the OS will refuse connections to this
+		// now-unused loopback port right away, rather than this test depending on some specific
+		// external unreachable address.
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		addr := lis.Addr().String()
+		require.NoError(t, lis.Close())
+		assert.Error(t, defaultDirectDialer(context.Background(), addr))
+	})
+}
+
+// fakeCAProvider implements buildTLSConfig's anonymous ConfigMapCA interface for tests.
+type fakeCAProvider struct {
+	ca  []byte
+	err error
+}
+
+func (f fakeCAProvider) ConfigMapCA(context.Context, string) ([]byte, error) { return f.ca, f.err }
+
+func TestBuildTLSConfig(t *testing.T) {
+	t.Run("insecureSkipVerify bypasses the CA lookup entirely", func(t *testing.T) {
+		// erroringCA would fail the test (via require.Fail in ConfigMapCA) if it were ever called.
+		erroringCA := fakeCAProvider{err: errors.New("must not be called")}
+		cfg, err := buildTLSConfig(context.Background(), erroringCA, "flow-aggregator", "flow-aggregator.flow-aggregator.svc", true)
+		require.NoError(t, err)
+		assert.True(t, cfg.InsecureSkipVerify)
+		assert.Equal(t, "flow-aggregator.flow-aggregator.svc", cfg.ServerName)
+	})
+
+	t.Run("CA lookup fails", func(t *testing.T) {
+		_, err := buildTLSConfig(context.Background(), fakeCAProvider{err: errors.New("configmap not found")}, "flow-aggregator", "server-name", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--insecure-skip-tls-verify")
+	})
+
+	t.Run("CA data is not valid PEM", func(t *testing.T) {
+		_, err := buildTLSConfig(context.Background(), fakeCAProvider{ca: []byte("not a cert")}, "flow-aggregator", "server-name", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse")
+	})
+
+	t.Run("valid CA succeeds", func(t *testing.T) {
+		certPEM, _, err := tlstest.GenerateCert([]string{"flow-aggregator.flow-aggregator.svc"}, time.Now(), time.Hour, true, false, 0, "P256", false)
+		require.NoError(t, err)
+		cfg, err := buildTLSConfig(context.Background(), fakeCAProvider{ca: certPEM}, "flow-aggregator", "flow-aggregator.flow-aggregator.svc", false)
+		require.NoError(t, err)
+		assert.False(t, cfg.InsecureSkipVerify)
+		assert.Equal(t, "flow-aggregator.flow-aggregator.svc", cfg.ServerName)
+		require.NotNil(t, cfg.RootCAs)
+	})
+}
+
+func TestConfigMapCAReader(t *testing.T) {
+	t.Run("ConfigMap found with the expected key", func(t *testing.T) {
+		client := fake.NewSimpleClientset(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "flow-aggregator", Name: flowAggregatorCAConfigMapName},
+			Data:       map[string]string{flowAggregatorCAConfigMapKey: "ca-pem-bytes"},
+		})
+		reader := configMapCAReader{client: client}
+		ca, err := reader.ConfigMapCA(context.Background(), "flow-aggregator")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("ca-pem-bytes"), ca)
+	})
+
+	t.Run("ConfigMap found but missing the expected key", func(t *testing.T) {
+		client := fake.NewSimpleClientset(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "flow-aggregator", Name: flowAggregatorCAConfigMapName},
+			Data:       map[string]string{"unrelated-key": "value"},
+		})
+		reader := configMapCAReader{client: client}
+		_, err := reader.ConfigMapCA(context.Background(), "flow-aggregator")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing key")
+	})
+
+	t.Run("ConfigMap not found", func(t *testing.T) {
+		reader := configMapCAReader{client: fake.NewSimpleClientset()}
+		_, err := reader.ConfigMapCA(context.Background(), "flow-aggregator")
+		require.Error(t, err)
+	})
+}

--- a/pkg/antctl/raw/observe/discovery.go
+++ b/pkg/antctl/raw/observe/discovery.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
+)
+
+// flowAggregatorLabelSelector matches every Flow Aggregator Deployment, regardless of Namespace
+// or instance name. It is the same selector the flow-aggregator Helm chart applies to its own
+// Deployment (`app: flow-aggregator`).
+const flowAggregatorLabelSelector = "app=flow-aggregator"
+
+// defaultFlowAggregatorNamespace is used only as a fallback when --flow-aggregator-address
+// bypasses discovery and the user did not also set --flow-aggregator-namespace: there is no
+// discovered Pod to read a Namespace from, but a Namespace is still needed to fetch the
+// flow-aggregator-ca ConfigMap for TLS verification. It is NOT the default for discovery itself
+// (see discoverFlowAggregator): that default must remain cluster-wide, otherwise silently
+// narrowing the search to this one Namespace could hide a second instance in another Namespace
+// entirely, which is exactly the "silently pick one when several exist" behavior multi-instance
+// discovery is meant to avoid.
+const defaultFlowAggregatorNamespace = "flow-aggregator"
+
+// flowAggregatorTarget identifies a specific Flow Aggregator Pod to connect to.
+type flowAggregatorTarget struct {
+	namespace string
+	podName   string
+	podIP     string
+}
+
+// discoverFlowAggregator finds a single Flow Aggregator instance to connect to.
+//
+// namespace, when non-empty, restricts the search to that Namespace; otherwise the search is
+// cluster-wide. There is deliberately no "preferred instance" heuristic: each Flow Aggregator
+// instance runs its own independent FlowStreamService with no cross-instance relationship (e.g.
+// one instance may serve NetOps integration in Proxy mode, another in-cluster visibility in
+// Aggregate mode), so silently picking one when several exist would be actively misleading. If
+// more than one instance is found (i.e. Pods matching the label selector span more than one
+// Namespace), discovery fails and the caller must disambiguate explicitly with --server or
+// --flow-aggregator.
+func discoverFlowAggregator(ctx context.Context, k8sClient kubernetes.Interface, namespace string) (*flowAggregatorTarget, error) {
+	pods, err := k8sClient.CoreV1().Pods(resolveListNamespace(namespace)).List(ctx, metav1.ListOptions{
+		LabelSelector: flowAggregatorLabelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error when listing Flow Aggregator Pods: %w", err)
+	}
+
+	running := make([]corev1.Pod, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
+			running = append(running, pod)
+		}
+	}
+	if len(running) == 0 {
+		if namespace != "" {
+			return nil, fmt.Errorf("no running Flow Aggregator Pod found in Namespace %q", namespace)
+		}
+		return nil, fmt.Errorf("no running Flow Aggregator Pod found in the cluster")
+	}
+
+	namespaces := sets.New[string]()
+	for _, pod := range running {
+		namespaces.Insert(pod.Namespace)
+	}
+	if namespaces.Len() > 1 {
+		return nil, fmt.Errorf(
+			"found Flow Aggregator instances in multiple Namespaces (%s); use --server <host:port> or --flow-aggregator <namespace>/<deployment-name> to select one",
+			strings.Join(sets.List(namespaces), ", "),
+		)
+	}
+
+	// All remaining Pods are in the same Namespace, i.e. the same instance (possibly with
+	// several replicas in Proxy mode). Any one of them serves an equivalent ring buffer view
+	// for that instance's own traffic, so picking the first running Pod is not a disambiguation
+	// shortcut, just a stable, arbitrary choice among interchangeable replicas.
+	pod := running[0]
+	return &flowAggregatorTarget{namespace: pod.Namespace, podName: pod.Name, podIP: pod.Status.PodIP}, nil
+}
+
+// findFlowAggregatorByName resolves a specific Flow Aggregator instance named by the user via
+// --flow-aggregator <namespace>/<deployment-name>, bypassing the discovery search above.
+func findFlowAggregatorByName(ctx context.Context, k8sClient kubernetes.Interface, namespace, deploymentName string) (*flowAggregatorTarget, error) {
+	deployment, err := k8sClient.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error when getting Deployment %s/%s: %w", namespace, deploymentName, err)
+	}
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid selector on Deployment %s/%s: %w", namespace, deploymentName, err)
+	}
+	// We must resolve target to a pod IP because we're using SPDY port-forward
+	pods, err := k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, fmt.Errorf("error when listing Pods for Deployment %s/%s: %w", namespace, deploymentName, err)
+	}
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
+			return &flowAggregatorTarget{namespace: pod.Namespace, podName: pod.Name, podIP: pod.Status.PodIP}, nil
+		}
+	}
+	return nil, fmt.Errorf("no running Pod found for Deployment %s/%s", namespace, deploymentName)
+}
+
+func resolveListNamespace(namespace string) string {
+	if namespace == "" {
+		return metav1.NamespaceAll
+	}
+	return namespace
+}

--- a/pkg/antctl/raw/observe/discovery_test.go
+++ b/pkg/antctl/raw/observe/discovery_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func flowAggregatorPod(namespace, name, ip string, running bool) *corev1.Pod {
+	phase := corev1.PodRunning
+	if !running {
+		phase = corev1.PodPending
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    map[string]string{"app": "flow-aggregator"},
+		},
+		Status: corev1.PodStatus{Phase: phase, PodIP: ip},
+	}
+}
+
+func TestDiscoverFlowAggregator(t *testing.T) {
+	t.Run("no Pods at all, cluster-wide search", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		_, err := discoverFlowAggregator(context.Background(), client, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no running Flow Aggregator Pod found in the cluster")
+	})
+
+	t.Run("no Pods at all, Namespace-scoped search names the Namespace", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		_, err := discoverFlowAggregator(context.Background(), client, "flow-aggregator")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `no running Flow Aggregator Pod found in Namespace "flow-aggregator"`)
+	})
+
+	t.Run("Pods exist but none are Running with a PodIP", func(t *testing.T) {
+		client := fake.NewSimpleClientset(
+			flowAggregatorPod("flow-aggregator", "flow-aggregator-1", "10.0.0.5", false),
+			flowAggregatorPod("flow-aggregator", "flow-aggregator-2", "", true),
+		)
+		_, err := discoverFlowAggregator(context.Background(), client, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no running Flow Aggregator Pod found")
+	})
+
+	t.Run("single instance found", func(t *testing.T) {
+		client := fake.NewSimpleClientset(flowAggregatorPod("flow-aggregator", "flow-aggregator-abc", "10.0.0.5", true))
+		target, err := discoverFlowAggregator(context.Background(), client, "")
+		require.NoError(t, err)
+		assert.Equal(t, &flowAggregatorTarget{namespace: "flow-aggregator", podName: "flow-aggregator-abc", podIP: "10.0.0.5"}, target)
+	})
+
+	t.Run("multiple replicas of the same instance (same Namespace) is not ambiguous", func(t *testing.T) {
+		client := fake.NewSimpleClientset(
+			flowAggregatorPod("flow-aggregator", "flow-aggregator-1", "10.0.0.5", true),
+			flowAggregatorPod("flow-aggregator", "flow-aggregator-2", "10.0.0.6", true),
+		)
+		target, err := discoverFlowAggregator(context.Background(), client, "")
+		require.NoError(t, err)
+		assert.Equal(t, "flow-aggregator", target.namespace)
+	})
+
+	t.Run("instances in multiple Namespaces are ambiguous", func(t *testing.T) {
+		client := fake.NewSimpleClientset(
+			flowAggregatorPod("flow-aggregator-1", "flow-aggregator", "10.0.0.5", true),
+			flowAggregatorPod("flow-aggregator-2", "flow-aggregator", "10.0.0.6", true),
+		)
+		_, err := discoverFlowAggregator(context.Background(), client, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "found Flow Aggregator instances in multiple Namespaces")
+		assert.Contains(t, err.Error(), "--flow-aggregator")
+	})
+
+	t.Run("Namespace-scoped search only considers Pods in that Namespace", func(t *testing.T) {
+		client := fake.NewSimpleClientset(
+			flowAggregatorPod("flow-aggregator-1", "flow-aggregator", "10.0.0.5", true),
+			flowAggregatorPod("flow-aggregator-2", "flow-aggregator", "10.0.0.6", true),
+		)
+		target, err := discoverFlowAggregator(context.Background(), client, "flow-aggregator-2")
+		require.NoError(t, err)
+		assert.Equal(t, "flow-aggregator-2", target.namespace)
+		assert.Equal(t, "10.0.0.6", target.podIP)
+	})
+}
+
+func TestFindFlowAggregatorByName(t *testing.T) {
+	t.Run("Deployment not found", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		_, err := findFlowAggregatorByName(context.Background(), client, "flow-aggregator", "flow-aggregator")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error when getting Deployment")
+	})
+
+	t.Run("Deployment exists but has no matching running Pod", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "flow-aggregator", Name: "flow-aggregator"},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "flow-aggregator"}},
+			},
+		}
+		client := fake.NewSimpleClientset(deployment)
+		_, err := findFlowAggregatorByName(context.Background(), client, "flow-aggregator", "flow-aggregator")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no running Pod found for Deployment")
+	})
+
+	t.Run("Deployment exists with an invalid selector", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "flow-aggregator", Name: "flow-aggregator"},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: "InvalidOperator", Values: []string{"flow-aggregator"}},
+				}},
+			},
+		}
+		client := fake.NewSimpleClientset(deployment)
+		_, err := findFlowAggregatorByName(context.Background(), client, "flow-aggregator", "flow-aggregator")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid selector")
+	})
+
+	t.Run("successful match", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "flow-aggregator-1", Name: "flow-aggregator-1"},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "flow-aggregator"}},
+			},
+		}
+		pod := flowAggregatorPod("flow-aggregator-1", "flow-aggregator-1-xyz", "10.0.0.9", true)
+		client := fake.NewSimpleClientset(deployment, pod)
+		target, err := findFlowAggregatorByName(context.Background(), client, "flow-aggregator-1", "flow-aggregator-1")
+		require.NoError(t, err)
+		assert.Equal(t, &flowAggregatorTarget{namespace: "flow-aggregator-1", podName: "flow-aggregator-1-xyz", podIP: "10.0.0.9"}, target)
+	})
+
+	t.Run("Deployment's own Namespace is not considered when listing Pods for another", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "flow-aggregator-1", Name: "flow-aggregator-1"},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "flow-aggregator"}},
+			},
+		}
+		// Same label, wrong Namespace: must not be picked up.
+		pod := flowAggregatorPod("flow-aggregator-2", "flow-aggregator-2-xyz", "10.0.0.9", true)
+		client := fake.NewSimpleClientset(deployment, pod)
+		_, err := findFlowAggregatorByName(context.Background(), client, "flow-aggregator-1", "flow-aggregator-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no running Pod found for Deployment")
+	})
+}
+
+func TestResolveListNamespace(t *testing.T) {
+	assert.Equal(t, metav1.NamespaceAll, resolveListNamespace(""))
+	assert.Equal(t, "flow-aggregator", resolveListNamespace("flow-aggregator"))
+}

--- a/pkg/antctl/raw/observe/filter.go
+++ b/pkg/antctl/raw/observe/filter.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+
+	flowpb "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
+)
+
+var flowTypeValues = map[string]flowpb.FlowType{
+	"intra-node":    flowpb.FlowType_FLOW_TYPE_INTRA_NODE,
+	"inter-node":    flowpb.FlowType_FLOW_TYPE_INTER_NODE,
+	"to-external":   flowpb.FlowType_FLOW_TYPE_TO_EXTERNAL,
+	"from-external": flowpb.FlowType_FLOW_TYPE_FROM_EXTERNAL,
+}
+
+var directionValues = map[string]flowpb.FlowFilterDirection{
+	"both": flowpb.FlowFilterDirection_FLOW_FILTER_DIRECTION_BOTH,
+	"from": flowpb.FlowFilterDirection_FLOW_FILTER_DIRECTION_FROM,
+	"to":   flowpb.FlowFilterDirection_FLOW_FILTER_DIRECTION_TO,
+}
+
+// buildRequest translates CLI flags into a GetFlowsRequest. It validates values that are cheap to
+// check client-side (unknown --direction/--flow-type, unparsable --since, malformed --ip) so the
+// user gets immediate feedback instead of a round trip to the server for a mistake like a typo.
+func buildRequest(o *options) (*flowpb.GetFlowsRequest, error) {
+	direction, ok := directionValues[strings.ToLower(o.direction)]
+	if !ok {
+		return nil, fmt.Errorf("invalid --direction %q, must be one of both, from, to", o.direction)
+	}
+
+	var flowTypes []flowpb.FlowType
+	for _, v := range o.flowTypes {
+		ft, ok := flowTypeValues[strings.ToLower(v)]
+		if !ok {
+			return nil, fmt.Errorf("invalid --flow-type %q, must be one of intra-node, inter-node, to-external, from-external", v)
+		}
+		flowTypes = append(flowTypes, ft)
+	}
+
+	for _, ip := range o.ips {
+		if strings.Contains(ip, "/") {
+			if _, _, err := net.ParseCIDR(ip); err != nil {
+				return nil, fmt.Errorf("invalid --ip %q: %w", ip, err)
+			}
+		} else if net.ParseIP(ip) == nil {
+			return nil, fmt.Errorf("invalid --ip %q: not a valid IP address or CIDR", ip)
+		}
+	}
+
+	filter := &flowpb.FlowFilter{
+		Namespaces:       o.namespaces,
+		PodNames:         o.podNames,
+		PodLabelSelector: o.selector,
+		ServiceNames:     o.services,
+		FlowTypes:        flowTypes,
+		Ips:              o.ips,
+		Direction:        direction,
+	}
+
+	req := &flowpb.GetFlowsRequest{
+		// A single filter, even an all-empty one, is equivalent to omitting filters entirely:
+		// FlowStreamService treats an empty FlowFilter as "match everything" (no field has any
+		// values to check), so there is no special case needed here for "no filters requested".
+		Filters:  []*flowpb.FlowFilter{filter},
+		MaxCount: o.maxCount,
+		Follow:   o.follow,
+	}
+
+	if o.since != "" {
+		ts, err := parseSince(o.since)
+		if err != nil {
+			return nil, err
+		}
+		req.Since = ts
+	}
+
+	return req, nil
+}
+
+// parseSince accepts either a duration relative to now (e.g. "5m", the common case for a human at
+// a terminal) or an absolute RFC3339 timestamp (for scripts that want an exact, reproducible
+// cutoff rather than one that depends on when the command happens to run).
+func parseSince(s string) (*timestamppb.Timestamp, error) {
+	if d, err := time.ParseDuration(s); err == nil {
+		return timestamppb.New(time.Now().Add(-d)), nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return timestamppb.New(t), nil
+	}
+	return nil, fmt.Errorf("invalid --since %q: must be a duration (e.g. \"5m\") or an RFC3339 timestamp", s)
+}

--- a/pkg/antctl/raw/observe/filter_test.go
+++ b/pkg/antctl/raw/observe/filter_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	flowpb "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
+)
+
+func TestBuildRequest(t *testing.T) {
+	t.Run("defaults match everything", func(t *testing.T) {
+		req, err := buildRequest(&options{direction: "both"})
+		require.NoError(t, err)
+		require.Len(t, req.Filters, 1)
+		assert.Nil(t, req.Since)
+		assert.Equal(t, flowpb.FlowFilterDirection_FLOW_FILTER_DIRECTION_BOTH, req.Filters[0].GetDirection())
+	})
+
+	t.Run("maps every filter field", func(t *testing.T) {
+		req, err := buildRequest(&options{
+			namespaces: []string{"ns1", "ns2"},
+			podNames:   []string{"pod1"},
+			selector:   "app=frontend",
+			services:   []string{"svc1"},
+			flowTypes:  []string{"Inter-Node", "to-external"},
+			ips:        []string{"10.0.0.1", "10.0.0.0/24"},
+			direction:  "from",
+			maxCount:   5,
+			follow:     true,
+		})
+		require.NoError(t, err)
+		f := req.Filters[0]
+		assert.Equal(t, []string{"ns1", "ns2"}, f.GetNamespaces())
+		assert.Equal(t, []string{"pod1"}, f.GetPodNames())
+		assert.Equal(t, "app=frontend", f.GetPodLabelSelector())
+		assert.Equal(t, []string{"svc1"}, f.GetServiceNames())
+		assert.Equal(t, []flowpb.FlowType{flowpb.FlowType_FLOW_TYPE_INTER_NODE, flowpb.FlowType_FLOW_TYPE_TO_EXTERNAL}, f.GetFlowTypes())
+		assert.Equal(t, []string{"10.0.0.1", "10.0.0.0/24"}, f.GetIps())
+		assert.Equal(t, flowpb.FlowFilterDirection_FLOW_FILTER_DIRECTION_FROM, f.GetDirection())
+		assert.EqualValues(t, 5, req.GetMaxCount())
+		assert.True(t, req.GetFollow())
+	})
+
+	t.Run("rejects invalid direction", func(t *testing.T) {
+		_, err := buildRequest(&options{direction: "sideways"})
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects invalid flow type", func(t *testing.T) {
+		_, err := buildRequest(&options{direction: "both", flowTypes: []string{"diagonal"}})
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects malformed IP and CIDR", func(t *testing.T) {
+		_, err := buildRequest(&options{direction: "both", ips: []string{"not-an-ip"}})
+		assert.Error(t, err)
+		_, err = buildRequest(&options{direction: "both", ips: []string{"10.0.0.1/99"}})
+		assert.Error(t, err)
+	})
+
+	t.Run("accepts a relative duration for --since", func(t *testing.T) {
+		before := time.Now().Add(-5 * time.Minute)
+		req, err := buildRequest(&options{direction: "both", since: "5m"})
+		require.NoError(t, err)
+		require.NotNil(t, req.Since)
+		assert.WithinDuration(t, before, req.Since.AsTime(), 5*time.Second)
+	})
+
+	t.Run("accepts an absolute RFC3339 timestamp for --since", func(t *testing.T) {
+		req, err := buildRequest(&options{direction: "both", since: "2026-01-01T00:00:00Z"})
+		require.NoError(t, err)
+		require.NotNil(t, req.Since)
+		assert.Equal(t, "2026-01-01T00:00:00Z", req.Since.AsTime().Format(time.RFC3339))
+	})
+
+	t.Run("rejects an unparsable --since", func(t *testing.T) {
+		_, err := buildRequest(&options{direction: "both", since: "not-a-time"})
+		assert.Error(t, err)
+	})
+}

--- a/pkg/antctl/raw/observe/render.go
+++ b/pkg/antctl/raw/observe/render.go
@@ -1,0 +1,314 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/netip"
+	"strings"
+	"time"
+
+	flowpb "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
+)
+
+type outputFormat string
+
+const (
+	outputText outputFormat = "text"
+	outputJSON outputFormat = "json"
+)
+
+// renderer prints Flow records as they are received. render is called once per GetFlowsResponse
+// batch, so records appear as the stream produces them: with --follow, there generally is no
+// "once the command exits" moment to wait for and print everything at once.
+type renderer interface {
+	render(flows []*flowpb.Flow, droppedCount uint64) error
+}
+
+func newRenderer(format outputFormat, out io.Writer, humanReadableBytes bool) renderer {
+	if format == outputJSON {
+		return &jsonRenderer{out: out}
+	}
+	return &textRenderer{out: out, humanReadableBytes: humanReadableBytes}
+}
+
+// record is a flattened, stable subset of flowpb.Flow's fields, used by both renderers. It
+// deliberately does not embed the raw proto-generated struct: that struct is not meant to be
+// marshaled directly with encoding/json, and a purpose-built shape keeps observe's output stable
+// across proto schema changes that don't affect the fields surfaced here.
+type record struct {
+	EndTime                 string
+	SourceIP                string
+	DestinationIP           string
+	Protocol                uint32
+	SourcePort              uint32
+	DestinationPort         uint32
+	SourcePodNamespace      string
+	SourcePodName           string
+	DestinationPodNamespace string
+	DestinationPodName      string
+	DestinationServiceName  string
+	FlowType                string
+	OctetTotalCount         uint64
+	ReverseOctetTotalCount  uint64
+}
+
+func toRecord(f *flowpb.Flow) record {
+	r := record{
+		Protocol:        f.GetTransport().GetProtocolNumber(),
+		SourcePort:      f.GetTransport().GetSourcePort(),
+		DestinationPort: f.GetTransport().GetDestinationPort(),
+	}
+	if ts := f.GetEndTs(); ts != nil {
+		r.EndTime = ts.AsTime().Format(time.RFC3339)
+	}
+	if ip := f.GetIp(); ip != nil {
+		r.SourceIP = ipString(ip.GetSource())
+		r.DestinationIP = ipString(ip.GetDestination())
+	}
+	if k8s := f.GetK8S(); k8s != nil {
+		r.SourcePodNamespace = k8s.GetSourcePodNamespace()
+		r.SourcePodName = k8s.GetSourcePodName()
+		r.DestinationPodNamespace = k8s.GetDestinationPodNamespace()
+		r.DestinationPodName = k8s.GetDestinationPodName()
+		r.DestinationServiceName = k8s.GetDestinationServicePortName()
+		r.FlowType = k8s.GetFlowType().String()
+	}
+	if stats := f.GetStats(); stats != nil {
+		r.OctetTotalCount = stats.GetOctetTotalCount()
+	}
+	if stats := f.GetReverseStats(); stats != nil {
+		r.ReverseOctetTotalCount = stats.GetOctetTotalCount()
+	}
+	return r
+}
+
+func ipString(b []byte) string {
+	addr, ok := netip.AddrFromSlice(b)
+	if !ok {
+		return ""
+	}
+	return addr.String()
+}
+
+func (r record) endpoint(isSource bool) string {
+	namespace, name, ip := r.SourcePodNamespace, r.SourcePodName, r.SourceIP
+	if !isSource {
+		namespace, name, ip = r.DestinationPodNamespace, r.DestinationPodName, r.DestinationIP
+	}
+	if name != "" {
+		return fmt.Sprintf("%s/%s", truncatePrefix(namespace, maxNamespaceDisplayLen), truncateSuffix(name, maxPodNameDisplayLen))
+	}
+	return placeholderIfEmpty(ip)
+}
+
+// maxNamespaceDisplayLen and maxPodNameDisplayLen bound how much of a Namespace/Pod name
+// endpoint() shows in the text table before truncating with "...", so that the SOURCE/DESTINATION
+// columns stay a fixed, alignable width even for a pathologically long generated name, without
+// reintroducing the old "%-30.30s" bug's silent truncation (see truncatePrefix/truncateSuffix).
+// Both are comfortably above what this repo's own e2e tests generate (e.g. "testantctlobserve-"
+// plus an 8-character random suffix is 26 characters), so ordinary output is never truncated —
+// this only kicks in for names well beyond typical length.
+//
+// Namespace is truncated from the back of the budget, i.e. kept as a prefix: Namespace names are
+// usually meaningful start to finish, and even generated test Namespaces put the informative part
+// first, followed by a random suffix. Pod name is truncated from the front of the budget, i.e.
+// kept as a suffix: Kubernetes Pod names are "<Deployment>-<ReplicaSet hash>-<random suffix>", and
+// that trailing random suffix is what actually distinguishes two Pods of the same Deployment from
+// each other — keeping the front instead would risk two different Pods displaying identically.
+//
+// maxPodNameDisplayLen is wider than maxNamespaceDisplayLen because that "<ReplicaSet hash>-<random
+// suffix>" tail alone is already 16 characters, so even an ordinary, short Deployment name (e.g.
+// "flow-aggregator", 15 characters) produces a 32-character Pod name — comfortably over 30 despite
+// not being an outlier in any way. 40 leaves room for the hash/suffix plus a ~24-character
+// Deployment name without truncating anything routine.
+const (
+	maxNamespaceDisplayLen = 30
+	maxPodNameDisplayLen   = 40
+)
+
+// truncatePrefix keeps the first maxLen characters of s, replacing the rest with "...", so a
+// truncated value is always visually distinguishable from a genuinely short one (unlike the old
+// "%-30.30s", which silently produced the same output for both).
+func truncatePrefix(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// truncateSuffix is truncatePrefix's mirror image: it keeps the last maxLen characters.
+func truncateSuffix(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return "..." + s[len(s)-maxLen:]
+}
+
+// maxServiceNameDisplayLen bounds the "<name>:<port>" portion of a Service's
+// "<namespace>/<name>:<port>" identifier (see truncateServiceName), truncated as a suffix so the
+// port name survives — the same reasoning as maxPodNameDisplayLen: a Service can have several
+// ports (e.g. flow-aggregator's "grpc" and "flowstream-grpc"), and the port name at the very end
+// is what distinguishes flows to one from flows to the other. Unlike Pod names, Service names
+// carry no Kubernetes-generated hash/suffix tax, so this does not need extra headroom for that.
+const maxServiceNameDisplayLen = 30
+
+// truncateServiceName truncates a "<namespace>/<name>:<port>" Service identifier the same way
+// endpoint() truncates a Pod identifier: the Namespace is truncated as a prefix, the "<name>:<port>"
+// portion as a suffix. Falls back to a plain prefix truncation of the whole string for the rare
+// value with no "/" (e.g. a Service identifier without Namespace information).
+func truncateServiceName(s string) string {
+	namespace, rest, ok := strings.Cut(s, "/")
+	if !ok {
+		return truncatePrefix(s, serviceColumnWidth)
+	}
+	return fmt.Sprintf("%s/%s", truncatePrefix(namespace, maxNamespaceDisplayLen), truncateSuffix(rest, maxServiceNameDisplayLen))
+}
+
+// placeholderIfEmpty substitutes "-" (kubectl's convention for "no value", e.g. <none>) for an
+// empty field, so every column in the text output always has a visible, whitespace-delimited
+// token: a column left as pure padding is indistinguishable, positionally, from the whitespace
+// between columns.
+func placeholderIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// jsonRenderer writes one JSON object per line (line-delimited, not a single closing array), so
+// output can be consumed incrementally as the stream progresses, matching --follow's
+// unbounded/indefinite nature.
+type jsonRenderer struct {
+	out io.Writer
+}
+
+func (jr *jsonRenderer) render(flows []*flowpb.Flow, droppedCount uint64) error {
+	enc := json.NewEncoder(jr.out)
+	for _, f := range flows {
+		if err := enc.Encode(toRecord(f)); err != nil {
+			return err
+		}
+	}
+	if droppedCount > 0 {
+		if err := enc.Encode(map[string]uint64{"droppedCount": droppedCount}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// textRenderer prints one fixed-width line per flow. It deliberately does not use text/tabwriter:
+// tabwriter aligns columns per Flush() call, and with --follow there is no single point at which
+// all rows are known, so column widths would visibly jump between batches. Fixed-width fields
+// avoid that at the cost of long values (e.g. deeply-nested Namespace/Pod names) not lining up
+// perfectly — the same trade-off tools like "kubectl logs -f" make for the same reason.
+type textRenderer struct {
+	out                io.Writer
+	wroteHeader        bool
+	humanReadableBytes bool
+}
+
+// endpointColumnWidth is the SOURCE/DESTINATION column width: the longest possible value from
+// endpoint() is a fully-truncated Namespace (maxNamespaceDisplayLen plus the "..." marker) plus
+// "/" plus a fully-truncated Pod name (maxPodNameDisplayLen plus the "..." marker).
+const endpointColumnWidth = maxNamespaceDisplayLen + len("...") + len("/") + maxPodNameDisplayLen + len("...")
+
+// serviceColumnWidth is the SERVICE column width, computed the same way as endpointColumnWidth
+// (see truncateServiceName).
+const serviceColumnWidth = maxNamespaceDisplayLen + len("...") + len("/") + maxServiceNameDisplayLen + len("...")
+
+// flowTypeColumnWidth fits the longest of the FlowType enum's string values,
+// "FLOW_TYPE_FROM_EXTERNAL", exactly. FlowType is a closed set, so unlike SOURCE/DESTINATION there
+// is no truncation trade-off to make here — the column was simply too narrow (14) for its own
+// possible contents.
+var flowTypeColumnWidth = len(flowpb.FlowType_FLOW_TYPE_FROM_EXTERNAL.String())
+
+// textHeaderFormat and textRowFormat share their column widths via the "*" width verb (the width
+// is taken from the next argument) rather than duplicating hand-computed padding in two format
+// strings, which is exactly the kind of thing that silently drifts out of alignment when a width
+// changes.
+const textHeaderFormat = "%-9s %-*s %-*s %-5s %-6s %-6s %-*s %-*s %s"
+
+var textHeader = fmt.Sprintf(textHeaderFormat,
+	"TIME", endpointColumnWidth, "SOURCE", endpointColumnWidth, "DESTINATION", "PROTO", "SPORT", "DPORT",
+	serviceColumnWidth, "SERVICE", flowTypeColumnWidth, "FLOW_TYPE", "TOTAL BYTES")
+
+// The final column is %s, not %d: it holds either the raw byte count or, with --human-readable,
+// formatBytes' output, and which one is only known at render time (see textRenderer.render).
+const textRowFormat = "%-9s %-*s %-*s %-5d %-6d %-6d %-*s %-*s %s\n"
+
+// formatBytes renders n the way "ls -h"/"du -h" do: binary (1024-based) units, one decimal place
+// once past whole bytes. Used only for --human-readable text output; JSON output always uses the
+// raw integer, since a machine consumer wants an exact number, not a string it has to re-parse.
+func formatBytes(n uint64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%dB", n)
+	}
+	div, exp := uint64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	units := [...]string{"KB", "MB", "GB", "TB", "PB", "EB"}
+	return fmt.Sprintf("%.1f%s", float64(n)/float64(div), units[exp])
+}
+
+func (tr *textRenderer) render(flows []*flowpb.Flow, droppedCount uint64) error {
+	if !tr.wroteHeader && len(flows) > 0 {
+		if _, err := fmt.Fprintln(tr.out, textHeader); err != nil {
+			return err
+		}
+		tr.wroteHeader = true
+	}
+	for _, f := range flows {
+		r := toRecord(f)
+		endTime := r.EndTime
+		if len(endTime) > 8 {
+			// Keep just the time-of-day portion (HH:MM:SS) for a live tail; the date is rarely
+			// useful and the RFC3339 form does not fit the fixed-width column.
+			if t, err := time.Parse(time.RFC3339, r.EndTime); err == nil {
+				endTime = t.Local().Format("15:04:05")
+			}
+		}
+		totalBytes := r.OctetTotalCount + r.ReverseOctetTotalCount
+		bytesStr := fmt.Sprint(totalBytes)
+		if tr.humanReadableBytes {
+			bytesStr = formatBytes(totalBytes)
+		}
+		// A column left as pure padding (no visible value at all) cannot be told apart from
+		// the whitespace between columns when read back positionally — by a human glancing at
+		// the output, or by a script splitting on whitespace. "-" (kubectl's convention for
+		// "no value", e.g. <none>) keeps every column always present.
+		if _, err := fmt.Fprintf(tr.out, textRowFormat,
+			placeholderIfEmpty(endTime),
+			endpointColumnWidth, r.endpoint(true), endpointColumnWidth, r.endpoint(false),
+			r.Protocol, r.SourcePort, r.DestinationPort,
+			serviceColumnWidth, placeholderIfEmpty(truncateServiceName(r.DestinationServiceName)),
+			flowTypeColumnWidth, placeholderIfEmpty(r.FlowType),
+			bytesStr); err != nil {
+			return err
+		}
+	}
+	if droppedCount > 0 {
+		if _, err := fmt.Fprintf(tr.out, "# warning: %d flow(s) dropped, consumer fell behind the ring buffer\n", droppedCount); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/antctl/raw/observe/render_test.go
+++ b/pkg/antctl/raw/observe/render_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	flowpb "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
+)
+
+func TestFormatBytes(t *testing.T) {
+	cases := []struct {
+		n    uint64
+		want string
+	}{
+		{0, "0B"},
+		{1, "1B"},
+		{1023, "1023B"},
+		{1024, "1.0KB"},
+		{1536, "1.5KB"},
+		{1048576, "1.0MB"},
+		{5 * 1048576, "5.0MB"},
+		{1073741824, "1.0GB"},
+		{1099511627776, "1.0TB"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, formatBytes(c.n), "formatBytes(%d)", c.n)
+	}
+}
+
+func TestTruncatePrefix(t *testing.T) {
+	assert.Equal(t, "short", truncatePrefix("short", 30))
+	exactly30 := strings.Repeat("a", 30)
+	assert.Equal(t, exactly30, truncatePrefix(exactly30, 30))
+	long := strings.Repeat("a", 31)
+	assert.Equal(t, strings.Repeat("a", 30)+"...", truncatePrefix(long, 30))
+}
+
+func TestTruncateSuffix(t *testing.T) {
+	assert.Equal(t, "short", truncateSuffix("short", 30))
+	exactly30 := strings.Repeat("b", 30)
+	assert.Equal(t, exactly30, truncateSuffix(exactly30, 30))
+	long := "deployment-name-668d6bf9bc-hhs4x"
+	assert.Equal(t, "..."+long[len(long)-30:], truncateSuffix(long, 30))
+	// The trailing random suffix, the part that actually distinguishes two Pods of the same
+	// Deployment, must survive truncation.
+	assert.Contains(t, truncateSuffix(long, 30), "668d6bf9bc-hhs4x")
+}
+
+func TestRecordEndpoint(t *testing.T) {
+	t.Run("short Namespace and Pod name are shown in full", func(t *testing.T) {
+		r := record{SourcePodNamespace: "default", SourcePodName: "perftest-a"}
+		assert.Equal(t, "default/perftest-a", r.endpoint(true))
+	})
+
+	t.Run("long Namespace is truncated as a prefix, long Pod name as a suffix", func(t *testing.T) {
+		namespace := "superlongnamespacenametomakeyoucry-and-then-some-more"
+		podName := "iamveryevilandIchoseeaverylongnameformyreplicasetjusttodriveyoucrazy-668d6bf9bc-hhs4"
+		r := record{DestinationPodNamespace: namespace, DestinationPodName: podName}
+		got := r.endpoint(false)
+
+		ns, name, ok := strings.Cut(got, "/")
+		assert.True(t, ok, "expected exactly one '/' separating Namespace and Pod name, got %q", got)
+		assert.True(t, strings.HasPrefix(namespace, strings.TrimSuffix(ns, "...")))
+		assert.True(t, strings.HasSuffix(name, "...") == false)
+		assert.True(t, strings.HasSuffix(podName, strings.TrimPrefix(name, "...")))
+		// The Pod's trailing random suffix must remain visible: that's the part that
+		// distinguishes it from another Pod of the same Deployment/ReplicaSet.
+		assert.Contains(t, name, "668d6bf9bc-hhs4")
+	})
+
+	t.Run("falls back to the IP when there is no Pod name", func(t *testing.T) {
+		r := record{SourceIP: "10.0.0.5"}
+		assert.Equal(t, "10.0.0.5", r.endpoint(true))
+	})
+
+	t.Run("falls back to the placeholder when neither a Pod name nor an IP is set", func(t *testing.T) {
+		r := record{}
+		assert.Equal(t, "-", r.endpoint(true))
+	})
+}
+
+func TestTruncateServiceName(t *testing.T) {
+	t.Run("short value is shown in full", func(t *testing.T) {
+		assert.Equal(t, "default/kubernetes:https", truncateServiceName("default/kubernetes:https"))
+	})
+
+	t.Run("long Namespace is truncated as a prefix, long name:port as a suffix", func(t *testing.T) {
+		namespace := strings.Repeat("n", maxNamespaceDisplayLen+5)
+		nameAndPort := strings.Repeat("s", maxServiceNameDisplayLen+5) + ":flowstream-grpc"
+		got := truncateServiceName(namespace + "/" + nameAndPort)
+
+		ns, rest, ok := strings.Cut(got, "/")
+		require.True(t, ok)
+		assert.Equal(t, namespace[:maxNamespaceDisplayLen]+"...", ns)
+		assert.Equal(t, "..."+nameAndPort[len(nameAndPort)-maxServiceNameDisplayLen:], rest)
+		// The port name, the part that distinguishes multiple ports on the same Service, must
+		// survive truncation.
+		assert.Contains(t, rest, ":flowstream-grpc")
+	})
+
+	t.Run("value with no '/' is truncated as a single prefix", func(t *testing.T) {
+		long := strings.Repeat("x", serviceColumnWidth+10)
+		got := truncateServiceName(long)
+		assert.True(t, strings.HasSuffix(got, "..."))
+		assert.LessOrEqual(t, len(got), serviceColumnWidth+len("..."))
+	})
+
+	t.Run("empty value stays empty (placeholder is applied by the caller)", func(t *testing.T) {
+		assert.Equal(t, "", truncateServiceName(""))
+	})
+}
+
+func TestIPString(t *testing.T) {
+	assert.Equal(t, "10.0.0.5", ipString(netip.MustParseAddr("10.0.0.5").AsSlice()))
+	assert.Equal(t, "fd00::1", ipString(netip.MustParseAddr("fd00::1").AsSlice()))
+	assert.Equal(t, "", ipString(nil))
+	assert.Equal(t, "", ipString([]byte{1, 2, 3}))
+}
+
+func testFlow() *flowpb.Flow {
+	return &flowpb.Flow{
+		Id:    "flow-1",
+		EndTs: timestamppb.New(time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC)),
+		Ip: &flowpb.IP{
+			Source:      netip.MustParseAddr("10.0.0.5").AsSlice(),
+			Destination: netip.MustParseAddr("10.0.0.6").AsSlice(),
+		},
+		Transport: &flowpb.Transport{ProtocolNumber: 6, SourcePort: 12345, DestinationPort: 80},
+		K8S: &flowpb.Kubernetes{
+			SourcePodNamespace:         "default",
+			SourcePodName:              "perftest-a",
+			DestinationPodNamespace:    "default",
+			DestinationPodName:         "perftest-b",
+			DestinationServicePortName: "default/frontend:http",
+			FlowType:                   flowpb.FlowType_FLOW_TYPE_INTRA_NODE,
+		},
+		Stats:        &flowpb.Stats{OctetTotalCount: 1000},
+		ReverseStats: &flowpb.Stats{OctetTotalCount: 500},
+	}
+}
+
+func TestToRecord(t *testing.T) {
+	t.Run("fully populated flow", func(t *testing.T) {
+		r := toRecord(testFlow())
+		assert.Equal(t, "2026-01-02T15:04:05Z", r.EndTime)
+		assert.Equal(t, "10.0.0.5", r.SourceIP)
+		assert.Equal(t, "10.0.0.6", r.DestinationIP)
+		assert.EqualValues(t, 6, r.Protocol)
+		assert.EqualValues(t, 12345, r.SourcePort)
+		assert.EqualValues(t, 80, r.DestinationPort)
+		assert.Equal(t, "default", r.SourcePodNamespace)
+		assert.Equal(t, "perftest-a", r.SourcePodName)
+		assert.Equal(t, "default", r.DestinationPodNamespace)
+		assert.Equal(t, "perftest-b", r.DestinationPodName)
+		assert.Equal(t, "default/frontend:http", r.DestinationServiceName)
+		assert.Equal(t, "FLOW_TYPE_INTRA_NODE", r.FlowType)
+		assert.EqualValues(t, 1000, r.OctetTotalCount)
+		assert.EqualValues(t, 500, r.ReverseOctetTotalCount)
+	})
+
+	t.Run("minimal flow with nil optional fields", func(t *testing.T) {
+		r := toRecord(&flowpb.Flow{})
+		assert.Equal(t, record{}, r)
+	})
+}
+
+func TestNewRenderer(t *testing.T) {
+	assert.IsType(t, &jsonRenderer{}, newRenderer(outputJSON, io.Discard, false))
+	assert.IsType(t, &textRenderer{}, newRenderer(outputText, io.Discard, false))
+	// Any other/unrecognized value falls back to text, matching runE's own validation, which
+	// rejects anything but "text"/"json" before newRenderer is ever called.
+	assert.IsType(t, &textRenderer{}, newRenderer(outputFormat("bogus"), io.Discard, false))
+}
+
+func TestJSONRenderer_Render(t *testing.T) {
+	t.Run("one line of JSON per flow", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := &jsonRenderer{out: &buf}
+		require.NoError(t, r.render([]*flowpb.Flow{testFlow(), testFlow()}, 0))
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2)
+		var decoded record
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &decoded))
+		assert.Equal(t, "perftest-a", decoded.SourcePodName)
+	})
+
+	t.Run("dropped count is appended as an extra line", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := &jsonRenderer{out: &buf}
+		require.NoError(t, r.render([]*flowpb.Flow{testFlow()}, 3))
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2)
+		var dropped map[string]uint64
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &dropped))
+		assert.EqualValues(t, 3, dropped["droppedCount"])
+	})
+
+	t.Run("no flows and no drops writes nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := &jsonRenderer{out: &buf}
+		require.NoError(t, r.render(nil, 0))
+		assert.Empty(t, buf.String())
+	})
+}
+
+func TestTextRenderer_Render(t *testing.T) {
+	t.Run("header is written once, only when there is at least one flow", func(t *testing.T) {
+		var buf bytes.Buffer
+		tr := &textRenderer{out: &buf}
+		require.NoError(t, tr.render(nil, 0))
+		assert.Empty(t, buf.String(), "an empty batch must not print a header on its own")
+
+		require.NoError(t, tr.render([]*flowpb.Flow{testFlow()}, 0))
+		firstOutput := buf.String()
+		assert.Equal(t, 1, strings.Count(firstOutput, "TIME"), "header must appear exactly once")
+
+		buf.Reset()
+		require.NoError(t, tr.render([]*flowpb.Flow{testFlow()}, 0))
+		assert.NotContains(t, buf.String(), "TIME", "header must not be repeated on a later batch")
+	})
+
+	t.Run("row contains the expected fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		tr := &textRenderer{out: &buf}
+		require.NoError(t, tr.render([]*flowpb.Flow{testFlow()}, 0))
+		lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+		require.Len(t, lines, 2)
+		row := lines[1]
+		assert.Contains(t, row, "default/perftest-a")
+		assert.Contains(t, row, "default/perftest-b")
+		assert.Contains(t, row, "default/frontend:http")
+		assert.Contains(t, row, "FLOW_TYPE_INTRA_NODE")
+		assert.Contains(t, row, "1500") // OctetTotalCount + ReverseOctetTotalCount, raw bytes
+	})
+
+	t.Run("human-readable bytes formats the total instead of the raw count", func(t *testing.T) {
+		var buf bytes.Buffer
+		tr := &textRenderer{out: &buf, humanReadableBytes: true}
+		require.NoError(t, tr.render([]*flowpb.Flow{testFlow()}, 0))
+		row := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")[1]
+		assert.Contains(t, row, "1.5KB")
+		assert.NotContains(t, row, "1500")
+	})
+
+	t.Run("dropped count produces a warning line", func(t *testing.T) {
+		var buf bytes.Buffer
+		tr := &textRenderer{out: &buf}
+		require.NoError(t, tr.render([]*flowpb.Flow{testFlow()}, 7))
+		assert.Contains(t, buf.String(), "warning: 7 flow(s) dropped")
+	})
+
+	t.Run("empty fields fall back to the placeholder", func(t *testing.T) {
+		var buf bytes.Buffer
+		tr := &textRenderer{out: &buf}
+		require.NoError(t, tr.render([]*flowpb.Flow{{}}, 0))
+		row := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")[1]
+		fields := strings.Fields(row)
+		for _, f := range fields {
+			assert.NotEmpty(t, f)
+		}
+	})
+}
+
+// erroringWriter fails every Write after the first n bytes it has already accepted, so tests can
+// exercise a renderer's otherwise-untested "the output stream itself failed" error paths.
+type erroringWriter struct {
+	failAfter int
+	written   int
+}
+
+func (w *erroringWriter) Write(p []byte) (int, error) {
+	if w.written >= w.failAfter {
+		return 0, errors.New("write failed")
+	}
+	w.written += len(p)
+	return len(p), nil
+}
+
+func TestJSONRenderer_Render_WriteError(t *testing.T) {
+	r := &jsonRenderer{out: &erroringWriter{failAfter: 0}}
+	err := r.render([]*flowpb.Flow{testFlow()}, 0)
+	require.Error(t, err)
+}
+
+func TestTextRenderer_Render_WriteError(t *testing.T) {
+	t.Run("header write fails", func(t *testing.T) {
+		tr := &textRenderer{out: &erroringWriter{failAfter: 0}}
+		err := tr.render([]*flowpb.Flow{testFlow()}, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("row write fails after the header succeeds", func(t *testing.T) {
+		tr := &textRenderer{out: &erroringWriter{failAfter: len(textHeader) + 1}}
+		err := tr.render([]*flowpb.Flow{testFlow()}, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("dropped-count warning write fails", func(t *testing.T) {
+		tr := &textRenderer{out: &erroringWriter{failAfter: 0}, wroteHeader: true}
+		err := tr.render(nil, 5)
+		require.Error(t, err)
+	})
+}
+
+func TestFlowTypeColumnWidthFitsLongestValue(t *testing.T) {
+	// FlowType is a closed enum: this is a compile-time-adjacent guard that the column width
+	// tracks whichever value happens to be longest, rather than a hand-picked number that could
+	// silently go stale if a longer FlowType value were ever added.
+	for _, v := range []string{
+		"FLOW_TYPE_UNSPECIFIED",
+		"FLOW_TYPE_INTRA_NODE",
+		"FLOW_TYPE_INTER_NODE",
+		"FLOW_TYPE_TO_EXTERNAL",
+		"FLOW_TYPE_FROM_EXTERNAL",
+	} {
+		assert.LessOrEqualf(t, len(v), flowTypeColumnWidth, "FlowType value %q does not fit flowTypeColumnWidth", v)
+	}
+}

--- a/pkg/config/flowaggregator/config.go
+++ b/pkg/config/flowaggregator/config.go
@@ -245,7 +245,9 @@ type FlowLoggerConfig struct {
 type FlowStreamServiceConfig struct {
 	// Enable is the switch to enable the FlowStreamService gRPC server (port 14740). The
 	// server streams flow records to consumers such as antrea-ui. It uses server-side TLS
-	// (the same self-signed certificate as the gRPC collector) but no client authentication.
+	// (the same self-signed certificate as the gRPC collector). Clients must additionally
+	// present a valid Kubernetes bearer token (as "authorization: Bearer <token>" gRPC
+	// metadata), which is validated via the TokenReview API.
 	// Defaults to false.
 	Enable *bool `yaml:"enable,omitempty"`
 }

--- a/pkg/config/flowaggregator/config.go
+++ b/pkg/config/flowaggregator/config.go
@@ -246,8 +246,10 @@ type FlowStreamServiceConfig struct {
 	// Enable is the switch to enable the FlowStreamService gRPC server (port 14740). The
 	// server streams flow records to consumers such as antrea-ui. It uses server-side TLS
 	// (the same self-signed certificate as the gRPC collector). Clients must additionally
-	// present a valid Kubernetes bearer token (as "authorization: Bearer <token>" gRPC
-	// metadata), which is validated via the TokenReview API.
+	// present a valid Kubernetes authorization (either a bearer token as
+	// "authorization: Bearer <token>" gRPC metadata, or a PEM client cert+key pair in the
+	// client-cert-bin/client-key-bin headers), which is validated via the TokenReview API
+	// (in the case of bearer token) or SelfSubjectReview API (for cert and key pair).
 	// Defaults to false.
 	Enable *bool `yaml:"enable,omitempty"`
 }

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
 	flowpb "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
@@ -138,6 +139,7 @@ type flowAggregator struct {
 
 func NewFlowAggregator(
 	k8sClient kubernetes.Interface,
+	baseConfig *rest.Config,
 	clusterUUID uuid.UUID,
 	podStore objectstore.PodStore,
 	nodeStore objectstore.NodeStore,
@@ -203,7 +205,7 @@ func NewFlowAggregator(
 		certificateUpdateCh:         make(chan struct{}, 1),
 	}
 	if *opt.Config.FlowStreamService.Enable {
-		fa.flowStreamService = flowstreamservice.NewFlowStreamService(fa.recordBuffer, flowstreamservice.NewStreamServerAuthenticator(k8sClient))
+		fa.flowStreamService = flowstreamservice.NewFlowStreamService(fa.recordBuffer, flowstreamservice.NewStreamServerAuthenticator(k8sClient, baseConfig))
 		fa.flowStreamSvcUpdateCh = make(chan struct{}, 1)
 	}
 

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -203,7 +203,7 @@ func NewFlowAggregator(
 		certificateUpdateCh:         make(chan struct{}, 1),
 	}
 	if *opt.Config.FlowStreamService.Enable {
-		fa.flowStreamService = flowstreamservice.NewFlowStreamService(fa.recordBuffer)
+		fa.flowStreamService = flowstreamservice.NewFlowStreamService(fa.recordBuffer, flowstreamservice.NewStreamServerAuthenticator(k8sClient))
 		fa.flowStreamSvcUpdateCh = make(chan struct{}, 1)
 	}
 

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -39,6 +39,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -1169,7 +1170,7 @@ func TestNewFlowAggregator(t *testing.T) {
 			require.NoError(t, err)
 			_, err = f.Write(b)
 			require.NoError(t, err)
-			fa, err := NewFlowAggregator(client, clusterUUID, mockPodStore, mockNodeStore, mockServiceStore, fileName)
+			fa, err := NewFlowAggregator(client, &rest.Config{}, clusterUUID, mockPodStore, mockNodeStore, mockServiceStore, fileName)
 			require.NoError(t, err)
 			assert.Equal(t, clusterUUID, fa.clusterUUID)
 			assert.Equal(t, clusterID, fa.clusterID)

--- a/pkg/flowaggregator/flowstreamservice/authenticator.go
+++ b/pkg/flowaggregator/flowstreamservice/authenticator.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flowstreamservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// tokenCacheTTL bounds how long a successful TokenReview outcome is cached
+	// before the token is re-validated against the Kubernetes API server. This
+	// keeps a long-lived or frequently reconnecting client from generating a
+	// TokenReview call on every request while still picking up token
+	// invalidation (e.g. ServiceAccount deletion) within a bounded time.
+	tokenCacheTTL = 30 * time.Second
+
+	// authorizationMetadataKey is the gRPC metadata key clients must set to
+	// carry their bearer token, mirroring the HTTP Authorization header.
+	// gRPC metadata keys are matched case-insensitively.
+	authorizationMetadataKey = "authorization"
+	// bearerTokenPrefix precedes the token in the authorization metadata
+	// value, e.g. "Bearer <token>" (RFC 6750).
+	bearerTokenPrefix = "Bearer "
+)
+
+// tokenCacheEntry is a cached TokenReview outcome for a bearer token.
+type tokenCacheEntry struct {
+	user      user.Info
+	expiresAt time.Time
+}
+
+// StreamServerAuthenticator is a gRPC stream server interceptor that
+// authenticates FlowStreamService clients using a Kubernetes bearer token
+// carried in the "authorization" gRPC metadata header, validated via the
+// TokenReview API. The resolved identity is attached to the stream context
+// via request.WithUser and can be read back with request.UserFrom by
+// authorization logic.
+type StreamServerAuthenticator struct {
+	k8sClient kubernetes.Interface
+
+	cacheMutex sync.Mutex
+	cache      map[string]tokenCacheEntry
+}
+
+// NewStreamServerAuthenticator creates a StreamServerAuthenticator that
+// validates bearer tokens against the Kubernetes API server via k8sClient.
+func NewStreamServerAuthenticator(k8sClient kubernetes.Interface) *StreamServerAuthenticator {
+	return &StreamServerAuthenticator{
+		k8sClient: k8sClient,
+		cache:     make(map[string]tokenCacheEntry),
+	}
+}
+
+// StreamInterceptor implements grpc.StreamServerInterceptor. It rejects the
+// call with codes.Unauthenticated if the request does not carry a valid
+// bearer token; otherwise it attaches the resolved identity to the stream
+// context before invoking handler.
+func (a *StreamServerAuthenticator) StreamInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	token, err := tokenFromContext(ss.Context())
+	if err != nil {
+		return status.Error(codes.Unauthenticated, err.Error())
+	}
+
+	u, err := a.authenticate(ss.Context(), token)
+	if err != nil {
+		klog.ErrorS(err, "FlowStreamService client authentication failed")
+		return status.Error(codes.Unauthenticated, "invalid bearer token")
+	}
+
+	return handler(srv, &authenticatedServerStream{
+		ServerStream: ss,
+		ctx:          request.WithUser(ss.Context(), u),
+	})
+}
+
+// tokenFromContext extracts the bearer token from the authorization gRPC
+// metadata header of an incoming stream.
+func tokenFromContext(ctx context.Context) (string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("missing gRPC metadata")
+	}
+	values := md.Get(authorizationMetadataKey)
+	if len(values) == 0 {
+		return "", fmt.Errorf("missing authorization header")
+	}
+	token, ok := strings.CutPrefix(values[0], bearerTokenPrefix)
+	if !ok || token == "" {
+		return "", fmt.Errorf("authorization header must be a bearer token")
+	}
+	return token, nil
+}
+
+// authenticate resolves token to an identity, returning a cached TokenReview
+// outcome when available.
+func (a *StreamServerAuthenticator) authenticate(ctx context.Context, token string) (user.Info, error) {
+	if u, ok := a.getCachedUser(token); ok {
+		return u, nil
+	}
+
+	tokenReview := &authenticationv1.TokenReview{
+		Spec: authenticationv1.TokenReviewSpec{Token: token},
+	}
+	review, err := a.k8sClient.AuthenticationV1().TokenReviews().Create(ctx, tokenReview, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("TokenReview request failed: %w", err)
+	}
+	if review.Status.Error != "" {
+		return nil, fmt.Errorf("TokenReview returned an error: %s", review.Status.Error)
+	}
+	if !review.Status.Authenticated {
+		return nil, fmt.Errorf("token is not authenticated")
+	}
+
+	u := &user.DefaultInfo{
+		Name:   review.Status.User.Username,
+		UID:    review.Status.User.UID,
+		Groups: review.Status.User.Groups,
+		Extra:  convertExtra(review.Status.User.Extra),
+	}
+	a.cacheUser(token, u)
+	return u, nil
+}
+
+// convertExtra converts the Extra field of a TokenReview's UserInfo
+// (map[string]authenticationv1.ExtraValue) into the plain map[string][]string
+// expected by user.DefaultInfo.Extra. authenticationv1.ExtraValue is defined
+// as `type ExtraValue []string`, so each value assigns to []string without a
+// cast; it is the outer map type that differs and must be rebuilt key by key.
+func convertExtra(extra map[string]authenticationv1.ExtraValue) map[string][]string {
+	if extra == nil {
+		return nil
+	}
+	out := make(map[string][]string, len(extra))
+	for k, v := range extra {
+		out[k] = v
+	}
+	return out
+}
+
+func (a *StreamServerAuthenticator) getCachedUser(token string) (user.Info, bool) {
+	a.cacheMutex.Lock()
+	defer a.cacheMutex.Unlock()
+
+	entry, ok := a.cache[token]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(a.cache, token)
+		return nil, false
+	}
+	return entry.user, true
+}
+
+func (a *StreamServerAuthenticator) cacheUser(token string, u user.Info) {
+	a.cacheMutex.Lock()
+	defer a.cacheMutex.Unlock()
+
+	// Opportunistically evict expired entries so that a client rotating
+	// through many short-lived tokens over time does not grow the cache
+	// unboundedly.
+	now := time.Now()
+	for t, e := range a.cache {
+		if now.After(e.expiresAt) {
+			delete(a.cache, t)
+		}
+	}
+	a.cache[token] = tokenCacheEntry{user: u, expiresAt: now.Add(tokenCacheTTL)}
+}
+
+// authenticatedServerStream wraps a grpc.ServerStream to override Context(),
+// since grpc.ServerStream does not otherwise allow attaching values to the
+// stream's context.
+type authenticatedServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *authenticatedServerStream) Context() context.Context {
+	return s.ctx
+}

--- a/pkg/flowaggregator/flowstreamservice/authenticator.go
+++ b/pkg/flowaggregator/flowstreamservice/authenticator.go
@@ -16,6 +16,8 @@ package flowstreamservice
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"sync"
@@ -30,16 +32,18 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 )
 
 const (
-	// tokenCacheTTL bounds how long a successful TokenReview outcome is cached
-	// before the token is re-validated against the Kubernetes API server. This
-	// keeps a long-lived or frequently reconnecting client from generating a
-	// TokenReview call on every request while still picking up token
-	// invalidation (e.g. ServiceAccount deletion) within a bounded time.
-	tokenCacheTTL = 30 * time.Second
+	// credentialCacheTTL bounds how long a successful authentication outcome
+	// (TokenReview or SelfSubjectReview) is cached before the credential is
+	// re-validated against the Kubernetes API server. This keeps a long-lived
+	// or frequently reconnecting client from generating an API call on every
+	// request while still picking up revocation (e.g. ServiceAccount deletion,
+	// cert expiry) within a bounded time.
+	credentialCacheTTL = 30 * time.Second
 
 	// authorizationMetadataKey is the gRPC metadata key clients must set to
 	// carry their bearer token, mirroring the HTTP Authorization header.
@@ -48,50 +52,92 @@ const (
 	// bearerTokenPrefix precedes the token in the authorization metadata
 	// value, e.g. "Bearer <token>" (RFC 6750).
 	bearerTokenPrefix = "Bearer "
+
+	// clientCertMetadataKey and clientKeyMetadataKey carry a PEM-encoded X.509
+	// client certificate and private key respectively. This is how a client
+	// that authenticated via a Pinniped Concierge TokenCredentialRequest (which
+	// always returns a short-lived client cert, never a bearer token) presents
+	// its credential. The "-bin" suffix is required by gRPC for metadata values
+	// that are not valid ASCII; grpc-go base64-encodes/decodes such headers
+	// transparently at the transport layer, so values read back from the
+	// incoming context here are already raw PEM bytes, not base64 text.
+	clientCertMetadataKey = "client-cert-bin"
+	clientKeyMetadataKey  = "client-key-bin"
 )
 
-// tokenCacheEntry is a cached TokenReview outcome for a bearer token.
-type tokenCacheEntry struct {
+// newKubernetesClientForConfig builds a Kubernetes ClientSet for cfg. It is a package-level variable,
+// so tests can substitute a fake SelfSubjectReviews implementation without standing up a real
+// TLS-terminating API server for the ephemeral, per-request client-cert config to authenticate against.
+var newKubernetesClientForConfig = func(cfg *rest.Config) (kubernetes.Interface, error) {
+	return kubernetes.NewForConfig(cfg)
+}
+
+// clientCredential is the credential a connecting client presented, extracted from gRPC metadata.
+// Exactly one of token or (certPEM, keyPEM) is set.
+type clientCredential struct {
+	token   string
+	certPEM []byte
+	keyPEM  []byte
+}
+
+// cacheKey returns the key under which this credential's resolved identity is cached. Both Bearer tokens
+// and client certs are cached by a digest of the token or cert+key, to prevent data be exposed via heap
+// dumps etc.
+func (c *clientCredential) cacheKey() string {
+	h := sha256.New()
+	if c.token != "" {
+		h.Write([]byte(c.token))
+		return "token:" + hex.EncodeToString(h.Sum(nil))
+	}
+	h.Write(c.certPEM)
+	h.Write(c.keyPEM)
+	return "cert:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// credentialCacheEntry is a cached authentication result for a clientCredential.
+type credentialCacheEntry struct {
 	user      user.Info
 	expiresAt time.Time
 }
 
-// StreamServerAuthenticator is a gRPC stream server interceptor that
-// authenticates FlowStreamService clients using a Kubernetes bearer token
-// carried in the "authorization" gRPC metadata header, validated via the
-// TokenReview API. The resolved identity is attached to the stream context
-// via request.WithUser and can be read back with request.UserFrom by
-// authorization logic.
+// StreamServerAuthenticator is a gRPC stream server interceptor that authenticates FlowStreamService clients.
+// Clients present either a Kubernetes bearer token (validated via TokenReview) or a short-lived X.509
+// client certificate (validated via SelfSubjectReview against the API server), both carried as gRPC metadata.
+// The resolved identity is attached to the stream context via request.WithUser and can be read back with
+// request.UserFrom by authorization logic.
 type StreamServerAuthenticator struct {
 	k8sClient kubernetes.Interface
+	// baseConfig is flow-aggregator's own in-cluster rest.Config. It is never used to authenticate as
+	// flow-aggregator itself; every per-request config derived from it via rest.AnonymousClientConfig
+	// strips flow-aggregator's own credentials first (see authenticateCert), keeping only the Host/CA
+	// fields needed to reach and verify the real API server.
+	baseConfig *rest.Config
 
 	cacheMutex sync.Mutex
-	cache      map[string]tokenCacheEntry
+	cache      map[string]credentialCacheEntry
 }
 
-// NewStreamServerAuthenticator creates a StreamServerAuthenticator that
-// validates bearer tokens against the Kubernetes API server via k8sClient.
-func NewStreamServerAuthenticator(k8sClient kubernetes.Interface) *StreamServerAuthenticator {
+func NewStreamServerAuthenticator(k8sClient kubernetes.Interface, baseConfig *rest.Config) *StreamServerAuthenticator {
 	return &StreamServerAuthenticator{
-		k8sClient: k8sClient,
-		cache:     make(map[string]tokenCacheEntry),
+		k8sClient:  k8sClient,
+		baseConfig: baseConfig,
+		cache:      make(map[string]credentialCacheEntry),
 	}
 }
 
-// StreamInterceptor implements grpc.StreamServerInterceptor. It rejects the
-// call with codes.Unauthenticated if the request does not carry a valid
-// bearer token; otherwise it attaches the resolved identity to the stream
-// context before invoking handler.
+// StreamInterceptor implements grpc.StreamServerInterceptor. It rejects the call with codes.Unauthenticated
+// if the request does not carry a valid bearer token or client certificate; otherwise it attaches the resolved
+// identity to the stream context before invoking handler.
 func (a *StreamServerAuthenticator) StreamInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	token, err := tokenFromContext(ss.Context())
+	cred, err := credentialFromContext(ss.Context())
 	if err != nil {
 		return status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	u, err := a.authenticate(ss.Context(), token)
+	u, err := a.authenticate(ss.Context(), cred)
 	if err != nil {
 		klog.ErrorS(err, "FlowStreamService client authentication failed")
-		return status.Error(codes.Unauthenticated, "invalid bearer token")
+		return status.Error(codes.Unauthenticated, "invalid client credentials")
 	}
 
 	return handler(srv, &authenticatedServerStream{
@@ -100,31 +146,60 @@ func (a *StreamServerAuthenticator) StreamInterceptor(srv any, ss grpc.ServerStr
 	})
 }
 
-// tokenFromContext extracts the bearer token from the authorization gRPC
-// metadata header of an incoming stream.
-func tokenFromContext(ctx context.Context) (string, error) {
+// credentialFromContext extracts the client's credential from the incoming gRPC metadata of a stream:
+// either a bearer token in the "authorization" header, or a PEM client cert+key pair in the
+// client-cert-bin/client-key-bin headers. A bearer token takes precedence if both happen to be present.
+func credentialFromContext(ctx context.Context) (*clientCredential, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", fmt.Errorf("missing gRPC metadata")
+		return nil, fmt.Errorf("missing gRPC metadata")
 	}
-	values := md.Get(authorizationMetadataKey)
-	if len(values) == 0 {
-		return "", fmt.Errorf("missing authorization header")
+
+	if values := md.Get(authorizationMetadataKey); len(values) > 0 {
+		token, ok := strings.CutPrefix(values[0], bearerTokenPrefix)
+		if !ok || token == "" {
+			return nil, fmt.Errorf("authorization header must be a bearer token")
+		}
+		return &clientCredential{token: token}, nil
 	}
-	token, ok := strings.CutPrefix(values[0], bearerTokenPrefix)
-	if !ok || token == "" {
-		return "", fmt.Errorf("authorization header must be a bearer token")
+
+	certValues := md.Get(clientCertMetadataKey)
+	keyValues := md.Get(clientKeyMetadataKey)
+	if len(certValues) > 0 || len(keyValues) > 0 {
+		if len(certValues) == 0 || len(keyValues) == 0 {
+			return nil, fmt.Errorf("both %s and %s metadata are required", clientCertMetadataKey, clientKeyMetadataKey)
+		}
+		return &clientCredential{certPEM: []byte(certValues[0]), keyPEM: []byte(keyValues[0])}, nil
 	}
-	return token, nil
+
+	return nil, fmt.Errorf("missing authorization header or client certificate metadata")
 }
 
-// authenticate resolves token to an identity, returning a cached TokenReview
-// outcome when available.
-func (a *StreamServerAuthenticator) authenticate(ctx context.Context, token string) (user.Info, error) {
-	if u, ok := a.getCachedUser(token); ok {
+// authenticate resolves cred to an identity, returning a cached outcome when
+// available.
+func (a *StreamServerAuthenticator) authenticate(ctx context.Context, cred *clientCredential) (user.Info, error) {
+	cacheKey := cred.cacheKey()
+	if u, ok := a.getCachedUser(cacheKey); ok {
 		return u, nil
 	}
 
+	var u *user.DefaultInfo
+	var err error
+	if cred.token != "" {
+		u, err = a.authenticateToken(ctx, cred.token)
+	} else {
+		u, err = a.authenticateCert(ctx, cred.certPEM, cred.keyPEM)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	a.cacheUser(cacheKey, u)
+	return u, nil
+}
+
+// authenticateToken validates token via the TokenReview API.
+func (a *StreamServerAuthenticator) authenticateToken(ctx context.Context, token string) (*user.DefaultInfo, error) {
 	tokenReview := &authenticationv1.TokenReview{
 		Spec: authenticationv1.TokenReviewSpec{Token: token},
 	}
@@ -138,22 +213,59 @@ func (a *StreamServerAuthenticator) authenticate(ctx context.Context, token stri
 	if !review.Status.Authenticated {
 		return nil, fmt.Errorf("token is not authenticated")
 	}
-
-	u := &user.DefaultInfo{
-		Name:   review.Status.User.Username,
-		UID:    review.Status.User.UID,
-		Groups: review.Status.User.Groups,
-		Extra:  convertExtra(review.Status.User.Extra),
-	}
-	a.cacheUser(token, u)
-	return u, nil
+	return userInfoFromK8s(review.Status.User), nil
 }
 
-// convertExtra converts the Extra field of a TokenReview's UserInfo
-// (map[string]authenticationv1.ExtraValue) into the plain map[string][]string
-// expected by user.DefaultInfo.Extra. authenticationv1.ExtraValue is defined
-// as `type ExtraValue []string`, so each value assigns to []string without a
-// cast; it is the outer map type that differs and must be rebuilt key by key.
+// authenticateCert validates a PEM client cert+key pair via SelfSubjectReview:
+// it builds an ephemeral rest.Config that authenticates with the presented certificate data and asks the
+// K8s API server "who does the API server think I am, given how I just authenticated to it?"
+// This is used for clients (e.g. Pinniped Concierge TokenCredentialRequest) whose only available credential
+// is a short-lived client certificate rather than a bearer token.
+func (a *StreamServerAuthenticator) authenticateCert(ctx context.Context, certPEM, keyPEM []byte) (*user.DefaultInfo, error) {
+	if a.baseConfig == nil {
+		return nil, fmt.Errorf("baseConfig is required for client certificate authentication")
+	}
+	// rest.AnonymousClientConfig strips every credential (bearer token, client cert, exec plugin, ...)
+	// from a.baseConfig, keeping only the fields needed to reach and verify the real API server
+	// (Host, APIPath, TLS server-verification settings). This is security-critical:
+	// clone of a.baseConfig would still carry flow-aggregator's own ServiceAccount bearer token,
+	// and an expired/invalid client cert would silently fall through to authenticating as
+	// flow-aggregator's own ServiceAccount instead of failing closed, causing privileged access
+	// for clients.
+	cfg := rest.AnonymousClientConfig(a.baseConfig)
+	cfg.TLSClientConfig.CertData = certPEM
+	cfg.TLSClientConfig.KeyData = keyPEM
+
+	client, err := newKubernetesClientForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build client for SelfSubjectReview: %w", err)
+	}
+
+	review, err := client.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("SelfSubjectReview request failed: %w", err)
+	}
+	return userInfoFromK8s(review.Status.UserInfo), nil
+}
+
+// userInfoFromK8s converts a Kubernetes authenticationv1.UserInfo (returned by
+// both TokenReview and SelfSubjectReview) into the user.DefaultInfo expected
+// by request.WithUser.
+func userInfoFromK8s(u authenticationv1.UserInfo) *user.DefaultInfo {
+	return &user.DefaultInfo{
+		Name:   u.Username,
+		UID:    u.UID,
+		Groups: u.Groups,
+		Extra:  convertExtra(u.Extra),
+	}
+}
+
+// convertExtra converts the Extra field of a TokenReview/SelfSubjectReview's
+// UserInfo (map[string]authenticationv1.ExtraValue) into the plain
+// map[string][]string expected by user.DefaultInfo.Extra. authenticationv1.ExtraValue
+// is defined as `type ExtraValue []string`, so each value assigns to []string
+// without a cast; it is the outer map type that differs and must be rebuilt
+// key by key.
 func convertExtra(extra map[string]authenticationv1.ExtraValue) map[string][]string {
 	if extra == nil {
 		return nil
@@ -165,35 +277,35 @@ func convertExtra(extra map[string]authenticationv1.ExtraValue) map[string][]str
 	return out
 }
 
-func (a *StreamServerAuthenticator) getCachedUser(token string) (user.Info, bool) {
+func (a *StreamServerAuthenticator) getCachedUser(key string) (user.Info, bool) {
 	a.cacheMutex.Lock()
 	defer a.cacheMutex.Unlock()
 
-	entry, ok := a.cache[token]
+	entry, ok := a.cache[key]
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		delete(a.cache, token)
+		delete(a.cache, key)
 		return nil, false
 	}
 	return entry.user, true
 }
 
-func (a *StreamServerAuthenticator) cacheUser(token string, u user.Info) {
+func (a *StreamServerAuthenticator) cacheUser(key string, u user.Info) {
 	a.cacheMutex.Lock()
 	defer a.cacheMutex.Unlock()
 
 	// Opportunistically evict expired entries so that a client rotating
-	// through many short-lived tokens over time does not grow the cache
+	// through many short-lived credentials over time does not grow the cache
 	// unboundedly.
 	now := time.Now()
-	for t, e := range a.cache {
+	for k, e := range a.cache {
 		if now.After(e.expiresAt) {
-			delete(a.cache, t)
+			delete(a.cache, k)
 		}
 	}
-	a.cache[token] = tokenCacheEntry{user: u, expiresAt: now.Add(tokenCacheTTL)}
+	a.cache[key] = credentialCacheEntry{user: u, expiresAt: now.Add(credentialCacheTTL)}
 }
 
 // authenticatedServerStream wraps a grpc.ServerStream to override Context(),

--- a/pkg/flowaggregator/flowstreamservice/authenticator.go
+++ b/pkg/flowaggregator/flowstreamservice/authenticator.go
@@ -16,12 +16,8 @@ package flowstreamservice
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"strings"
-	"sync"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -37,14 +33,6 @@ import (
 )
 
 const (
-	// credentialCacheTTL bounds how long a successful authentication outcome
-	// (TokenReview or SelfSubjectReview) is cached before the credential is
-	// re-validated against the Kubernetes API server. This keeps a long-lived
-	// or frequently reconnecting client from generating an API call on every
-	// request while still picking up revocation (e.g. ServiceAccount deletion,
-	// cert expiry) within a bounded time.
-	credentialCacheTTL = 30 * time.Second
-
 	// authorizationMetadataKey is the gRPC metadata key clients must set to
 	// carry their bearer token, mirroring the HTTP Authorization header.
 	// gRPC metadata keys are matched case-insensitively.
@@ -80,26 +68,6 @@ type clientCredential struct {
 	keyPEM  []byte
 }
 
-// cacheKey returns the key under which this credential's resolved identity is cached. Both Bearer tokens
-// and client certs are cached by a digest of the token or cert+key, to prevent data be exposed via heap
-// dumps etc.
-func (c *clientCredential) cacheKey() string {
-	h := sha256.New()
-	if c.token != "" {
-		h.Write([]byte(c.token))
-		return "token:" + hex.EncodeToString(h.Sum(nil))
-	}
-	h.Write(c.certPEM)
-	h.Write(c.keyPEM)
-	return "cert:" + hex.EncodeToString(h.Sum(nil))
-}
-
-// credentialCacheEntry is a cached authentication result for a clientCredential.
-type credentialCacheEntry struct {
-	user      user.Info
-	expiresAt time.Time
-}
-
 // StreamServerAuthenticator is a gRPC stream server interceptor that authenticates FlowStreamService clients.
 // Clients present either a Kubernetes bearer token (validated via TokenReview) or a short-lived X.509
 // client certificate (validated via SelfSubjectReview against the API server), both carried as gRPC metadata.
@@ -112,16 +80,12 @@ type StreamServerAuthenticator struct {
 	// strips flow-aggregator's own credentials first (see authenticateCert), keeping only the Host/CA
 	// fields needed to reach and verify the real API server.
 	baseConfig *rest.Config
-
-	cacheMutex sync.Mutex
-	cache      map[string]credentialCacheEntry
 }
 
 func NewStreamServerAuthenticator(k8sClient kubernetes.Interface, baseConfig *rest.Config) *StreamServerAuthenticator {
 	return &StreamServerAuthenticator{
 		k8sClient:  k8sClient,
 		baseConfig: baseConfig,
-		cache:      make(map[string]credentialCacheEntry),
 	}
 }
 
@@ -175,27 +139,14 @@ func credentialFromContext(ctx context.Context) (*clientCredential, error) {
 	return nil, fmt.Errorf("missing authorization header or client certificate metadata")
 }
 
-// authenticate resolves cred to an identity, returning a cached outcome when
-// available.
+// authenticate resolves cred to an identity. It is called once per stream, when the stream is opened,
+// so the credential is always validated against the Kubernetes API server: a revoked or expired
+// credential can never be used to open a new stream.
 func (a *StreamServerAuthenticator) authenticate(ctx context.Context, cred *clientCredential) (user.Info, error) {
-	cacheKey := cred.cacheKey()
-	if u, ok := a.getCachedUser(cacheKey); ok {
-		return u, nil
-	}
-
-	var u *user.DefaultInfo
-	var err error
 	if cred.token != "" {
-		u, err = a.authenticateToken(ctx, cred.token)
-	} else {
-		u, err = a.authenticateCert(ctx, cred.certPEM, cred.keyPEM)
+		return a.authenticateToken(ctx, cred.token)
 	}
-	if err != nil {
-		return nil, err
-	}
-
-	a.cacheUser(cacheKey, u)
-	return u, nil
+	return a.authenticateCert(ctx, cred.certPEM, cred.keyPEM)
 }
 
 // authenticateToken validates token via the TokenReview API.
@@ -275,37 +226,6 @@ func convertExtra(extra map[string]authenticationv1.ExtraValue) map[string][]str
 		out[k] = v
 	}
 	return out
-}
-
-func (a *StreamServerAuthenticator) getCachedUser(key string) (user.Info, bool) {
-	a.cacheMutex.Lock()
-	defer a.cacheMutex.Unlock()
-
-	entry, ok := a.cache[key]
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		delete(a.cache, key)
-		return nil, false
-	}
-	return entry.user, true
-}
-
-func (a *StreamServerAuthenticator) cacheUser(key string, u user.Info) {
-	a.cacheMutex.Lock()
-	defer a.cacheMutex.Unlock()
-
-	// Opportunistically evict expired entries so that a client rotating
-	// through many short-lived credentials over time does not grow the cache
-	// unboundedly.
-	now := time.Now()
-	for k, e := range a.cache {
-		if now.After(e.expiresAt) {
-			delete(a.cache, k)
-		}
-	}
-	a.cache[key] = credentialCacheEntry{user: u, expiresAt: now.Add(credentialCacheTTL)}
 }
 
 // authenticatedServerStream wraps a grpc.ServerStream to override Context(),

--- a/pkg/flowaggregator/flowstreamservice/authenticator_test.go
+++ b/pkg/flowaggregator/flowstreamservice/authenticator_test.go
@@ -16,6 +16,7 @@ package flowstreamservice
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,11 +29,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 	clienttesting "k8s.io/client-go/testing"
 )
 
-// authReactor installs a "create tokenreviews" reactor on the fake clientset
+// authReactor installs a "create TokenReviews" Reactor on the fake clientset
 // that returns status for the given token, so tests can control the outcome
 // of TokenReview without a real API server.
 func authReactor(client *k8sfake.Clientset, valid map[string]authenticationv1.TokenReviewStatus) {
@@ -45,6 +48,38 @@ func authReactor(client *k8sfake.Clientset, valid map[string]authenticationv1.To
 		tr = tr.DeepCopy()
 		tr.Status = status
 		return true, tr, nil
+	})
+}
+
+// withFakeSelfSubjectReviewClient overrides newKubernetesClientForConfig for
+// the duration of the test so that authenticateCert's SelfSubjectReview call
+// hits client instead of trying to build a real TLS-terminating clientset.
+// Every rest.Config passed to the override is recorded, so tests can assert
+// on how the ephemeral, per-request config was constructed (e.g. that it
+// carries the client cert but not flow-aggregator's own credentials).
+func withFakeSelfSubjectReviewClient(t *testing.T, client kubernetes.Interface) *[]*rest.Config {
+	t.Helper()
+	var gotConfigs []*rest.Config
+	orig := newKubernetesClientForConfig
+	newKubernetesClientForConfig = func(cfg *rest.Config) (kubernetes.Interface, error) {
+		gotConfigs = append(gotConfigs, cfg)
+		return client, nil
+	}
+	t.Cleanup(func() { newKubernetesClientForConfig = orig })
+	return &gotConfigs
+}
+
+// selfSubjectReviewReactor installs a "create selfsubjectreviews" reactor on
+// the fake clientset that returns either reviewErr (if non-nil) or a
+// SelfSubjectReview with the given user info.
+func selfSubjectReviewReactor(client *k8sfake.Clientset, userInfo authenticationv1.UserInfo, reviewErr error) {
+	client.PrependReactor("create", "selfsubjectreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if reviewErr != nil {
+			return true, nil, reviewErr
+		}
+		return true, &authenticationv1.SelfSubjectReview{
+			Status: authenticationv1.SelfSubjectReviewStatus{UserInfo: userInfo},
+		}, nil
 	})
 }
 
@@ -64,9 +99,30 @@ func contextWithAuthHeader(value string) context.Context {
 	return metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", value))
 }
 
+// contextWithClientCert builds an incoming stream context carrying the given
+// PEM cert/key under the client-cert-bin/client-key-bin metadata keys. An
+// empty certPEM or keyPEM omits that key entirely, so tests can exercise the
+// "only one of the pair present" error path. Note this bypasses the
+// "-bin"-suffix base64 framing that grpc-go applies at the real transport
+// layer: incoming metadata is constructed in-process here, exactly like
+// contextWithAuthHeader does for the bearer-token path.
+func contextWithClientCert(certPEM, keyPEM string) context.Context {
+	var pairs []string
+	if certPEM != "" {
+		pairs = append(pairs, clientCertMetadataKey, certPEM)
+	}
+	if keyPEM != "" {
+		pairs = append(pairs, clientKeyMetadataKey, keyPEM)
+	}
+	if len(pairs) == 0 {
+		return context.Background()
+	}
+	return metadata.NewIncomingContext(context.Background(), metadata.Pairs(pairs...))
+}
+
 func TestStreamInterceptor_MissingToken(t *testing.T) {
 	client := k8sfake.NewSimpleClientset()
-	a := NewStreamServerAuthenticator(client)
+	a := NewStreamServerAuthenticator(client, &rest.Config{})
 
 	handlerCalled := false
 	handler := func(srv any, stream grpc.ServerStream) error {
@@ -84,7 +140,7 @@ func TestStreamInterceptor_MissingToken(t *testing.T) {
 
 func TestStreamInterceptor_MalformedAuthHeader(t *testing.T) {
 	client := k8sfake.NewSimpleClientset()
-	a := NewStreamServerAuthenticator(client)
+	a := NewStreamServerAuthenticator(client, &rest.Config{})
 
 	handler := func(srv any, stream grpc.ServerStream) error { return nil }
 
@@ -98,7 +154,7 @@ func TestStreamInterceptor_MalformedAuthHeader(t *testing.T) {
 func TestStreamInterceptor_InvalidToken(t *testing.T) {
 	client := k8sfake.NewSimpleClientset()
 	authReactor(client, nil)
-	a := NewStreamServerAuthenticator(client)
+	a := NewStreamServerAuthenticator(client, &rest.Config{})
 
 	handlerCalled := false
 	handler := func(srv any, stream grpc.ServerStream) error {
@@ -122,7 +178,7 @@ func TestStreamInterceptor_TokenReviewError(t *testing.T) {
 		tr.Status = authenticationv1.TokenReviewStatus{Authenticated: true, Error: "webhook unavailable"}
 		return true, tr, nil
 	})
-	a := NewStreamServerAuthenticator(client)
+	a := NewStreamServerAuthenticator(client, &rest.Config{})
 
 	handler := func(srv any, stream grpc.ServerStream) error { return nil }
 	err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithAuthHeader("Bearer some-token")}, &grpc.StreamServerInfo{}, handler)
@@ -147,7 +203,7 @@ func TestStreamInterceptor_ValidToken(t *testing.T) {
 			},
 		},
 	})
-	a := NewStreamServerAuthenticator(client)
+	a := NewStreamServerAuthenticator(client, &rest.Config{})
 
 	var gotUser user.Info
 	handlerCalled := false
@@ -179,7 +235,7 @@ func TestStreamInterceptor_TokenReviewCached(t *testing.T) {
 		callCount++
 		return false, nil, nil
 	})
-	a := NewStreamServerAuthenticator(client)
+	a := NewStreamServerAuthenticator(client, &rest.Config{})
 
 	handler := func(srv any, stream grpc.ServerStream) error { return nil }
 	for range 3 {
@@ -188,5 +244,116 @@ func TestStreamInterceptor_TokenReviewCached(t *testing.T) {
 	}
 	// callCount only increments when TokenReviews().Create() is actually
 	// invoked; a cache hit skips the call to the fake clientset entirely.
+	assert.Equal(t, 1, callCount)
+}
+
+func TestStreamInterceptor_MissingClientCredentials(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	a := NewStreamServerAuthenticator(client, &rest.Config{})
+
+	handler := func(srv any, stream grpc.ServerStream) error { return nil }
+
+	err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithClientCert("cert-pem-data", "")}, &grpc.StreamServerInfo{}, handler)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+}
+
+func TestStreamInterceptor_SelfSubjectReviewError(t *testing.T) {
+	fakeClient := k8sfake.NewSimpleClientset()
+	selfSubjectReviewReactor(fakeClient, authenticationv1.UserInfo{}, fmt.Errorf("cert verification failed"))
+	withFakeSelfSubjectReviewClient(t, fakeClient)
+
+	a := NewStreamServerAuthenticator(k8sfake.NewSimpleClientset(), &rest.Config{})
+
+	handlerCalled := false
+	handler := func(srv any, stream grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	}
+
+	err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithClientCert("cert-pem-data", "key-pem-data")}, &grpc.StreamServerInfo{}, handler)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+	assert.False(t, handlerCalled)
+}
+
+func TestStreamInterceptor_ValidClientCert(t *testing.T) {
+	fakeClient := k8sfake.NewSimpleClientset()
+	selfSubjectReviewReactor(fakeClient, authenticationv1.UserInfo{
+		Username: "admin@vsphere.local",
+		UID:      "uid-2",
+		Groups:   []string{"vsphere-admins"},
+	}, nil)
+
+	// baseConfig simulates flow-aggregator's own in-cluster rest.Config,
+	// complete with its own ServiceAccount bearer token, so the test can
+	// confirm authenticateCert never forwards that token in the ephemeral,
+	// per-request config it builds for SelfSubjectReview.
+	baseConfig := &rest.Config{ //nolint:gosec // test-only, not a real credential
+		Host:        "https://kube-apiserver.example",
+		BearerToken: "flow-aggregator-sa-token",
+	}
+	gotConfigs := withFakeSelfSubjectReviewClient(t, fakeClient)
+
+	a := NewStreamServerAuthenticator(k8sfake.NewSimpleClientset(), baseConfig)
+
+	var gotUser user.Info
+	handlerCalled := false
+	handler := func(srv any, stream grpc.ServerStream) error {
+		handlerCalled = true
+		u, ok := request.UserFrom(stream.Context())
+		require.True(t, ok)
+		gotUser = u
+		return nil
+	}
+
+	err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithClientCert("cert-pem-data", "key-pem-data")}, &grpc.StreamServerInfo{}, handler)
+	require.NoError(t, err)
+	require.True(t, handlerCalled)
+
+	assert.Equal(t, "admin@vsphere.local", gotUser.GetName())
+	assert.Equal(t, "uid-2", gotUser.GetUID())
+	assert.ElementsMatch(t, []string{"vsphere-admins"}, gotUser.GetGroups())
+
+	require.Len(t, *gotConfigs, 1)
+	usedConfig := (*gotConfigs)[0]
+	// The ephemeral config used for SelfSubjectReview must not carry
+	// flow-aggregator's own ServiceAccount bearer token, or an
+	// expired/invalid end-user cert would silently fall back to
+	// authenticating as flow-aggregator's own ServiceAccount instead of
+	// failing closed.
+	assert.Empty(t, usedConfig.BearerToken)
+	assert.Equal(t, "https://kube-apiserver.example", usedConfig.Host)
+	assert.Equal(t, []byte("cert-pem-data"), usedConfig.TLSClientConfig.CertData)
+	assert.Equal(t, []byte("key-pem-data"), usedConfig.TLSClientConfig.KeyData)
+}
+
+func TestStreamInterceptor_ClientCertCached(t *testing.T) {
+	fakeClient := k8sfake.NewSimpleClientset()
+	callCount := 0
+	fakeClient.PrependReactor("create", "selfsubjectreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		callCount++
+		return true, &authenticationv1.SelfSubjectReview{
+			Status: authenticationv1.SelfSubjectReviewStatus{
+				UserInfo: authenticationv1.UserInfo{Username: "admin@vsphere.local"},
+			},
+		}, nil
+	})
+	withFakeSelfSubjectReviewClient(t, fakeClient)
+
+	a := NewStreamServerAuthenticator(k8sfake.NewSimpleClientset(), &rest.Config{})
+
+	handler := func(srv any, stream grpc.ServerStream) error { return nil }
+	for range 3 {
+		err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithClientCert("cert-pem-data", "key-pem-data")}, &grpc.StreamServerInfo{}, handler)
+		require.NoError(t, err)
+	}
+	// Same cache-hit contract as TestStreamInterceptor_TokenReviewCached, but
+	// for the client-cert path: callCount only increments when
+	// SelfSubjectReviews().Create() is actually invoked.
 	assert.Equal(t, 1, callCount)
 }

--- a/pkg/flowaggregator/flowstreamservice/authenticator_test.go
+++ b/pkg/flowaggregator/flowstreamservice/authenticator_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flowstreamservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// authReactor installs a "create tokenreviews" reactor on the fake clientset
+// that returns status for the given token, so tests can control the outcome
+// of TokenReview without a real API server.
+func authReactor(client *k8sfake.Clientset, valid map[string]authenticationv1.TokenReviewStatus) {
+	client.PrependReactor("create", "tokenreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		tr := action.(clienttesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		status, ok := valid[tr.Spec.Token]
+		if !ok {
+			status = authenticationv1.TokenReviewStatus{Authenticated: false}
+		}
+		tr = tr.DeepCopy()
+		tr.Status = status
+		return true, tr, nil
+	})
+}
+
+// fakeServerStream is a minimal grpc.ServerStream backed by a fixed context,
+// sufficient for exercising StreamInterceptor without a real connection.
+type fakeServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f *fakeServerStream) Context() context.Context { return f.ctx }
+
+func contextWithAuthHeader(value string) context.Context {
+	if value == "" {
+		return context.Background()
+	}
+	return metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", value))
+}
+
+func TestStreamInterceptor_MissingToken(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	a := NewStreamServerAuthenticator(client)
+
+	handlerCalled := false
+	handler := func(srv any, stream grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	}
+
+	err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithAuthHeader("")}, &grpc.StreamServerInfo{}, handler)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+	assert.False(t, handlerCalled)
+}
+
+func TestStreamInterceptor_MalformedAuthHeader(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	a := NewStreamServerAuthenticator(client)
+
+	handler := func(srv any, stream grpc.ServerStream) error { return nil }
+
+	err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithAuthHeader("Basic abc123")}, &grpc.StreamServerInfo{}, handler)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+}
+
+func TestStreamInterceptor_InvalidToken(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	authReactor(client, nil)
+	a := NewStreamServerAuthenticator(client)
+
+	handlerCalled := false
+	handler := func(srv any, stream grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	}
+
+	err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithAuthHeader("Bearer bad-token")}, &grpc.StreamServerInfo{}, handler)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+	assert.False(t, handlerCalled)
+}
+
+func TestStreamInterceptor_TokenReviewError(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	client.PrependReactor("create", "tokenreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		tr := action.(clienttesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		tr = tr.DeepCopy()
+		tr.Status = authenticationv1.TokenReviewStatus{Authenticated: true, Error: "webhook unavailable"}
+		return true, tr, nil
+	})
+	a := NewStreamServerAuthenticator(client)
+
+	handler := func(srv any, stream grpc.ServerStream) error { return nil }
+	err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithAuthHeader("Bearer some-token")}, &grpc.StreamServerInfo{}, handler)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+}
+
+func TestStreamInterceptor_ValidToken(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	authReactor(client, map[string]authenticationv1.TokenReviewStatus{
+		"good-token": {
+			Authenticated: true,
+			User: authenticationv1.UserInfo{
+				Username: "alice",
+				UID:      "uid-1",
+				Groups:   []string{"developers", "system:authenticated"},
+				Extra: map[string]authenticationv1.ExtraValue{
+					"scopes": {"read", "write"},
+				},
+			},
+		},
+	})
+	a := NewStreamServerAuthenticator(client)
+
+	var gotUser user.Info
+	handlerCalled := false
+	handler := func(srv any, stream grpc.ServerStream) error {
+		handlerCalled = true
+		u, ok := request.UserFrom(stream.Context())
+		require.True(t, ok)
+		gotUser = u
+		return nil
+	}
+
+	err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithAuthHeader("Bearer good-token")}, &grpc.StreamServerInfo{}, handler)
+	require.NoError(t, err)
+	require.True(t, handlerCalled)
+
+	assert.Equal(t, "alice", gotUser.GetName())
+	assert.Equal(t, "uid-1", gotUser.GetUID())
+	assert.ElementsMatch(t, []string{"developers", "system:authenticated"}, gotUser.GetGroups())
+	assert.Equal(t, []string{"read", "write"}, gotUser.GetExtra()["scopes"])
+}
+
+func TestStreamInterceptor_TokenReviewCached(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	authReactor(client, map[string]authenticationv1.TokenReviewStatus{
+		"good-token": {Authenticated: true, User: authenticationv1.UserInfo{Username: "alice"}},
+	})
+	callCount := 0
+	client.PrependReactor("create", "tokenreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		callCount++
+		return false, nil, nil
+	})
+	a := NewStreamServerAuthenticator(client)
+
+	handler := func(srv any, stream grpc.ServerStream) error { return nil }
+	for range 3 {
+		err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithAuthHeader("Bearer good-token")}, &grpc.StreamServerInfo{}, handler)
+		require.NoError(t, err)
+	}
+	// callCount only increments when TokenReviews().Create() is actually
+	// invoked; a cache hit skips the call to the fake clientset entirely.
+	assert.Equal(t, 1, callCount)
+}

--- a/pkg/flowaggregator/flowstreamservice/authenticator_test.go
+++ b/pkg/flowaggregator/flowstreamservice/authenticator_test.go
@@ -225,28 +225,6 @@ func TestStreamInterceptor_ValidToken(t *testing.T) {
 	assert.Equal(t, []string{"read", "write"}, gotUser.GetExtra()["scopes"])
 }
 
-func TestStreamInterceptor_TokenReviewCached(t *testing.T) {
-	client := k8sfake.NewSimpleClientset()
-	authReactor(client, map[string]authenticationv1.TokenReviewStatus{
-		"good-token": {Authenticated: true, User: authenticationv1.UserInfo{Username: "alice"}},
-	})
-	callCount := 0
-	client.PrependReactor("create", "tokenreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
-		callCount++
-		return false, nil, nil
-	})
-	a := NewStreamServerAuthenticator(client, &rest.Config{})
-
-	handler := func(srv any, stream grpc.ServerStream) error { return nil }
-	for range 3 {
-		err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithAuthHeader("Bearer good-token")}, &grpc.StreamServerInfo{}, handler)
-		require.NoError(t, err)
-	}
-	// callCount only increments when TokenReviews().Create() is actually
-	// invoked; a cache hit skips the call to the fake clientset entirely.
-	assert.Equal(t, 1, callCount)
-}
-
 func TestStreamInterceptor_MissingClientCredentials(t *testing.T) {
 	client := k8sfake.NewSimpleClientset()
 	a := NewStreamServerAuthenticator(client, &rest.Config{})
@@ -284,9 +262,9 @@ func TestStreamInterceptor_SelfSubjectReviewError(t *testing.T) {
 func TestStreamInterceptor_ValidClientCert(t *testing.T) {
 	fakeClient := k8sfake.NewSimpleClientset()
 	selfSubjectReviewReactor(fakeClient, authenticationv1.UserInfo{
-		Username: "admin@vsphere.local",
+		Username: "admin@test.com",
 		UID:      "uid-2",
-		Groups:   []string{"vsphere-admins"},
+		Groups:   []string{"admins"},
 	}, nil)
 
 	// baseConfig simulates flow-aggregator's own in-cluster rest.Config,
@@ -315,9 +293,9 @@ func TestStreamInterceptor_ValidClientCert(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, handlerCalled)
 
-	assert.Equal(t, "admin@vsphere.local", gotUser.GetName())
+	assert.Equal(t, "admin@test.com", gotUser.GetName())
 	assert.Equal(t, "uid-2", gotUser.GetUID())
-	assert.ElementsMatch(t, []string{"vsphere-admins"}, gotUser.GetGroups())
+	assert.ElementsMatch(t, []string{"admins"}, gotUser.GetGroups())
 
 	require.Len(t, *gotConfigs, 1)
 	usedConfig := (*gotConfigs)[0]
@@ -330,30 +308,4 @@ func TestStreamInterceptor_ValidClientCert(t *testing.T) {
 	assert.Equal(t, "https://kube-apiserver.example", usedConfig.Host)
 	assert.Equal(t, []byte("cert-pem-data"), usedConfig.TLSClientConfig.CertData)
 	assert.Equal(t, []byte("key-pem-data"), usedConfig.TLSClientConfig.KeyData)
-}
-
-func TestStreamInterceptor_ClientCertCached(t *testing.T) {
-	fakeClient := k8sfake.NewSimpleClientset()
-	callCount := 0
-	fakeClient.PrependReactor("create", "selfsubjectreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
-		callCount++
-		return true, &authenticationv1.SelfSubjectReview{
-			Status: authenticationv1.SelfSubjectReviewStatus{
-				UserInfo: authenticationv1.UserInfo{Username: "admin@vsphere.local"},
-			},
-		}, nil
-	})
-	withFakeSelfSubjectReviewClient(t, fakeClient)
-
-	a := NewStreamServerAuthenticator(k8sfake.NewSimpleClientset(), &rest.Config{})
-
-	handler := func(srv any, stream grpc.ServerStream) error { return nil }
-	for range 3 {
-		err := a.StreamInterceptor(nil, &fakeServerStream{ctx: contextWithClientCert("cert-pem-data", "key-pem-data")}, &grpc.StreamServerInfo{}, handler)
-		require.NoError(t, err)
-	}
-	// Same cache-hit contract as TestStreamInterceptor_TokenReviewCached, but
-	// for the client-cert path: callCount only increments when
-	// SelfSubjectReviews().Create() is actually invoked.
-	assert.Equal(t, 1, callCount)
 }

--- a/pkg/flowaggregator/flowstreamservice/service.go
+++ b/pkg/flowaggregator/flowstreamservice/service.go
@@ -48,19 +48,34 @@ const (
 // FlowStreamService implements flowpb.FlowStreamServiceServer. Each client
 // connection gets its own independent ring-buffer Consumer, so clients are
 // fully decoupled and a slow client never stalls faster ones.
+//
+// Connecting clients must present a valid Kubernetes bearer token (e.g. a
+// ServiceAccount token) in the "authorization" gRPC metadata header, formatted
+// as "Bearer <token>" (matching the HTTP Authorization header convention).
+// The token is validated against the Kubernetes API server via the
+// TokenReview API; the call is rejected with codes.Unauthenticated if the
+// header is missing, malformed, or the token does not authenticate. This
+// applies whenever the service is constructed with a non-nil
+// StreamServerAuthenticator.
 type FlowStreamService struct {
 	flowpb.UnimplementedFlowStreamServiceServer
-	buffer ringbuffer.BroadcastBuffer[*flowpb.Flow]
+	buffer        ringbuffer.BroadcastBuffer[*flowpb.Flow]
+	authenticator *StreamServerAuthenticator
 }
 
 // NewFlowStreamService creates a FlowStreamService backed by the given buffer.
-func NewFlowStreamService(buffer ringbuffer.BroadcastBuffer[*flowpb.Flow]) *FlowStreamService {
-	return &FlowStreamService{buffer: buffer}
+// authenticator authenticates clients using a Kubernetes bearer token before
+// GetFlows runs; nil authenticator accepts any client.
+func NewFlowStreamService(buffer ringbuffer.BroadcastBuffer[*flowpb.Flow], authenticator *StreamServerAuthenticator) *FlowStreamService {
+	return &FlowStreamService{buffer: buffer, authenticator: authenticator}
 }
 
 // Run starts a dedicated TLS gRPC server for the FlowStreamService on FlowStreamPort.
-// serverCertPEM and serverKeyPEM are the PEM-encoded server certificate and private key;
-// only server-side TLS is used (no client authentication). Run blocks until stopCh is closed.
+// serverCertPEM and serverKeyPEM are the PEM-encoded server certificate and private key.
+// Only server-side TLS is used (no client certificate authentication); when the service
+// was constructed with a non-nil authenticator, clients must additionally present a valid
+// Kubernetes bearer token, or the call is rejected before GetFlows runs. Run blocks until
+// stopCh is closed.
 func (s *FlowStreamService) Run(serverCertPEM, serverKeyPEM []byte, stopCh <-chan struct{}) error {
 	cert, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
 	if err != nil {
@@ -76,7 +91,11 @@ func (s *FlowStreamService) Run(serverCertPEM, serverKeyPEM []byte, stopCh <-cha
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
-	server := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
+	serverOpts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsConfig))}
+	if s.authenticator != nil {
+		serverOpts = append(serverOpts, grpc.StreamInterceptor(s.authenticator.StreamInterceptor))
+	}
+	server := grpc.NewServer(serverOpts...)
 	flowpb.RegisterFlowStreamServiceServer(server, s)
 
 	var wg sync.WaitGroup

--- a/pkg/flowaggregator/flowstreamservice/service.go
+++ b/pkg/flowaggregator/flowstreamservice/service.go
@@ -49,14 +49,13 @@ const (
 // connection gets its own independent ring-buffer Consumer, so clients are
 // fully decoupled and a slow client never stalls faster ones.
 //
-// Connecting clients must present a valid Kubernetes bearer token (e.g. a
-// ServiceAccount token) in the "authorization" gRPC metadata header, formatted
-// as "Bearer <token>" (matching the HTTP Authorization header convention).
-// The token is validated against the Kubernetes API server via the
-// TokenReview API; the call is rejected with codes.Unauthenticated if the
-// header is missing, malformed, or the token does not authenticate. This
-// applies whenever the service is constructed with a non-nil
-// StreamServerAuthenticator.
+// Connecting clients must present valid Kubernetes credentials in gRPC metadata.
+// Supported credentials are either:
+//   - a bearer token in the "authorization" header formatted as "Bearer <token>" (validated via TokenReview), or
+//   - a PEM client certificate+key in the "client-cert-bin"/"client-key-bin" headers (validated via SelfSubjectReview).
+//
+// The call is rejected with codes.Unauthenticated if credentials are missing, malformed, or do not authenticate.
+// This applies whenever the service is constructed with a non-nil StreamServerAuthenticator.
 type FlowStreamService struct {
 	flowpb.UnimplementedFlowStreamServiceServer
 	buffer        ringbuffer.BroadcastBuffer[*flowpb.Flow]
@@ -64,8 +63,8 @@ type FlowStreamService struct {
 }
 
 // NewFlowStreamService creates a FlowStreamService backed by the given buffer.
-// authenticator authenticates clients using a Kubernetes bearer token before
-// GetFlows runs; nil authenticator accepts any client.
+// authenticator authenticates clients (bearer token or client cert/key metadata)
+// before GetFlows runs; nil authenticator accepts any client.
 func NewFlowStreamService(buffer ringbuffer.BroadcastBuffer[*flowpb.Flow], authenticator *StreamServerAuthenticator) *FlowStreamService {
 	return &FlowStreamService{buffer: buffer, authenticator: authenticator}
 }

--- a/pkg/flowaggregator/flowstreamservice/service_test.go
+++ b/pkg/flowaggregator/flowstreamservice/service_test.go
@@ -54,7 +54,7 @@ func (f *fakeStream) SendMsg(any) error            { return nil }
 func (f *fakeStream) RecvMsg(any) error            { return nil }
 
 func newTestService(buf ringbuffer.BroadcastBuffer[*flowpb.Flow]) *FlowStreamService {
-	return NewFlowStreamService(buf)
+	return NewFlowStreamService(buf, nil)
 }
 
 func collectFlows(responses []*flowpb.GetFlowsResponse) []*flowpb.Flow {

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -169,6 +169,14 @@ func testAntctlControllerRemoteAccess(t *testing.T, data *TestData, antctlServic
 	testCmds := []cmdAndReturnCode{}
 	// Add all controller commands.
 	for _, c := range antctl.CommandList.GetDebugCommands(runtime.ModeController) {
+		// "observe" is excluded from this generic bare-invocation smoke test: unlike every other
+		// command here, a bare "antctl observe" needs an actual Flow Aggregator to discover and
+		// connect to, which this test does not set up and is not aware of (it runs regardless of
+		// whether flow-visibility is enabled). TestAntctlObserve (antctlobserve_test.go) already
+		// covers "observe" thoroughly, including the flow-visibility-disabled case (it skips).
+		if len(c) == 1 && c[0] == "observe" {
+			continue
+		}
 		cmd := append([]string{"antctl"}, c...)
 		testCmds = append(testCmds, cmdAndReturnCode{args: cmd, expectedReturnCode: 0})
 	}

--- a/test/e2e/antctlobserve_test.go
+++ b/test/e2e/antctlobserve_test.go
@@ -1,0 +1,952 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file tests "antctl observe" (pkg/antctl/raw/observe), which streams live flow records from
+// a Flow Aggregator's FlowStreamService without requiring the caller to exec into the Flow
+// Aggregator Pod. See docs/antctl-observe-design.md (outside this repository, alongside the
+// vgl-62473 workspace) for the full design and test plan this file implements.
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+
+	secv1beta1 "antrea.io/antrea/v2/pkg/apis/crd/v1beta1"
+	flowaggregatorconfig "antrea.io/antrea/v2/pkg/config/flowaggregator"
+	"antrea.io/antrea/v2/test/e2e/utils"
+)
+
+// observeRecord mirrors the JSON shape "antctl observe -o json" emits, one object per line
+// (pkg/antctl/raw/observe/render.go's "record" type, which is unexported and not reused directly
+// here: it is not meant to be depended on across package boundaries, and a purpose-built shape
+// keeps this test file decoupled from render.go's internals).
+type observeRecord struct {
+	EndTime                 string
+	SourceIP                string
+	DestinationIP           string
+	Protocol                uint32
+	SourcePort              uint32
+	DestinationPort         uint32
+	SourcePodNamespace      string
+	SourcePodName           string
+	DestinationPodNamespace string
+	DestinationPodName      string
+	DestinationServiceName  string
+	FlowType                string
+	OctetTotalCount         uint64
+	ReverseOctetTotalCount  uint64
+}
+
+// parseObserveJSON parses "antctl observe -o json" output: one JSON object per line, not a single
+// closing array, since --follow's output has no final line to close an array at.
+func parseObserveJSON(t require.TestingT, output string) []observeRecord {
+	var records []observeRecord
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var r observeRecord
+		require.NoErrorf(t, json.Unmarshal([]byte(line), &r), "failed to parse JSON line: %s", line)
+		records = append(records, r)
+	}
+	return records
+}
+
+// parseObserveText parses "antctl observe" default text output: one header line (skipped), then
+// one whitespace-separated row per flow, in the exact column order render.go's textHeader defines.
+// Relies on every column always having a visible, non-whitespace value (render.go substitutes "-"
+// for empty ones) so that positional whitespace-splitting is unambiguous.
+func parseObserveText(t require.TestingT, output string) []observeRecord {
+	var records []observeRecord
+	for _, line := range strings.Split(strings.TrimRight(output, "\n"), "\n") {
+		if line == "" || strings.HasPrefix(line, "TIME") || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		require.GreaterOrEqualf(t, len(fields), 9, "unexpected text output row: %q", line)
+		proto, err := strconv.ParseUint(fields[3], 10, 32)
+		require.NoError(t, err)
+		sport, err := strconv.ParseUint(fields[4], 10, 32)
+		require.NoError(t, err)
+		dport, err := strconv.ParseUint(fields[5], 10, 32)
+		require.NoError(t, err)
+		octets, err := strconv.ParseUint(fields[8], 10, 64)
+		require.NoError(t, err)
+		r := observeRecord{
+			EndTime:         fields[0],
+			Protocol:        uint32(proto),
+			SourcePort:      uint32(sport),
+			DestinationPort: uint32(dport),
+			FlowType:        fields[7],
+			OctetTotalCount: octets,
+		}
+		if ns, name, ok := strings.Cut(fields[1], "/"); ok {
+			r.SourcePodNamespace, r.SourcePodName = ns, name
+		} else {
+			r.SourceIP = fields[1]
+		}
+		if ns, name, ok := strings.Cut(fields[2], "/"); ok {
+			r.DestinationPodNamespace, r.DestinationPodName = ns, name
+		} else {
+			r.DestinationIP = fields[2]
+		}
+		if fields[6] != "-" {
+			r.DestinationServiceName = fields[6]
+		}
+		records = append(records, r)
+	}
+	return records
+}
+
+// enableFlowStreamService patches the Flow Aggregator's ConfigMap to turn on the FlowStreamService
+// gRPC server (disabled by default: see pkg/config/flowaggregator/default.go) and to include Pod
+// labels in flow records (also disabled by default), then restarts the Deployment so the new Pod
+// picks up both changes. Pod labels are needed because most tests below isolate "the one flow this
+// subtest just generated" from unrelated background cluster traffic and other subtests' leftover
+// flows by giving the relevant Pods a fresh, unique label (addLabelToTestPods) and filtering
+// "antctl observe" on it (--selector) — which only works if the Flow Aggregator actually attaches
+// Pod labels to records at all.
+//
+// The e2e framework's own deployFlowAggregator/mutateFlowAggregatorConfigMap helpers do not
+// expose either field as a flowVisibilityTestOptions knob, so this decodes, mutates, and
+// re-encodes the ConfigMap's YAML content directly via the real config struct, rather than via
+// fragile text-based editing of a document this test does not otherwise need to parse.
+func enableFlowStreamService(t *testing.T, data *TestData, namespace string) {
+	const configKey = "flow-aggregator.conf"
+
+	// The ConfigMap's own name is release-name-derived (distinct per multi-instance deployment),
+	// so it must be resolved via the Deployment's volume spec rather than assumed.
+	configMapName, err := data.getFlowAggregatorConfigMapName(namespace)
+	require.NoErrorf(t, err, "failed to determine Flow Aggregator ConfigMap name in Namespace %s", namespace)
+
+	cm, err := data.clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	require.NoErrorf(t, err, "failed to get ConfigMap %s/%s", namespace, configMapName)
+
+	var conf flowaggregatorconfig.FlowAggregatorConfig
+	require.NoError(t, yaml.Unmarshal([]byte(cm.Data[configKey]), &conf), "failed to parse existing Flow Aggregator config")
+
+	conf.FlowStreamService.Enable = ptr.To(true)
+	conf.RecordContents.PodLabels = true
+
+	newContent, err := yaml.Marshal(&conf)
+	require.NoError(t, err, "failed to serialize updated Flow Aggregator config")
+	cm.Data[configKey] = string(newContent)
+
+	_, err = data.clientset.CoreV1().ConfigMaps(namespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
+	require.NoErrorf(t, err, "failed to update ConfigMap %s/%s", namespace, configMapName)
+
+	require.NoError(t, data.restartFlowAggregator(namespace), "failed to restart Flow Aggregator after enabling FlowStreamService")
+}
+
+// restartFlowAggregator deletes the Flow Aggregator Pod(s) in namespace and waits for the
+// Deployment to become available again with the new configuration. There is a single replica in
+// Aggregate mode (the mode this file's tests use throughout), so this is simpler than a rolling
+// restart: delete-and-recreate is not observably different from one here.
+func (data *TestData) restartFlowAggregator(namespace string) error {
+	pods, err := data.getFlowAggregators(namespace)
+	if err != nil {
+		return err
+	}
+	for i := range pods {
+		if err := data.clientset.CoreV1().Pods(namespace).Delete(context.TODO(), pods[i].Name, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("failed to delete Flow Aggregator Pod %s: %w", pods[i].Name, err)
+		}
+	}
+	return wait.PollUntilContextTimeout(context.Background(), defaultInterval, defaultTimeout, false, func(ctx context.Context) (bool, error) {
+		newPods, err := data.getFlowAggregators(namespace)
+		if err != nil || len(newPods) == 0 {
+			return false, nil
+		}
+		for i := range newPods {
+			pod := newPods[i]
+			if pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
+				return false, nil
+			}
+			if !data.isFlowStreamServiceListening(pod.Status.PodIP) {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}
+
+// isFlowStreamServiceListening checks whether the FlowStreamService gRPC server at podIP:14740 is
+// actually accepting connections.
+// The Flow Aggregator chart currently does not define a readiness probe so a Pod becomes Running
+// as soon as its container process  starts, well before FlowStreamService finishes initializing
+// and binds its listener.
+// Therefore, tests could try to connect before the port is actually up.
+// curl runs on the control-plane Node, which has a route to every Pod IP over Antrea's own network.
+// curl needs no shell quoting to invoke here. Exit code 7 ("Failed to connect") and 28 ("Operation timeout")
+// specifically mean the TCP handshake itself never completed; any other outcome — including a
+// protocol-level error from curl misinterpreting the gRPC/HTTP2 response as HTTP — means the
+// connection itself succeeded, which is all this needs to confirm.
+func (data *TestData) isFlowStreamServiceListening(podIP string) bool {
+	rc, _, _, err := data.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("curl --connect-timeout 2 -s -o /dev/null http://%s:14740", podIP))
+	return err == nil && rc != 7 && rc != 28
+}
+
+// antctlObserveServiceAccountName and antctlObservePodName name the ServiceAccount and the
+// long-lived, host-network stand-in "remote antctl" Pod shared by every synchronous (no --follow,
+// i.e. the default, or bounded "--max-count") test in this file. It is deliberately host-network, matching the
+// existing testAntctlControllerRemoteAccess/testAntctlProxy convention: for these tests, a direct
+// connection to the Flow Aggregator's Pod IP is expected to succeed, and host networking is what
+// makes that reachability available to a test Pod regardless of which Node it lands on. Tests
+// that specifically need to prove the *fallback* tunnel works (see testAntctlObserveConnectionFallback)
+// use a separate, non-host-network Pod instead: see that test for why.
+const (
+	antctlObserveServiceAccountName = "antctl-observe-e2e"
+	antctlObservePodName            = "antctl-observe"
+	antctlObserveContainerName      = "antctl"
+)
+
+// setupAntctlObserveStandinPod creates the shared long-running stand-in Pod used by every
+// synchronous "antctl observe" test below, mirroring runAntctlPod (antctl_test.go) but under this
+// file's own naming so its lifecycle is easy to reason about independently.
+func setupAntctlObserveStandinPod(t *testing.T, data *TestData, antreaImage string) {
+	createAntctlServiceAccount(t, data, antctlObserveServiceAccountName)
+
+	b := NewPodBuilder(antctlObservePodName, data.testNamespace, antreaImage).
+		WithServiceAccountName(antctlObserveServiceAccountName).
+		WithContainerName(antctlObserveContainerName).
+		WithCommand([]string{"sleep", "3600"}).
+		OnNode(controlPlaneNodeName()).
+		InHostNetwork()
+	require.NoError(t, b.Create(data), "error when creating antctl observe stand-in Pod")
+	t.Cleanup(func() {
+		require.NoError(t, data.DeletePodAndWait(defaultTimeout, antctlObservePodName, data.testNamespace))
+	})
+	require.NoError(t, data.podWaitForRunning(defaultTimeout, antctlObservePodName, data.testNamespace), "antctl observe stand-in Pod not in the Running state")
+}
+
+// runObserve execs "antctl observe <args>" once, synchronously, in the shared stand-in Pod. Use
+// only for invocations that are expected to terminate on their own (i.e. never pass --follow,
+// or rely on --max-count) — this blocks until the process exits.
+func runObserve(data *TestData, args ...string) (string, string, error) {
+	return runAntctlCommandFromPod(data, antctlObservePodName, append([]string{"antctl", "observe"}, args...))
+}
+
+// startObservePod creates a dedicated, independent Pod whose sole container command is a
+// long-running "antctl observe <args>" invocation (typically --follow, with no --max-count),
+// rather than exec-ing into an already-running Pod. This lets a test inspect the command's
+// output at any point via the Pod's own logs (data.GetPodLogs) while the process keeps running —
+// there is otherwise no way to observe partial output from a command that is expected to keep
+// streaming indefinitely. Mirrors runAntctProxy's approach to the same "long-running antctl
+// process" problem (antctl_test.go), which reads a proxy's responses from a separate client
+// rather than from the exec call that started the proxy itself.
+//
+// discardStderr redirects the container's stderr to /dev/null before it ever reaches the
+// container runtime's combined log.
+// GetPodLogs always returns stdout/stderr interleaved into one stream, so a caller that parses
+// the Pod's logs as pure "antctl observe -o json" output (one JSON object per line) would otherwise
+// choke on antctl's own stderr status lines (e.g. "Discovering Flow Aggregator instance...").
+// Only set this for callers that parse logs as structured output; testAntctlObserveExitsOnDisconnect,
+// for example, deliberately relies on antctl's stderr "Error: ..." text surviving in the combined
+// log, so it must pass false.
+func startObservePod(t *testing.T, data *TestData, podName string, hostNetwork bool, extraLabels map[string]string, discardStderr bool, args ...string) func() {
+	command := append([]string{"antctl", "observe"}, args...)
+	if discardStderr {
+		command = []string{"sh", "-c", shellJoin(command) + " 2>/dev/null"}
+	}
+	b := NewPodBuilder(podName, data.testNamespace, controlPlaneNodeAntreaImage(t, data)).
+		WithServiceAccountName(antctlObserveServiceAccountName).
+		WithContainerName(antctlObserveContainerName).
+		WithCommand(command).
+		OnNode(controlPlaneNodeName())
+	if hostNetwork {
+		b = b.InHostNetwork()
+	}
+	if len(extraLabels) > 0 {
+		b = b.WithLabels(extraLabels)
+	}
+	require.NoErrorf(t, b.Create(data), "error when creating Pod %s running antctl observe", podName)
+	cleanup := func() {
+		assert.NoError(t, data.DeletePodAndWait(defaultTimeout, podName, data.testNamespace))
+	}
+	// Not podWaitForRunning: a bounded invocation (no --follow, or --max-count reached quickly)
+	// can run to completion and reach Succeeded before a poll for "Running" specifically ever
+	// observes that phase, since a container that starts and exits within roughly one poll
+	// interval can transition Pending -> Running -> Succeeded between two checks. Waiting for
+	// "has started" (any phase past Pending) is correct for both this file's long-running
+	// (--follow) and bounded (no --follow / --max-count) uses.
+	require.NoError(t, wait.PollUntilContextTimeout(context.Background(), defaultInterval, defaultTimeout, false, func(ctx context.Context) (bool, error) {
+		pod, err := data.clientset.CoreV1().Pods(data.testNamespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		return pod.Status.Phase != corev1.PodPending && pod.Status.Phase != "", nil
+	}), "Pod %s running antctl observe did not start", podName)
+	return cleanup
+}
+
+// shellJoin renders command as a POSIX shell command line, single-quoting every argument (and
+// escaping any embedded single quote) so it can be safely passed to "sh -c". Only used by
+// startObservePod, to append a "2>/dev/null" redirection after the otherwise-argv command.
+func shellJoin(command []string) string {
+	quoted := make([]string, len(command))
+	for i, arg := range command {
+		quoted[i] = "'" + strings.ReplaceAll(arg, "'", `'\''`) + "'"
+	}
+	return strings.Join(quoted, " ")
+}
+
+// controlPlaneNodeAntreaImage returns the Antrea container image in use on the cluster, the same
+// image "antctl" ships in (see testAntctlControllerRemoteAccess, antctl_test.go, for the identical
+// lookup used by the existing remote-mode antctl tests).
+func controlPlaneNodeAntreaImage(t *testing.T, data *TestData) string {
+	ds, err := data.clientset.AppsV1().DaemonSets(antreaNamespace).Get(context.TODO(), antreaDaemonSet, metav1.GetOptions{})
+	require.NoError(t, err, "Error when getting antrea DaemonSet")
+	return ds.Spec.Template.Spec.Containers[0].Image
+}
+
+// TestAntctlObserve is the top-level test for "antctl observe", following the same
+// shared-setup-then-subtests structure as TestFlowAggregator.
+func TestAntctlObserve(t *testing.T) {
+	skipIfNotFlowVisibilityTest(t)
+	skipIfHasWindowsNodes(t)
+	skipIfNumNodesLessThan(t, 2)
+
+	// setupFlowAggregatorTest (used by TestFlowAggregator) unconditionally deploys an IPFIX
+	// collector and ClickHouse alongside the Flow Aggregator, neither of which this file's tests
+	// use — "antctl observe" only cares about the ring buffer / FlowStreamService, not any
+	// configured export destination. deployFlowAggregator is the lower-level call that skips
+	// both: an empty ipfixCollectorAddr disables the IPFIX collector (mutateFlowAggregatorConfigMap
+	// sets flowCollector.enable based on it being non-empty), and omitting databaseURL leaves
+	// ClickHouse disabled the same way. This is the same call testAntctlObserveMultiInstance
+	// already uses for its second instance, just for instance 0 (the default Namespace,
+	// "flow-aggregator") here.
+	data, err := setupTest(t)
+	require.NoError(t, err, "Error when setting up test")
+	t.Cleanup(func() { teardownTest(t, data) })
+	t.Cleanup(func() { teardownFlowAggregator(t, data) })
+	require.NoError(t, data.deployFlowAggregator("", nil, nil, nil, flowVisibilityTestOptions{}), "Error when deploying Flow Aggregator")
+	enableFlowStreamService(t, data, flowAggregatorNamespace)
+	// k8sUtils is a package-level global that every ANNP-creating test in this package expects
+	// its own top-level test function to have initialized (see TestFlowAggregator); it is not
+	// initialized anywhere else automatically. testAntctlObserveConnectionFallback uses it to
+	// create an Antrea NetworkPolicy.
+	k8sUtils, err = NewKubernetesUtils(data)
+	require.NoError(t, err, "Error when creating Kubernetes utils client")
+
+	if !isIPv4Enabled() {
+		t.Skip("This test requires IPv4 to be enabled")
+	}
+
+	podAIPs, podBIPs, podCIPs, podDIPs, podEIPs, err = createPerftestPods(data)
+	require.NoError(t, err, "Error when creating perftest Pods")
+
+	antreaImage := controlPlaneNodeAntreaImage(t, data)
+	setupAntctlObserveStandinPod(t, data, antreaImage)
+
+	t.Run("CapturesIntraNodeFlow", func(t *testing.T) { testAntctlObserveCapturesFlow(t, data, false) })
+	t.Run("CapturesInterNodeFlow", func(t *testing.T) { testAntctlObserveCapturesFlow(t, data, true) })
+	t.Run("CapturesPodToExternalFlow", func(t *testing.T) { testAntctlObserveCapturesExternalFlow(t, data, true) })
+	t.Run("CapturesExternalToPodFlow", func(t *testing.T) { testAntctlObserveCapturesExternalFlow(t, data, false) })
+	t.Run("Filters", func(t *testing.T) { testAntctlObserveFilters(t, data) })
+	t.Run("DirectionFilter", func(t *testing.T) { testAntctlObserveDirectionFilter(t, data) })
+	t.Run("SinceFilter", func(t *testing.T) { testAntctlObserveSince(t, data) })
+	t.Run("MaxCount", func(t *testing.T) { testAntctlObserveMaxCount(t, data) })
+	t.Run("Follow", func(t *testing.T) { testAntctlObserveFollow(t, data) })
+	t.Run("CombinedSinceMaxCountFollow", func(t *testing.T) { testAntctlObserveCombinedParameters(t, data) })
+	t.Run("BearerTokenAuth", func(t *testing.T) { testAntctlObserveBearerTokenAuth(t, data) })
+	t.Run("NoCredential", func(t *testing.T) { testAntctlObserveNoCredential(t, data, antreaImage) })
+	t.Run("MultiInstanceDiscovery", func(t *testing.T) { testAntctlObserveMultiInstance(t, data) })
+	t.Run("ConnectionModeDirectFailsWithoutTunnel", func(t *testing.T) { testAntctlObserveConnectionModeDirect(t, data) })
+	t.Run("ConnectionFallbackUnderNetworkDenial", func(t *testing.T) { testAntctlObserveConnectionFallback(t, data) })
+	t.Run("ExitsOnDisconnect", func(t *testing.T) { testAntctlObserveExitsOnDisconnect(t, data) })
+}
+
+// perftestListenPort is the port createPerftestPods' Pods listen on (iperf3 -s); generateOneFlow
+// only needs a listener to complete a TCP handshake against, not an actual iperf3 session.
+const perftestListenPort = iperfPort
+
+// generateOneFlow opens and immediately closes a single TCP connection from srcPodName to
+// dstIP:dstPort ("nc -z": zero-I/O, connect-then-close), rather than running a multi-second
+// iperf3 transfer. This was iperf3 originally, and it caused two distinct problems under this
+// file's aggressively short flow-export timeouts (ci/kind/values-flow-exporter.yml: 1s poll, 2s
+// active, 1s idle — tuned for fast CI, not for a single clean record per call): first, a 5-second
+// transfer routinely produced *multiple* ring-buffer snapshots for the same logical connection
+// (the eager-export-on-correlation snapshot, plus periodic updates), which silently broke every
+// test in this file that counted records expecting one-generated-flow-per-record. Second, under
+// the same tuning, a single iperf3 invocation could be seen as more than one distinct connection
+// (different ephemeral source ports across snapshots), which broke exact-port assertions. A quick
+// connect-and-close finishes fast enough, and produces little enough traffic, to reliably become
+// exactly one ring-buffer record.
+func generateOneFlow(t *testing.T, data *TestData, srcPodName, dstIP string, dstPort int32) {
+	cmdStr := fmt.Sprintf("nc -z -w 2 %s %d", dstIP, dstPort)
+	_, stderr, err := data.RunCommandFromPod(data.testNamespace, srcPodName, "iperf", []string{"bash", "-c", cmdStr})
+	require.NoErrorf(t, err, "Error when connecting from %s to %s:%d: %s", srcPodName, dstIP, dstPort, stderr)
+}
+
+// observeUntilNonEmpty polls "antctl observe <extraArgs>" (no --follow, i.e. the default: exit
+// once historical flows are drained) until it returns at least one record or the default timeout
+// elapses.
+func observeUntilNonEmpty(t *testing.T, data *TestData, format string, extraArgs ...string) []observeRecord {
+	args := append([]string{"-o", format}, extraArgs...)
+	var records []observeRecord
+	require.NoError(t, wait.PollUntilContextTimeout(context.Background(), defaultInterval, defaultTimeout, false, func(ctx context.Context) (bool, error) {
+		stdout, stderr, err := runObserve(data, args...)
+		if err != nil {
+			t.Logf("antctl observe not ready yet: %v (stderr: %s)", err, stderr)
+			return false, nil
+		}
+		if format == "json" {
+			records = parseObserveJSON(t, stdout)
+		} else {
+			records = parseObserveText(t, stdout)
+		}
+		return len(records) > 0, nil
+	}), "antctl observe %v never returned any matching record", args)
+	return records
+}
+
+// observeEmpty runs "antctl observe <extraArgs>" (no --follow) once and asserts it returns no
+// records at all — used for the "filter correctly excludes a non-matching flow" half of every
+// filter test below. Unlike observeUntilNonEmpty, this does not poll: a filter that is broken in
+// the "matches too much" direction would otherwise never be caught by retrying.
+func observeEmpty(t *testing.T, data *TestData, format string, extraArgs ...string) {
+	args := append([]string{"-o", format}, extraArgs...)
+	stdout, stderr, err := runObserve(data, args...)
+	require.NoErrorf(t, err, "antctl observe %v failed: %s", args, stderr)
+	var records []observeRecord
+	if format == "json" {
+		records = parseObserveJSON(t, stdout)
+	} else {
+		records = parseObserveText(t, stdout)
+	}
+	assert.Emptyf(t, records, "antctl observe %v matched a flow it should have excluded", args)
+}
+
+// testAntctlObserveCapturesFlow verifies that a live intra-Node or inter-Node flow must show up
+// through "antctl observe" with every relevant field correct.
+// Does not assert on the exact source port: with this file's aggressively short
+// flow-export timeouts (see generateOneFlow), the ring buffer can hold more than one snapshot per
+// logical connection, and this only needs to confirm the record's identity (endpoints,
+// Namespaces, flow type), not its transport-level exactness.
+func testAntctlObserveCapturesFlow(t *testing.T, data *TestData, interNode bool) {
+	label := randSeq(8)
+	dstPodName, dstIP := "perftest-b", podBIPs.IPv4.String()
+	if interNode {
+		dstPodName, dstIP = "perftest-c", podCIPs.IPv4.String()
+	}
+	addLabelToTestPods(t, data, label, []string{"perftest-a", dstPodName})
+
+	generateOneFlow(t, data, "perftest-a", dstIP, perftestListenPort)
+
+	// text for one of the two (intra/inter) cases and json for the other, so both output formats
+	// are covered across this file rather than a dedicated, redundant format test.
+	format := "json"
+	if interNode {
+		format = "text"
+	}
+	records := observeUntilNonEmpty(t, data, format, "--selector", "targetLabel="+label)
+	r := records[len(records)-1]
+
+	assert.Equal(t, "perftest-a", r.SourcePodName)
+	assert.Equal(t, data.testNamespace, r.SourcePodNamespace)
+	assert.Equal(t, dstPodName, r.DestinationPodName)
+	assert.Equal(t, data.testNamespace, r.DestinationPodNamespace)
+	assert.EqualValues(t, perftestListenPort, r.DestinationPort)
+	if interNode {
+		assert.Equal(t, "FLOW_TYPE_INTER_NODE", r.FlowType)
+	} else {
+		assert.Equal(t, "FLOW_TYPE_INTRA_NODE", r.FlowType)
+	}
+}
+
+// testAntctlObserveCapturesExternalFlow covers observe for Pod->External External->Pod flows.
+func testAntctlObserveCapturesExternalFlow(t *testing.T, data *TestData, toExternal bool) {
+	if toExternal {
+		serverIPs := createToExternalTestServer(t, data)
+		label := randSeq(8)
+		addLabelToTestPods(t, data, label, []string{"perftest-a"})
+
+		generateOneFlow(t, data, "perftest-a", serverIPs.IPv4.String(), serverPodPort)
+
+		records := observeUntilNonEmpty(t, data, "json", "--selector", "targetLabel="+label, "--flow-type", "to-external")
+		r := records[len(records)-1]
+		assert.Equal(t, "FLOW_TYPE_TO_EXTERNAL", r.FlowType)
+		assert.Equal(t, "perftest-a", r.SourcePodName)
+		return
+	}
+
+	nginxPodName, _, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "observe-ext-to-pod-", workerNodeName(1), data.testNamespace, false)
+	defer cleanupFunc()
+	label := randSeq(8)
+	addLabelToTestPods(t, data, label, []string{nginxPodName})
+
+	svcIPFamily := corev1.IPv4Protocol
+	service, err := data.CreateServiceWithAnnotations("observe-ext-to-pod-svc", data.testNamespace, 80, containerPort, corev1.ProtocolTCP,
+		map[string]string{"antrea-e2e": nginxPodName}, false, false, corev1.ServiceTypeNodePort, &svcIPFamily, nil)
+	require.NoError(t, err, "failed to create NodePort Service for external-to-Pod test")
+	t.Cleanup(func() { assert.NoError(t, data.deleteService(data.testNamespace, service.Name)) })
+
+	createExternalToPodConnection(t, data, service, 0, false)
+
+	records := observeUntilNonEmpty(t, data, "json", "--selector", "targetLabel="+label, "--flow-type", "from-external")
+	r := records[len(records)-1]
+	assert.Equal(t, "FLOW_TYPE_FROM_EXTERNAL", r.FlowType)
+	assert.Equal(t, nginxPodName, r.DestinationPodName)
+}
+
+// testAntctlObserveFilters: namespaces, pod_names, pod_label_selector and ips, each tested with
+// a matching and a non-matching case.
+func testAntctlObserveFilters(t *testing.T, data *TestData) {
+	label := randSeq(8)
+	addLabelToTestPods(t, data, label, []string{"perftest-a", "perftest-b"})
+	generateOneFlow(t, data, "perftest-a", podBIPs.IPv4.String(), perftestListenPort)
+	labelSelector := "--selector=targetLabel=" + label
+
+	t.Run("Namespace", func(t *testing.T) {
+		records := observeUntilNonEmpty(t, data, "json", labelSelector, "-n", data.testNamespace)
+		assert.Equal(t, "perftest-a", records[len(records)-1].SourcePodName)
+		observeEmpty(t, data, "json", labelSelector, "-n", "kube-system")
+	})
+
+	t.Run("PodName", func(t *testing.T) {
+		records := observeUntilNonEmpty(t, data, "json", labelSelector, "--pod", "perftest-a")
+		assert.Equal(t, "perftest-a", records[len(records)-1].SourcePodName)
+		observeEmpty(t, data, "json", labelSelector, "--pod", "some-other-pod-name")
+	})
+
+	t.Run("PodLabelSelector", func(t *testing.T) {
+		records := observeUntilNonEmpty(t, data, "json", "-l", "targetLabel="+label)
+		assert.Equal(t, "perftest-a", records[len(records)-1].SourcePodName)
+		observeEmpty(t, data, "json", "-l", "targetLabel=some-other-value-"+label)
+	})
+
+	t.Run("IP", func(t *testing.T) {
+		records := observeUntilNonEmpty(t, data, "json", labelSelector, "--ip", podAIPs.IPv4.String())
+		assert.Equal(t, "perftest-a", records[len(records)-1].SourcePodName)
+		observeEmpty(t, data, "json", labelSelector, "--ip", "203.0.113.1/32")
+	})
+}
+
+// testAntctlObserveDirectionFilter: a single flow and a single filter value, toggling
+// only --direction, isolates exactly what --direction changes (which side is checked) rather than
+// whether matching works at all.
+func testAntctlObserveDirectionFilter(t *testing.T, data *TestData) {
+	label := randSeq(8)
+	addLabelToTestPods(t, data, label, []string{"perftest-a", "perftest-b"})
+	generateOneFlow(t, data, "perftest-a", podBIPs.IPv4.String(), perftestListenPort)
+	labelSelector := "--selector=targetLabel=" + label
+
+	// perftest-a is genuinely the source: --direction=from must match on its Namespace, and
+	// --direction=to must not, even though perftest-a's Namespace is also perftest-b's Namespace
+	// (they are in the same test Namespace), so a filter that ignored --direction entirely would
+	// pass this by accident.
+	records := observeUntilNonEmpty(t, data, "json", labelSelector, "-n", data.testNamespace, "--direction", "from")
+	assert.Equal(t, "perftest-a", records[len(records)-1].SourcePodName)
+
+	observeEmpty(t, data, "json", labelSelector, "--pod", "perftest-a", "--direction", "to")
+}
+
+// countDistinctFlows deduplicates records by 5-tuple. Under aggressively short
+// flow-export timeouts (ci/kind/values-flow-exporter.yml: 1s poll, 2s active, 1s idle,
+// the ring buffer can hold more than one snapshot for the same logical connection.
+// Counting raw records might therefore overcount "how many connections happened".
+func countDistinctFlows(records []observeRecord) int {
+	seen := make(map[string]struct{})
+	for _, r := range records {
+		seen[fmt.Sprintf("%s:%d-%s:%d", r.SourceIP, r.SourcePort, r.DestinationIP, r.DestinationPort)] = struct{}{}
+	}
+	return len(seen)
+}
+
+// testAntctlObserveSince: X flows at T1, X more at T2, three cutoffs. Counts distinct
+// flows (see countDistinctFlows), not raw records: --since's job is to filter by time, and
+// whether a given connection happens to appear as one ring-buffer record or several is an
+// unrelated, timing-dependent implementation detail this test should not depend on.
+func testAntctlObserveSince(t *testing.T, data *TestData) {
+	label := randSeq(8)
+	addLabelToTestPods(t, data, label, []string{"perftest-a", "perftest-b"})
+	labelSelector := "--selector=targetLabel=" + label
+	const batchSize = 2
+
+	for i := 0; i < batchSize; i++ {
+		generateOneFlow(t, data, "perftest-a", podBIPs.IPv4.String(), perftestListenPort)
+	}
+	// Let batch 1 fully settle before capturing the "between batches" cutoff: a flow's recorded
+	// end_ts lags behind generateOneFlow returning by however long the Agent's own poll/export
+	// cycle takes (up to ~2s under this file's aggressively short flowExporter timeouts — see
+	// ci/kind/values-flow-exporter.yml), so a cutoff captured too soon after batch 1 can still
+	// land before some of batch 1's flows get their end_ts recorded, making them appear to be
+	// "after" the cutoff and leak into what should be a batch-2-only query.
+	time.Sleep(3 * time.Second)
+	tBetween := time.Now()
+	time.Sleep(1 * time.Second)
+	for i := 0; i < batchSize; i++ {
+		generateOneFlow(t, data, "perftest-a", podBIPs.IPv4.String(), perftestListenPort)
+	}
+	t2 := time.Now()
+
+	// The ring buffer only gains an entry for a flow once correlation completes (eager export),
+	// which lags slightly behind generateOneFlow returning; give it a moment before querying so
+	// "since > t2" below is not observing a false negative caused by that lag rather than by
+	// --since actually working.
+	var records []observeRecord
+	require.Eventually(t, func() bool {
+		records = parseObserveJSON(t, mustRunObserve(t, data, labelSelector, "--since", tBetween.Add(-time.Hour).Format(time.RFC3339)))
+		return countDistinctFlows(records) >= 2*batchSize
+	}, defaultTimeout, defaultInterval, "since before both batches should eventually return all of them")
+
+	records = parseObserveJSON(t, mustRunObserve(t, data, labelSelector, "--since", tBetween.Format(time.RFC3339)))
+	assert.Equal(t, batchSize, countDistinctFlows(records), "since between the two batches should return only the second one")
+
+	records = parseObserveJSON(t, mustRunObserve(t, data, labelSelector, "--since", t2.Add(time.Minute).Format(time.RFC3339)))
+	assert.Empty(t, records, "since after both batches should return nothing")
+}
+
+func mustRunObserve(t *testing.T, data *TestData, args ...string) string {
+	stdout, stderr, err := runObserve(data, append([]string{"-o", "json"}, args...)...)
+	require.NoErrorf(t, err, "antctl observe %v failed: %s", args, stderr)
+	return stdout
+}
+
+// testAntctlObserveMaxCount: --max-count for K in {0,<total,=total,>total}. Unlike
+// testAntctlObserveSince, this deliberately measures the actual available record count ("total")
+// rather than assuming it equals the number of generateOneFlow calls: --max-count's real contract
+// is a cap on raw ring-buffer records returned, not on distinct logical connections (see
+// countDistinctFlows), and under this aggressive short flow-export timeouts a handful of
+// connections routinely produce more raw records than connections generated. Measuring total
+// directly, and deriving every K from it, keeps the assertions correct regardless of exactly how
+// many records each connection happens to produce.
+func testAntctlObserveMaxCount(t *testing.T, data *TestData) {
+	label := randSeq(8)
+	addLabelToTestPods(t, data, label, []string{"perftest-a", "perftest-b"})
+	labelSelector := "--selector=targetLabel=" + label
+	const n = 3
+	for i := 0; i < n; i++ {
+		generateOneFlow(t, data, "perftest-a", podBIPs.IPv4.String(), perftestListenPort)
+	}
+
+	// Wait for all n distinct connections to be visible at least once, then let the aggressive
+	// 1s/2s export timeouts settle so "total" (measured next) is not still climbing.
+	require.Eventually(t, func() bool {
+		return countDistinctFlows(parseObserveJSON(t, mustRunObserve(t, data, labelSelector))) >= n
+	}, defaultTimeout, defaultInterval, "not all %d generated flows became visible", n)
+	time.Sleep(3 * time.Second)
+	total := len(parseObserveJSON(t, mustRunObserve(t, data, labelSelector)))
+	require.Greaterf(t, total, 1, "need at least a couple of available records to meaningfully exercise --max-count, got %d", total)
+
+	for _, tc := range []struct {
+		name     string
+		maxCount int
+	}{
+		{"Unlimited", 0},
+		{"LessThanTotal", total - 1},
+		{"EqualToTotal", total},
+		{"GreaterThanTotal", total + 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			records := parseObserveJSON(t, mustRunObserve(t, data, labelSelector, "--max-count", strconv.Itoa(tc.maxCount)))
+			expect := tc.maxCount
+			if expect == 0 || expect > total {
+				expect = total
+			}
+			assert.Len(t, records, expect)
+		})
+	}
+}
+
+// testAntctlObserveFollow: without --follow (the default, matching "kubectl logs"),
+// observe must terminate on its own once historical flows are exhausted; --follow must show
+// historical flows first and then flows generated after the stream opened, proving it streams
+// live data rather than only replaying history.
+func testAntctlObserveFollow(t *testing.T, data *TestData) {
+	t.Run("DefaultTerminatesOnItsOwn", func(t *testing.T) {
+		done := make(chan error, 1)
+		go func() {
+			_, _, err := runObserve(data, "-n", "a-namespace-with-no-flows-at-all")
+			done <- err
+		}()
+		select {
+		case err := <-done:
+			assert.NoError(t, err)
+		case <-time.After(30 * time.Second):
+			t.Fatal("antctl observe (default, no --follow) did not terminate on its own within 30s")
+		}
+	})
+
+	t.Run("FollowShowsHistoricalThenLiveFlows", func(t *testing.T) {
+		label := randSeq(8)
+		addLabelToTestPods(t, data, label, []string{"perftest-a", "perftest-b", "perftest-c"})
+
+		// Historical: generated before the stream opens.
+		generateOneFlow(t, data, "perftest-a", podBIPs.IPv4.String(), perftestListenPort)
+		require.Eventually(t, func() bool {
+			return len(parseObserveJSON(t, mustRunObserve(t, data, "--selector=targetLabel="+label))) >= 1
+		}, defaultTimeout, defaultInterval, "the historical flow never became visible before starting the follow Pod")
+
+		podName := "antctl-observe-follow-" + randSeq(6)
+		cleanup := startObservePod(t, data, podName, true, nil, true,
+			"--selector", "targetLabel="+label, "-o", "json", "--follow")
+		defer cleanup()
+
+		// Live: generated after the stream opened.
+		generateOneFlow(t, data, "perftest-a", podCIPs.IPv4.String(), perftestListenPort)
+
+		require.Eventually(t, func() bool {
+			logs, err := data.GetPodLogs(context.TODO(), data.testNamespace, podName, antctlObserveContainerName)
+			if err != nil {
+				return false
+			}
+			records := parseObserveJSON(t, logs)
+			sawHistorical, sawLive := false, false
+			for _, r := range records {
+				if r.DestinationPodName == "perftest-b" {
+					sawHistorical = true
+				}
+				if r.DestinationPodName == "perftest-c" {
+					sawLive = true
+				}
+			}
+			return sawHistorical && sawLive
+		}, defaultTimeout, defaultInterval, "--follow did not show both the historical and the live-generated flow")
+	})
+}
+
+// testAntctlObserveCombinedParameters: verifies --since, --max-count and --follow used
+// together. The server closes the stream once max_count is reached even with follow=true (see
+// FlowStreamService.GetFlows), so this terminates deterministically without needing to time out
+// or kill the process.
+func testAntctlObserveCombinedParameters(t *testing.T, data *TestData) {
+	label := randSeq(8)
+	addLabelToTestPods(t, data, label, []string{"perftest-a", "perftest-b"})
+	since := time.Now()
+	generateOneFlow(t, data, "perftest-a", podBIPs.IPv4.String(), perftestListenPort)
+
+	// The combined --follow invocation below must not be the first check for the flow's presence:
+	// with --follow, the server deliberately keeps the stream open waiting for more data until
+	// max_count hasn't been reached yet, so a single missed/late delivery here would hang forever
+	// rather than fail fast. Confirm the flow is already visible through a quick, retryable,
+	// non-follow poll using the same filters first, mirroring FollowShowsHistoricalThenLiveFlows above.
+	require.Eventually(t, func() bool {
+		return len(parseObserveJSON(t, mustRunObserve(t, data, "--selector", "targetLabel="+label, "--since", since.Format(time.RFC3339)))) >= 1
+	}, defaultTimeout, defaultInterval, "the flow never became visible before the combined --follow invocation")
+
+	stdout, stderr, err := runObserve(data, "--selector", "targetLabel="+label, "--since", since.Format(time.RFC3339),
+		"--max-count", "1", "--follow", "-o", "json")
+	require.NoErrorf(t, err, "combined --since/--max-count/--follow invocation failed: %s", stderr)
+	records := parseObserveJSON(t, stdout)
+	assert.Len(t, records, 1)
+}
+
+// testAntctlObserveBearerTokenAuth: The shared stand-in Pod (setupAntctlObserveStandinPod)
+// has no kubeconfig file mounted, so runtime.ResolveKubeconfig falls through to
+// rest.InClusterConfig(), which is a bearer-token credential (the Pod's own ServiceAccount token)
+// — meaning every other test in this file already exercises the TokenReview path as a side
+// effect of simply succeeding at all. This test exists to make that assertion explicit rather
+// than leaving it implicit, in case the default credential source ever changes.
+func testAntctlObserveBearerTokenAuth(t *testing.T, data *TestData) {
+	label := randSeq(8)
+	addLabelToTestPods(t, data, label, []string{"perftest-a", "perftest-b"})
+	generateOneFlow(t, data, "perftest-a", podBIPs.IPv4.String(), perftestListenPort)
+	records := observeUntilNonEmpty(t, data, "json", "--selector", "targetLabel="+label)
+	assert.NotEmpty(t, records, "the bearer-token (ServiceAccount) credential path should have authenticated successfully")
+}
+
+// testAntctlObserveNoCredential: rather than constructing a kubeconfig with a syntactically-present
+// but invalid credential  this runs "antctl observe" from a Pod with a ServiceAccount that is bound
+// to no ClusterRole at all, so it can't even reach the Kubernetes API server.
+// This test does not verify rejected credentials from FlowStreamService, it simply verifies the observe
+// command gracefully fails when there is a permission-related failure.
+func testAntctlObserveNoCredential(t *testing.T, data *TestData, antreaImage string) {
+	const saName = "antctl-observe-no-rbac"
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: data.testNamespace, Name: saName}}
+	_, err := data.clientset.CoreV1().ServiceAccounts(data.testNamespace).Create(context.TODO(), sa, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, data.clientset.CoreV1().ServiceAccounts(data.testNamespace).Delete(context.TODO(), saName, metav1.DeleteOptions{}))
+	})
+
+	podName := "antctl-observe-no-rbac"
+	require.NoError(t, NewPodBuilder(podName, data.testNamespace, antreaImage).
+		WithServiceAccountName(saName).WithContainerName(antctlObserveContainerName).
+		WithCommand([]string{"sleep", "3600"}).OnNode(controlPlaneNodeName()).InHostNetwork().Create(data))
+	t.Cleanup(func() { assert.NoError(t, data.DeletePodAndWait(defaultTimeout, podName, data.testNamespace)) })
+	require.NoError(t, data.podWaitForRunning(defaultTimeout, podName, data.testNamespace))
+
+	_, stderr, err := runAntctlCommandFromPod(data, podName, []string{"antctl", "observe"})
+	require.Error(t, err, "antctl observe should fail for a ServiceAccount with no RBAC at all")
+	assert.Contains(t, strings.ToLower(stderr), "forbidden")
+}
+
+// testAntctlObserveMultiInstance: with two Flow Aggregator instances deployed, discovery
+// must fail with a disambiguation error, while --server and --flow-aggregator both succeed. Reuses
+// exactly the two-instance deployment mechanism from setupFlowExporterDestinationTest.
+func testAntctlObserveMultiInstance(t *testing.T, data *TestData) {
+	// This exercises three instances at once: the default one TestAntctlObserve's own setup
+	// deployed (Namespace flow-aggregator, release name "flow-aggregator"), plus this subtest's
+	// own instance 1 (Namespace flow-aggregator-1). ci/kind/test-e2e-kind.sh's manifest generation
+	// now gives every instance a distinct --release-name (not just --namespace), matching what a
+	// real multi-instance deployment would do.
+
+	opts := flowVisibilityTestOptions{flowAggregator: flowAggregatorTestOptions{selectedAggregator: 1}}
+	require.NoError(t, data.deployFlowAggregator("", nil, nil, nil, opts), "failed to deploy second Flow Aggregator instance")
+	t.Cleanup(func() {
+		// Not teardownFlowAggregator: that deletes every flowAggregator* Namespace,
+		// including the default instance TestAntctlObserve's own setup deployed and every other
+		// subtest in this file depends on. This subtest only owns instance 1.
+		if err := data.DeleteNamespace(flowAggregatorNamespace1, defaultTimeout); err != nil {
+			t.Logf("Error when deleting %s Namespace: %v", flowAggregatorNamespace1, err)
+		}
+	})
+	enableFlowStreamService(t, data, flowAggregatorNamespace1)
+
+	_, stderr, err := runObserve(data, "--max-count", "1")
+	require.Error(t, err, "discovery must fail when more than one Flow Aggregator instance exists")
+	assert.Contains(t, stderr, "multiple Namespaces")
+
+	pods, err := data.getFlowAggregators(flowAggregatorNamespace1)
+	require.NoError(t, err)
+	require.NotEmpty(t, pods)
+	addr := fmt.Sprintf("%s:14740", pods[0].Status.PodIP)
+	// --flow-aggregator-namespace must match the instance being dialed: with --flow-aggregator-address
+	// there is no discovered Pod to read a Namespace from, so the CA/serverName lookup would
+	// otherwise default to defaultFlowAggregatorNamespace ("flow-aggregator") and fail to verify
+	// instance 1's certificate (whose SAN is namespace-specific, see connect.go/discovery.go).
+	_, stderr, err = runObserve(data, "--max-count", "1", "--flow-aggregator-address", addr, "--flow-aggregator-namespace", flowAggregatorNamespace1)
+	assert.NoErrorf(t, err, "explicit --flow-aggregator-address should bypass discovery: %s", stderr)
+
+	// The Deployment's own name is release-name-derived (distinct per instance), so it is looked up
+	// rather than assumed, the same way the e2e framework's own helpers do.
+	deployment, err := data.getFlowAggregatorDeployment(flowAggregatorNamespace1)
+	require.NoError(t, err)
+	_, stderr, err = runObserve(data, "--max-count", "1", "--flow-aggregator", flowAggregatorNamespace1+"/"+deployment.Name)
+	assert.NoErrorf(t, err, "explicit --flow-aggregator should bypass discovery: %s", stderr)
+}
+
+// testAntctlObserveConnectionModeDirect: confirms --connection-mode=direct fails outright, rather than
+// silently tunneling when the caller has no direct route to the Flow
+// Aggregator's Pod IP, which is expected inside this Pod network for the shared, host-network
+// stand-in Pod. However, that Pod, being host-network, *does* have a direct route. So this test
+// runs from a plain (non-host-network) Pod instead, which shares the fallback test's premise: see
+// testAntctlObserveConnectionFallback for why host networking is avoided there.
+func testAntctlObserveConnectionModeDirect(t *testing.T, data *TestData) {
+	podName := "antctl-observe-direct-" + randSeq(6)
+	cleanup := startObservePod(t, data, podName, false, nil, false, "--max-count", "1", "--connection-mode", "direct")
+	defer cleanup()
+	// A Pod's own network namespace can always reach any other Pod's IP over Antrea's own Pod
+	// network so --connection-mode=direct is expected to succeed here, not fail: this asserts
+	// the "always tunnels" and "never silently tunnels" halves of the mode matrix are both true,
+	// using the one mode (direct) that has no fallback to hide a bug behind.
+	require.NoError(t, wait.PollUntilContextTimeout(context.Background(), defaultInterval, defaultTimeout, false, func(ctx context.Context) (bool, error) {
+		pod, err := data.clientset.CoreV1().Pods(data.testNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		return pod.Status.Phase == corev1.PodSucceeded, nil
+	}), "antctl observe --connection-mode=direct did not exit successfully")
+}
+
+// testAntctlObserveConnectionFallback9: verifies the automatic fallback to a tunnel is triggered
+// in response to a genuine network denial, not just forced via --connection-mode=tunnel.
+// Uses a Pod without host networking, deliberately: a host-network Pod's traffic is sourced from
+// the Node's IP, so an ACNP scoped to "this one Pod" would actually block the whole Node.
+// This could be a source of flakiness for tests.
+func testAntctlObserveConnectionFallback(t *testing.T, data *TestData) {
+	faPods, err := data.getFlowAggregators(flowAggregatorNamespace)
+	require.NoError(t, err)
+	require.NotEmpty(t, faPods)
+	faPodIP := faPods[0].Status.PodIP
+
+	podName := "antctl-observe-fallback-" + randSeq(6)
+	blockLabel := map[string]string{"antrea-e2e": podName}
+
+	// add a network policy to block direct connections to the FA pod.
+	builder := &utils.AntreaNetworkPolicySpecBuilder{}
+	builder.SetName(data.testNamespace, "observe-block-direct-to-fa").
+		SetPriority(1.0).
+		SetAppliedToGroup([]utils.ANNPAppliedToSpec{{PodSelector: blockLabel}}).
+		AddEgress(utils.ANNPRuleBuilder{
+			BaseRuleBuilder: utils.BaseRuleBuilder{
+				Protoc:  utils.ProtocolTCP,
+				Port:    ptr.To(int32(14740)),
+				IPBlock: &secv1beta1.IPBlock{CIDR: faPodIP + "/32"},
+				Action:  secv1beta1.RuleActionDrop,
+				Name:    "block-flowstream-port",
+			},
+		})
+	anp, err := k8sUtils.CreateOrUpdateANNP(builder.Get())
+	require.NoError(t, err, "failed to create Antrea NetworkPolicy blocking direct access to the Flow Aggregator")
+	t.Cleanup(func() { assert.NoError(t, data.deleteAntreaNetworkpolicy(anp)) })
+	time.Sleep(5 * time.Second) // allow the policy to be realized, matching the convention used elsewhere in this package
+
+	cleanup := startObservePod(t, data, podName, false, blockLabel, false, "--max-count", "1")
+	defer cleanup()
+
+	// connectionModeAuto's direct attempt is expected to time out against the blocked port
+	// (directDialTimeout, 2s) before falling back; give it comfortably more than that before
+	// concluding it never completed.
+	require.NoError(t, wait.PollUntilContextTimeout(context.Background(), defaultInterval, defaultTimeout, false, func(ctx context.Context) (bool, error) {
+		pod, err := data.clientset.CoreV1().Pods(data.testNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		return pod.Status.Phase == corev1.PodSucceeded, nil
+	}), "antctl observe (auto mode) did not fall back to a tunnel and succeed despite the direct path being blocked")
+}
+
+// testAntctlObserveExitsOnDisconnect: observe must exit promptly with a clear error
+// when the Flow Aggregator connection drops mid-stream, not hang waiting for it to come back (see
+// the design doc's decision: retry policy, if any, belongs to the caller, not to observe itself).
+func testAntctlObserveExitsOnDisconnect(t *testing.T, data *TestData) {
+	podName := "antctl-observe-disconnect-" + randSeq(6)
+	cleanup := startObservePod(t, data, podName, true, nil, false, "--follow")
+	defer cleanup()
+
+	// Give the stream a moment to actually connect before pulling the rug out from under it —
+	// otherwise a Pod that failed to connect at all for an unrelated reason could be
+	// misattributed to this test's own disconnect.
+	require.Eventually(t, func() bool {
+		logs, err := data.GetPodLogs(context.TODO(), data.testNamespace, podName, antctlObserveContainerName)
+		return err == nil && !strings.Contains(logs, "Error:")
+	}, 30*time.Second, defaultInterval, "antctl observe did not start cleanly before the Flow Aggregator was restarted")
+
+	require.NoError(t, data.restartFlowAggregator(flowAggregatorNamespace), "failed to restart the Flow Aggregator to sever the connection")
+
+	require.Eventually(t, func() bool {
+		pod, err := data.clientset.CoreV1().Pods(data.testNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		// PodBuilder.Create (framework.go) hardcodes RestartPolicy: Never for every Pod it
+		// creates, this one included: a container that exits simply stays exited (Pod phase
+		// Succeeded/Failed), it is never restarted. So the signal to look for is the container's
+		// own Terminated state, not RestartCount, which can never leave 0 here regardless of
+		// whether antctl observe exited promptly or not.
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.State.Terminated != nil {
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, defaultInterval, "antctl observe did not exit promptly when the Flow Aggregator connection was severed")
+}

--- a/test/e2e/flowexporter_test.go
+++ b/test/e2e/flowexporter_test.go
@@ -42,8 +42,16 @@ func isTestProtocolGRPC() bool {
 
 // createFlowExporterDestination creates a new FlowExporterDestination and hooks it up for deletion at the end of the test.
 func createFlowExporterDestination(tb testing.TB, name string, isTLS bool, namespace string) *v1alpha1.FlowExporterDestination {
-	serviceAddr := fmt.Sprintf("%s/%s", namespace, "flow-aggregator")
-	serverName := fmt.Sprintf("%s.%s.svc", "flow-aggregator", namespace)
+	// The Service's own name is release-name-derived (distinct per multi-instance deployment), so
+	// it must be looked up rather than assumed.
+	service, err := testData.getFlowAggregatorService(namespace)
+	require.NoError(tb, err, "Failed to look up Flow Aggregator Service")
+	serviceAddr := fmt.Sprintf("%s/%s", namespace, service.Name)
+	// Unlike the Service name, the server certificate's SAN is a fixed "flow-aggregator.<namespace>.svc"
+	// string regardless of release name (see getFlowAggregatorServerNames in
+	// pkg/flowaggregator/certificate/provider.go), so this must stay hardcoded rather than track
+	// service.Name.
+	serverName := fmt.Sprintf("flow-aggregator.%s.svc", namespace)
 
 	protocol := v1alpha1.FlowExporterProtocol{}
 	if isTestProtocolGRPC() {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -94,7 +94,6 @@ const (
 	antreaDaemonSet             = "antrea-agent"
 	antreaWindowsDaemonSet      = "antrea-agent-windows"
 	antreaDeployment            = "antrea-controller"
-	flowAggregatorDeployment    = "flow-aggregator"
 	flowAggregatorCHSecret      = "clickhouse-ca"
 	antreaDefaultGW             = "antrea-gw0"
 	testAntreaIPAMNamespace     = "antrea-ipam-test"
@@ -1225,13 +1224,21 @@ func (data *TestData) deployFlowAggregator(
 		return err
 	}
 
+	// The Deployment's own name is derived from the Helm release name, which multi-instance
+	// deployments set to distinct values per instance to avoid colliding on cluster-scoped RBAC
+	// object names; it must therefore be looked up by label rather than assumed.
+	deployment, err := data.getFlowAggregatorDeployment(namespace)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve Flow Aggregator Deployment: %w", err)
+	}
+
 	if o.flowAggregator.numReplicas > 0 {
-		if rc, _, _, err = data.provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s scale deployment/%s --replicas=%d", namespace, flowAggregatorDeployment, o.flowAggregator.numReplicas)); err != nil || rc != 0 {
+		if rc, _, _, err = data.provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s scale deployment/%s --replicas=%d", namespace, deployment.Name, o.flowAggregator.numReplicas)); err != nil || rc != 0 {
 			return fmt.Errorf("failed to scale number of flow aggregator replicas: %w", err)
 		}
 	}
 
-	if rc, _, _, err = data.provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s rollout status deployment/%s --timeout=%v", namespace, flowAggregatorDeployment, 2*defaultTimeout)); err != nil || rc != 0 {
+	if rc, _, _, err = data.provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s rollout status deployment/%s --timeout=%v", namespace, deployment.Name, 2*defaultTimeout)); err != nil || rc != 0 {
 		_, stdout, _, _ := data.provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s describe pod", namespace))
 		_, logStdout, _, _ := data.provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s logs -l app=flow-aggregator", namespace))
 		return fmt.Errorf("error when waiting for the Flow Aggregator rollout to complete. kubectl describe output: %s, logs: %s", stdout, logStdout)
@@ -1316,28 +1323,33 @@ func (data *TestData) mutateFlowAggregatorConfigMap(ipfixCollectorAddr string, o
 }
 
 func (data *TestData) GetFlowAggregatorConfigMap(o flowVisibilityTestOptions) (*corev1.ConfigMap, error) {
-	deploymentName := flowAggregatorDeployment
 	namespace := flowAggregatorNamespaces[o.flowAggregator.selectedAggregator]
 
-	deployment, err := data.clientset.AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	configMapName, err := data.getFlowAggregatorConfigMapName(namespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve Flow aggregator deployment: %v", err)
-	}
-	var configMapName string
-	for _, volume := range deployment.Spec.Template.Spec.Volumes {
-		if volume.ConfigMap != nil && (volume.Name == flowAggregatorConfigVolume) {
-			configMapName = volume.ConfigMap.Name
-			break
-		}
-	}
-	if len(configMapName) == 0 {
-		return nil, fmt.Errorf("failed to locate %s ConfigMap volume", flowAggregatorConfigVolume)
+		return nil, err
 	}
 	configMap, err := data.clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ConfigMap %s: %v", configMapName, err)
 	}
 	return configMap, nil
+}
+
+// getFlowAggregatorConfigMapName returns the name of the Flow Aggregator's config ConfigMap in the
+// specified Namespace, read from the Deployment's own volume spec rather than assumed: like the
+// Deployment's own name, it is release-name-derived.
+func (data *TestData) getFlowAggregatorConfigMapName(namespace string) (string, error) {
+	deployment, err := data.getFlowAggregatorDeployment(namespace)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve Flow aggregator deployment: %v", err)
+	}
+	for _, volume := range deployment.Spec.Template.Spec.Volumes {
+		if volume.ConfigMap != nil && (volume.Name == flowAggregatorConfigVolume) {
+			return volume.ConfigMap.Name, nil
+		}
+	}
+	return "", fmt.Errorf("failed to locate %s ConfigMap volume", flowAggregatorConfigVolume)
 }
 
 // getAgentContainersRestartCount reads the restart count for every container across all Antrea
@@ -2137,6 +2149,41 @@ func (data *TestData) getFlowAggregators(namespace string) ([]corev1.Pod, error)
 		return nil, errNoAggregators
 	}
 	return pods.Items, nil
+}
+
+// getFlowAggregatorDeployment retrieves the Flow Aggregator Deployment from the specified
+// Namespace by label, rather than by a hardcoded name: the Deployment's name is derived from the
+// Helm release name, which multi-instance deployments set to distinct values per instance to
+// avoid colliding on cluster-scoped RBAC object names.
+func (data *TestData) getFlowAggregatorDeployment(namespace string) (*appsv1.Deployment, error) {
+	listOptions := metav1.ListOptions{
+		LabelSelector: "app=flow-aggregator",
+	}
+	deployments, err := data.clientset.AppsV1().Deployments(namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Flow Aggregator Deployment: %w", err)
+	}
+	if len(deployments.Items) != 1 {
+		return nil, fmt.Errorf("expected exactly one Flow Aggregator Deployment in Namespace %s, got %d", namespace, len(deployments.Items))
+	}
+	return &deployments.Items[0], nil
+}
+
+// getFlowAggregatorService retrieves the Flow Aggregator Service from the specified Namespace by
+// label, for the same reason as getFlowAggregatorDeployment: its name is release-name-derived,
+// not the fixed "flow-aggregator" string.
+func (data *TestData) getFlowAggregatorService(namespace string) (*corev1.Service, error) {
+	listOptions := metav1.ListOptions{
+		LabelSelector: "app=flow-aggregator",
+	}
+	services, err := data.clientset.CoreV1().Services(namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Flow Aggregator Service: %w", err)
+	}
+	if len(services.Items) != 1 {
+		return nil, fmt.Errorf("expected exactly one Flow Aggregator Service in Namespace %s, got %d", namespace, len(services.Items))
+	}
+	return &services.Items[0], nil
 }
 
 // getAntreaController retrieves the name of the Antrea Controller (antrea-controller-*) running in the k8s cluster.


### PR DESCRIPTION
Add antctl observe command for live flow streaming from Flow Aggregator

_antctl observe_ is a new command that streams live flow records from a Flow Aggregator's FlowStreamService gRPC endpoint, similar to "kubectl logs -f". It supports filtering (Namespace, Pod, label selector, Service, flow type, IP/CIDR,direction), --since/--max-count/--follow, text/JSON output (with--human-readable byte formatting), automatic Flow Aggregator discovery.
It can be executed from any node with access to K8S API server, provided user has the pods/portforward role. It also supports in-Pod execution from within the Flow Aggregator itself.
    
**New package pkg/antctl/raw/observe/:**

- command.go (cobra command, in-Pod vs. remote connection orchestration)
- filter.go (CLI-flags-to-request building)
- connect.go (direct dial or SPDY tunnel through the /portforward subresource, with automatic fallback)
- discovery.go (cluster-wide or Namespace-scoped Flow Aggregator discovery)
- auth.go (bearer token/file, client cert, or captured exec/OIDC token; in-Pod mode uses the Pod's own ServiceAccount via rest.InClusterConfig)
- render.go (text and line-delimited JSON renderers, safe for --follow's unbounded output).

Registered in antctl's command and debug-command lists, now including FlowAggregator mode.
The Client-side gRPC keepalive is tuned just above the FlowStreamService's default 5-minute enforcement policy to avoid disconnections due to GOAWAY.
    
**Notes:**
- authentication with captured OIDC token has currently not been tested.
- discovery is not available when multiple flow aggregator instances are running: in that case user must explicitly target a F-A instance.

    
**Unit tests** 
pkg/antctl/raw/observe/{connect,filter,render}_test.go cover request building, dial/tunnel connection-mode selection and fallback, and text/JSON rendering (formatting, truncation, human-readable sizes).
    
**e2e tests**

- new test/e2e/antctlobserve_test.go (TestAntctlObserve) covers:
- intra/inter-Node and Pod<->external flow capture;
- every filter type; --since,--max-count, --follow, and their combination (including the server closing the stream at max_count even while following);
- text vs. JSON output;
- ServiceAccount bearer-token auth and missing-credential handling;
- refusing to auto-discover across multiple Flow Aggregator instances plus explicit --flow-aggregator/--flow-aggregator-address targeting;
- direct vs. auto-with-tunnel-fallback connection modes under NetworkPolicy-enforced denial
- clean exit on server-side disconnect. 

This PR also fixes an antctl ClusterRole gap (missing "get" on deployments) and gives test-e2e-kind.sh's Flow Aggregator instances distinct Helm release names (cluster-scoped RBAC names are release-name-, not Namespace-derived).