### PR TITLE
Expose FlowStreamService's readiness through the Flow aggregator apiserver

### DIFF
--- a/build/charts/flow-aggregator/templates/deployment.yaml
+++ b/build/charts/flow-aggregator/templates/deployment.yaml
@@ -111,6 +111,38 @@ spec:
             containerPort: 14740
             protocol: TCP
           {{- end }}
+          - name: api
+            containerPort: {{ .Values.apiServer.apiPort }}
+            protocol: TCP
+        readinessProbe:
+          # Backed by a healthz.HealthChecker reflecting FlowStreamService's own state (see
+          # pkg/flowaggregator/apiserver), not by a check on this port itself: unlike
+          # antrea-agent/antrea-controller, this apiserver has no independent liveness concern of
+          # its own beyond FlowStreamService, which is the only thing actually worth probing here.
+          # Always present, even when flowStreamService.enable is false: the check itself reports
+          # healthy when the feature is disabled, so there is nothing to gate on here.
+          #
+          # No "host" override here (unlike antrea-agent/antrea-controller's own probes): those
+          # always run with hostNetwork true, so "localhost" resolves to the same network
+          # namespace for both kubelet and Pod. flow-aggregator does not (hostNetwork defaults to
+          # false), so an explicit "localhost" would have the kubelet dial its own Node instead of
+          # the Pod. Leaving "host" unset defaults to the Pod IP, which is correct either way.
+          httpGet:
+            path: /readyz
+            port: api
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+          periodSeconds: 10
+          failureThreshold: 5
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: api
+            scheme: HTTPS
+          timeoutSeconds: 5
+          periodSeconds: 10
+          failureThreshold: 5
         volumeMounts:
         - mountPath: /etc/flow-aggregator
           name: flow-aggregator-config

--- a/pkg/flowaggregator/apiserver/apiserver.go
+++ b/pkg/flowaggregator/apiserver/apiserver.go
@@ -16,8 +16,10 @@ package apiserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"path"
 
@@ -26,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/healthz"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	basecompatibility "k8s.io/component-base/compatibility"
 
@@ -74,6 +77,21 @@ func installHandlers(s *genericapiserver.GenericAPIServer, faq querier.FlowAggre
 	s.Handler.NonGoRestfulMux.HandleFunc("/loglevel", loglevel.HandleFunc())
 }
 
