### PR TITLE
Enable OSV alerts for release branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,8 +37,6 @@
     // Don't write any rules before this rule
     {
       matchBaseBranches: ["release-2.7", "release-2.6", "release-2.5"],
-      groupName: "all dependencies active release branches",
-      groupSlug: "all-deps-active-release-branches",
       enabled: false,
     },
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,11 @@
     enabled: true,
   },
 
+  // GitHub vulnerability alerts only reflect the default branch. Supplement them with OSV
+  // checks so direct dependencies vulnerable only on release branches can be updated.
+  // OSV vulnerability alerts are experimental and do not cover indirect dependencies.
+  osvVulnerabilityAlerts: true,
+
   packageRules: [
     // Disable all regular updates for active release branches
     // Don't write any rules before this rule


### PR DESCRIPTION
GitHub vulnerability alerts only reflect the default branch, so Renovate can miss direct dependencies that remain vulnerable on active release branches. This gap was exposed by #8266.

Enable experimental OSV vulnerability alerts to supplement GitHub alert data for direct dependencies on every monitored base branch. Indirect dependencies remain outside this feature's coverage.