### PR TITLE
Fix self-destined Egress connections with WireGuard encryption

### DIFF
--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -1403,7 +1403,7 @@ func (c *Client) restoreIptablesData(podCIDR *net.IPNet,
 			"-j", iptables.MarkTarget, "--or-mark", fmt.Sprintf("%#08x", types.HostLocalSourceMark),
 		}...)
 	}
-	if c.egressEnabled && c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid {
+	if c.shouldEnableEgressPolicyRouting() {
 		writeLine(iptablesData, []string{
 			"-A", antreaOutputChain,
 			"-m", "comment", "--comment", `"Antrea: restore fwmark from connmark for reply Egress packets to remote Pods"`,

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -512,6 +512,7 @@ COMMIT
 -A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 172.16.10.0/24 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+-A ANTREA-OUTPUT -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]
@@ -580,6 +581,7 @@ COMMIT
 -A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 2001:ab03:cd04:55ef::/64 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+-A ANTREA-OUTPUT -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]
@@ -709,6 +711,7 @@ COMMIT
 -A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 172.16.10.0/24 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+-A ANTREA-OUTPUT -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]
@@ -750,6 +753,7 @@ COMMIT
 -A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 2001:ab03:cd04:55ef::/64 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+-A ANTREA-OUTPUT -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]


### PR DESCRIPTION
The mangle OUTPUT rule which restores the Egress fwmark from the conntrack mark is only installed in hybrid mode, while the PREROUTING rule it is paired with is installed in hybrid mode and with WireGuard encryption.

The rule was added by #7611 for connections whose destination is an address of the Egress Node itself. The reply packets of such a connection are generated locally and go through OUTPUT rather than PREROUTING, so the fwmark has to be restored there as well for the reply to take the policy routing back to OVS.

#7628 later replaced the hybrid mode checks with `shouldEnableEgressPolicyRouting`, so that Egress also uses policy routing with WireGuard encryption. It converted six of them and missed this one.

Nothing about the rule is specific to the hybrid mode. It applies whenever Egress takes a tunnel path distinct from the Pod-to-Pod traffic path, which is also the case with WireGuard encryption. With WireGuard encryption enabled, a remote Pod which is the source of an Egress connection to an address of the Egress Node receives no reply, while the same connection works in hybrid mode.

The two existing encap + WireGuard cases of `TestSyncIPTables` now expect the rule. Reverting the one line change makes both of them fail.

Affected releases: the branches which carry both #7611 and #7628, which are release-2.6 and release-2.7. release-2.5 and earlier do not have the rule at all.