+// installHealthChecks registers a healthz.HealthChecker reflecting FlowStreamService's own
+// readiness on healthz, livez and readyz alike (AddHealthChecks, not AddReadyzChecks: the two
+// probes are meant to share this same check, and AddReadyzChecks alone would leave livez seeing
+// only the default "ping" check). This must run before GenericAPIServer.PrepareRun installs the
+// actual endpoint handlers (called from flowAggregatorAPIServer.Run), which New's own caller does
+// separately and later, so registering here, inside New, is always in time.
+func installHealthChecks(s *genericapiserver.GenericAPIServer, faq querier.FlowAggregatorQuerier) error {
+	return s.AddHealthChecks(healthz.NamedCheck("flowstreamservice", func(_ *http.Request) error {
+		if !faq.FlowStreamServiceReady() {
+			return errors.New("FlowStreamService is not serving")
+		}
+		return nil
+	}))
+}
+
 // New creates an APIServer for running in flow aggregator.
 func New(faq querier.FlowAggregatorQuerier, bindPort int, cipherSuites []uint16, tlsMinVersion uint16) (*flowAggregatorAPIServer, error) {
 	cfg, err := newConfig(bindPort)
@@ -87,6 +105,9 @@ func New(faq querier.FlowAggregatorQuerier, bindPort int, cipherSuites []uint16,
 	s.SecureServingInfo.CipherSuites = cipherSuites
 	s.SecureServingInfo.MinTLSVersion = tlsMinVersion
 	installHandlers(s, faq)
+	if err := installHealthChecks(s, faq); err != nil {
+		return nil, err
+	}
 	return &flowAggregatorAPIServer{GenericAPIServer: s}, nil
 }
 

--- a/pkg/flowaggregator/apiserver/apiserver_test.go
+++ b/pkg/flowaggregator/apiserver/apiserver_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	restclient "k8s.io/client-go/rest"
+	basecompatibility "k8s.io/component-base/compatibility"
+	netutils "k8s.io/utils/net"
+
+	queriertest "antrea.io/antrea/v2/pkg/flowaggregator/querier/testing"
+)
+
+// newTestGenericAPIServer builds a minimal, unstarted GenericAPIServer, sufficient to register
+// and exercise health checks via Handler.ServeHTTP directly, without binding any real listener
+// (that only happens in Run/RunWithContext) and without going through this package's own New,
+// which writes a loopback token to a hardcoded system path unsuitable for unit tests.
+func newTestGenericAPIServer(t *testing.T) *genericapiserver.GenericAPIServer {
+	cfg := genericapiserver.NewConfig(codecs)
+	cfg.ExternalAddress = "192.168.10.4:443"
+	cfg.PublicAddress = netutils.ParseIPSloppy("192.168.10.4")
+	cfg.LoopbackClientConfig = &restclient.Config{}
+	cfg.EffectiveVersion = basecompatibility.NewEffectiveVersionFromString("", "", "")
+	s, err := cfg.Complete(nil).New(Name, genericapiserver.NewEmptyDelegate())
+	require.NoError(t, err)
+	return s
+}
+
+func getResponse(s *genericapiserver.GenericAPIServer, path string) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest(http.MethodGet, path, nil)
+	recorder := httptest.NewRecorder()
+	s.Handler.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func TestInstallHealthChecks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	faq := queriertest.NewMockFlowAggregatorQuerier(ctrl)
+	var ready atomic.Bool
+	ready.Store(true)
+	faq.EXPECT().FlowStreamServiceReady().DoAndReturn(ready.Load).AnyTimes()
+
+	s := newTestGenericAPIServer(t)
+	require.NoError(t, installHealthChecks(s, faq))
+
+	// SecureServingInfo is nil here (this test never binds a real listener), so
+	// RunWithContext only runs the post-start hooks; leaving it running for the duration of the
+	// test lets those hooks (which /healthz also checks) actually complete.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = s.PrepareRun().RunWithContext(ctx)
+	}()
+
+	// Wait for the server to become healthy with FlowStreamService reported ready, so that the
+	// subsequent, deterministic checks below aren't confused by post-start hooks still pending.
+	require.Eventuallyf(t, func() bool {
+		response := getResponse(s, "/healthz")
+		return response.Code == http.StatusOK && response.Body.String() == "ok"
+	}, 5*time.Second, 100*time.Millisecond, "APIServer didn't become healthy within 5 seconds")
+
+	// Now that the server is known-healthy, flipping FlowStreamService's reported state must be
+	// reflected immediately on the very next request: the check is pull-based, not cached.
+	ready.Store(false)
+	response := getResponse(s, "/healthz")
+	assert.Equal(t, http.StatusInternalServerError, response.Code)
+	assert.Contains(t, response.Body.String(), "[-]flowstreamservice failed: reason withheld")
+
+	ready.Store(true)
+	response = getResponse(s, "/healthz")
+	assert.Equal(t, http.StatusOK, response.Code)
+	assert.Equal(t, "ok", response.Body.String())
+}
+
+func TestInstallHealthChecksAlreadyInstalled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	faq := queriertest.NewMockFlowAggregatorQuerier(ctrl)
+
+	s := newTestGenericAPIServer(t)
+	require.NoError(t, installHealthChecks(s, faq))
+	s.PrepareRun()
+
+	// Once PrepareRun has installed the actual handlers, adding further checks must fail: this is
+	// exactly why installHealthChecks must run before PrepareRun, as documented on the function.
+	assert.Error(t, installHealthChecks(s, faq))
+}

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -72,7 +72,7 @@ var (
 // flowStreamProvider is the interface used by flowAggregator to start and stop
 // the FlowStreamService.
 type flowStreamProvider interface {
-	Run(serverCertPEM, serverKeyPEM []byte, stopCh <-chan struct{}) error
+	Run(serverCertPEM, serverKeyPEM []byte, stopCh <-chan struct{}, setReady func(bool)) error
 }
 
 // exporterHandle tracks the lifecycle of a running exporter goroutine.
@@ -126,14 +126,21 @@ type flowAggregator struct {
 	logTickerDuration time.Duration
 	recordCh          chan *flowpb.Flow
 
-	recordBuffer        ringbuffer.BroadcastBuffer[*flowpb.Flow]
-	flowStreamService   flowStreamProvider
-	ipfixHandle         *exporterHandle
-	clickHouseHandle    *exporterHandle
-	s3Handle            *exporterHandle
-	logHandle           *exporterHandle
-	exportersMutex      sync.Mutex
-	certificateProvider *certificate.Provider
+	recordBuffer      ringbuffer.BroadcastBuffer[*flowpb.Flow]
+	flowStreamService flowStreamProvider
+	// flowStreamServiceReady reflects whether FlowStreamService is currently serving: false before
+	// its listener is bound (including before flowStreamService.Run is ever called for the first
+	// time), true once bound, false again if Run's Serve call ever returns. Read by
+	// FlowStreamServiceReady, which is what the Flow Aggregator's own apiserver readyz/livez checks
+	// call (see pkg/flowaggregator/apiserver) — flowStreamService itself has no HTTP-serving
+	// responsibility of its own.
+	flowStreamServiceReady atomic.Bool
+	ipfixHandle            *exporterHandle
+	clickHouseHandle       *exporterHandle
+	s3Handle               *exporterHandle
+	logHandle              *exporterHandle
+	exportersMutex         sync.Mutex
+	certificateProvider    *certificate.Provider
 }
 
 func NewFlowAggregator(
@@ -353,7 +360,7 @@ func (fa *flowAggregator) runFlowStreamService(stopCh <-chan struct{}) {
 		svcWg.Add(1)
 		go func() {
 			defer svcWg.Done()
-			if err := fa.flowStreamService.Run(serverCert, serverKey, svcStopCh); err != nil {
+			if err := fa.flowStreamService.Run(serverCert, serverKey, svcStopCh, fa.flowStreamServiceReady.Store); err != nil {
 				klog.ErrorS(err, "FlowStreamService failed to start")
 			}
 		}()
@@ -813,6 +820,18 @@ func (fa *flowAggregator) GetRecordMetrics() querier.Metrics {
 	metrics.WithLogExporter = fa.logHandle != nil
 	metrics.WithIPFIXExporter = fa.ipfixHandle != nil
 	return metrics
+}
+
+// FlowStreamServiceReady reports whether FlowStreamService is currently serving. When the
+// feature is disabled entirely (flowStreamService is nil), it reports true unconditionally: a
+// readiness/liveness check must not report perpetually unhealthy for a feature that was never
+// supposed to run in the first place, which matters because a user could add this same probe to
+// a Deployment manually (bypassing the chart's own conditional gating of the container port).
+func (fa *flowAggregator) FlowStreamServiceReady() bool {
+	if fa.flowStreamService == nil {
+		return true
+	}
+	return fa.flowStreamServiceReady.Load()
 }
 
 func (fa *flowAggregator) watchConfiguration(stopCh <-chan struct{}) {

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -969,6 +969,27 @@ func TestFlowAggregator_GetRecordMetrics(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestFlowAggregator_FlowStreamServiceReady(t *testing.T) {
+	t.Run("feature disabled entirely: always ready, regardless of flowStreamServiceReady", func(t *testing.T) {
+		fa := &flowAggregator{flowStreamService: nil}
+		assert.True(t, fa.FlowStreamServiceReady())
+
+		fa.flowStreamServiceReady.Store(true)
+		assert.True(t, fa.FlowStreamServiceReady(), "must stay true even if the never-consulted field happens to be true")
+	})
+
+	t.Run("feature enabled: reflects flowStreamServiceReady", func(t *testing.T) {
+		fa := &flowAggregator{flowStreamService: &fakeFlowStreamService{}}
+		assert.False(t, fa.FlowStreamServiceReady())
+
+		fa.flowStreamServiceReady.Store(true)
+		assert.True(t, fa.FlowStreamServiceReady())
+
+		fa.flowStreamServiceReady.Store(false)
+		assert.False(t, fa.FlowStreamServiceReady())
+	})
+}
+
 func TestFlowAggregator_InitCollectors(t *testing.T) {
 	tests := []struct {
 		name                        string
@@ -1256,9 +1277,11 @@ type fakeFlowStreamService struct {
 	runCount atomic.Int64
 }
 
-func (f *fakeFlowStreamService) Run(_, _ []byte, stopCh <-chan struct{}) error {
+func (f *fakeFlowStreamService) Run(_, _ []byte, stopCh <-chan struct{}, setReady func(bool)) error {
 	f.runCount.Add(1)
+	setReady(true)
 	<-stopCh
+	setReady(false)
 	return nil
 }
 
@@ -1325,6 +1348,9 @@ func TestFlowAggregator_runFlowStreamService(t *testing.T) {
 		fssCh <- struct{}{}
 		synctest.Wait()
 		assert.Equal(t, int64(1), fakeRunner.runCount.Load(), "Run should start after cert update signal")
+		// Confirms the real wiring, not just the fake: runFlowStreamService must pass
+		// fa.flowStreamServiceReady.Store itself as Run's setReady callback.
+		assert.True(t, fa.flowStreamServiceReady.Load(), "flowStreamServiceReady should reflect the running fake server")
 	})
 }
 

--- a/pkg/flowaggregator/flowstreamservice/service.go
+++ b/pkg/flowaggregator/flowstreamservice/service.go
@@ -61,7 +61,15 @@ func NewFlowStreamService(buffer ringbuffer.BroadcastBuffer[*flowpb.Flow]) *Flow
 // Run starts a dedicated TLS gRPC server for the FlowStreamService on FlowStreamPort.
 // serverCertPEM and serverKeyPEM are the PEM-encoded server certificate and private key;
 // only server-side TLS is used (no client authentication). Run blocks until stopCh is closed.
-func (s *FlowStreamService) Run(serverCertPEM, serverKeyPEM []byte, stopCh <-chan struct{}) error {
+//
+// setReady is called with false before the listener is bound, true once it is confirmed bound
+// (the earliest point at which FlowStreamService can honestly be called up), and false again
+// once Serve returns, whether from this call's own graceful shutdown or an unexpected failure.
+// The caller is expected to back it with something a readiness/liveness check can read live (e.g.
+// an atomic.Bool's Store method) — Run itself has no probe-serving responsibility of its own; see
+// pkg/flowaggregator/apiserver, which is what actually exposes this over HTTP.
+func (s *FlowStreamService) Run(serverCertPEM, serverKeyPEM []byte, stopCh <-chan struct{}, setReady func(bool)) error {
+	setReady(false)
 	cert, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
 	if err != nil {
 		return fmt.Errorf("failed to parse server TLS key pair: %w", err)
@@ -76,6 +84,8 @@ func (s *FlowStreamService) Run(serverCertPEM, serverKeyPEM []byte, stopCh <-cha
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
+	setReady(true)
+
 	server := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
 	flowpb.RegisterFlowStreamServiceServer(server, s)
 
@@ -87,6 +97,10 @@ func (s *FlowStreamService) Run(serverCertPEM, serverKeyPEM []byte, stopCh <-cha
 		if err := server.Serve(lis); err != nil {
 			klog.ErrorS(err, "FlowStreamService gRPC server failed to start")
 		}
+		// Serve only returns once this server has stopped accepting connections, whether that is
+		// this Run call's own graceful shutdown below or an unexpected failure — either way,
+		// FlowStreamService is no longer reachable.
+		setReady(false)
 	}()
 	<-stopCh
 	// GracefulStop waits for all active GetFlows RPCs to return before shutting

--- a/pkg/flowaggregator/flowstreamservice/service_test.go
+++ b/pkg/flowaggregator/flowstreamservice/service_test.go
@@ -17,7 +17,9 @@ package flowstreamservice
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/netip"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -32,6 +34,7 @@ import (
 	flowpb "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
 	"antrea.io/antrea/v2/pkg/flowaggregator/exporter"
 	"antrea.io/antrea/v2/pkg/flowaggregator/ringbuffer"
+	"antrea.io/antrea/v2/pkg/util/tlstest"
 )
 
 // fakeStream implements flowpb.FlowStreamService_GetFlowsServer.
@@ -800,4 +803,112 @@ func TestGetFlows_FollowContextCancelled(t *testing.T) {
 			t.Fatal("GetFlows did not return after context cancellation")
 		}
 	})
+}
+
+// readyRecorder records every value Run passes to setReady, in call order. Safe for concurrent
+// use: Run calls it both from its own top-level flow and from the goroutine running Serve.
+type readyRecorder struct {
+	mu     sync.Mutex
+	values []bool
+}
+
+func (r *readyRecorder) set(v bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.values = append(r.values, v)
+}
+
+func (r *readyRecorder) snapshot() []bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]bool(nil), r.values...)
+}
+
+func (r *readyRecorder) last() (bool, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.values) == 0 {
+		return false, false
+	}
+	return r.values[len(r.values)-1], true
+}
+
+// TestRun_ReadyTransitionsAndShutdown exercises Run end to end over its real, hardcoded port
+// (flowStreamPort is a constant, not a parameter, so there is no simpler way to inject an
+// ephemeral one without a larger refactor than this test warrants): confirms setReady(false) is
+// called first, setReady(true) only once the TLS listener is genuinely reachable, and
+// setReady(false) again once a graceful shutdown completes.
+func TestRun_ReadyTransitionsAndShutdown(t *testing.T) {
+	certPEM, keyPEM, err := tlstest.GenerateCert([]string{"127.0.0.1"}, time.Now(), time.Hour, true, false, 0, "P256", false)
+	require.NoError(t, err)
+
+	buf := ringbuffer.NewBroadcastBuffer[*flowpb.Flow](64)
+	t.Cleanup(func() { buf.Shutdown() })
+	svc := NewFlowStreamService(buf)
+
+	rec := &readyRecorder{}
+	stopCh := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() { errCh <- svc.Run(certPEM, keyPEM, stopCh, rec.set) }()
+
+	// Poll rather than sleep a fixed duration: proves the TLS port is genuinely reachable by the
+	// time setReady(true) is expected to have been called, without hardcoding how long Run takes
+	// to bind its listener.
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", flowStreamPort), 200*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		last, ok := rec.last()
+		return ok && last
+	}, 5*time.Second, 10*time.Millisecond, "TLS port never became reachable with setReady(true) already observed")
+
+	close(stopCh)
+	select {
+	case runErr := <-errCh:
+		require.NoError(t, runErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after stopCh was closed")
+	}
+
+	assert.Equal(t, []bool{false, true, false}, rec.snapshot())
+
+	_, err = net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", flowStreamPort), 500*time.Millisecond)
+	assert.Error(t, err, "TLS port should no longer be listening after a graceful shutdown")
+}
+
+// TestRun_TLSListenFailure covers Run's listener-bind error path: setReady(true) must never be
+// called if the listener never actually bound.
+func TestRun_TLSListenFailure(t *testing.T) {
+	blocker, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", flowStreamPort))
+	require.NoError(t, err)
+	defer blocker.Close()
+
+	certPEM, keyPEM, err := tlstest.GenerateCert([]string{"127.0.0.1"}, time.Now(), time.Hour, true, false, 0, "P256", false)
+	require.NoError(t, err)
+
+	buf := ringbuffer.NewBroadcastBuffer[*flowpb.Flow](64)
+	t.Cleanup(func() { buf.Shutdown() })
+	svc := NewFlowStreamService(buf)
+
+	rec := &readyRecorder{}
+	runErr := svc.Run(certPEM, keyPEM, make(chan struct{}), rec.set)
+	require.Error(t, runErr)
+	assert.Contains(t, runErr.Error(), "failed to listen")
+	assert.Equal(t, []bool{false}, rec.snapshot())
+}
+
+// TestRun_InvalidCert covers Run's earliest error path (bad TLS key pair): setReady(false) is
+// still called once (it is the very first thing Run does), but never flips to true.
+func TestRun_InvalidCert(t *testing.T) {
+	buf := ringbuffer.NewBroadcastBuffer[*flowpb.Flow](64)
+	t.Cleanup(func() { buf.Shutdown() })
+	svc := NewFlowStreamService(buf)
+
+	rec := &readyRecorder{}
+	err := svc.Run([]byte("not a cert"), []byte("not a key"), make(chan struct{}), rec.set)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse server TLS key pair")
+	assert.Equal(t, []bool{false}, rec.snapshot())
 }

--- a/pkg/flowaggregator/querier/querier.go
+++ b/pkg/flowaggregator/querier/querier.go
@@ -33,6 +33,10 @@ type Metrics struct {
 type FlowAggregatorQuerier interface {
 	GetFlowRecords(flowKey *intermediate.FlowKey) []map[string]interface{}
 	GetRecordMetrics() Metrics
+	// FlowStreamServiceReady reports whether FlowStreamService is currently serving, for the Flow
+	// Aggregator's own apiserver to expose via readyz/livez. It reports true when the feature is
+	// disabled entirely, not just when the (enabled) service happens to be up.
+	FlowStreamServiceReady() bool
 }
 
 type ExternalFlowCollectorAddr struct {

--- a/pkg/flowaggregator/querier/testing/mock_querier.go
+++ b/pkg/flowaggregator/querier/testing/mock_querier.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Antrea Authors
+// Copyright 2026 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,6 +54,20 @@ func NewMockFlowAggregatorQuerier(ctrl *gomock.Controller) *MockFlowAggregatorQu
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFlowAggregatorQuerier) EXPECT() *MockFlowAggregatorQuerierMockRecorder {
 	return m.recorder
+}
+
+// FlowStreamServiceReady mocks base method.
+func (m *MockFlowAggregatorQuerier) FlowStreamServiceReady() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FlowStreamServiceReady")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// FlowStreamServiceReady indicates an expected call of FlowStreamServiceReady.
+func (mr *MockFlowAggregatorQuerierMockRecorder) FlowStreamServiceReady() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlowStreamServiceReady", reflect.TypeOf((*MockFlowAggregatorQuerier)(nil).FlowStreamServiceReady))
 }
 
 // GetFlowRecords mocks base method.


### PR DESCRIPTION
- FlowStreamService.Run takes a setReady callback and set it to false->true->false according to its listener-bind/serve lifecycle.
- The apiserver registers a healthz.HealthChecker via AddHealthChecks wired to a new FlowAggregatorQuerier.FlowStreamServiceReady method.
- This check will back healthz, livez and readyz. When FlowStreamService is disabled entirely, the check reports healthy unconditionally, so probes succeed trivially when FlowStreamService is not enabled
- Liveness and Readiness probes are added to the YAML template for the Flow Aggregator deployment. The API server port is added as a namedport.
    