### PR TITLE
Disable IPv6 RA and SLAAC on container interfaces

### DIFF
--- a/ci/kind/test-secondary-network-kind.sh
+++ b/ci/kind/test-secondary-network-kind.sh
@@ -258,7 +258,7 @@ function run_test {
   kubectl apply -f "$ATTACHMENT_DEFINITION_YAML"
   kubectl apply -f "$SECONDARY_NETWORKS_YAML"
 
-  go test -v -timeout="$TIMEOUT" antrea.io/antrea/v2/test/e2e-secondary-network -run='^TestVLANNetwork$' -provider=kind "${TEST_OPTIONS[@]}"
+  go test -v -timeout="$TIMEOUT" antrea.io/antrea/v2/test/e2e-secondary-network -run='^(TestVLANNetwork|TestSecondaryInterfaceDisableIPv6RA)$' -provider=kind "${TEST_OPTIONS[@]}"
   run_test_without_antrea_node_config
   run_test_with_antreanodeconfigs
 }

--- a/pkg/agent/cniserver/interface_configuration_linux.go
+++ b/pkg/agent/cniserver/interface_configuration_linux.go
@@ -101,6 +101,12 @@ func (ic *ifConfigurator) configureVFLinkAndIPAM(link netlink.Link, containerID 
 	if err != nil {
 		return fmt.Errorf("failed to set MTU for VF netdevice %s: %w", containerIfaceName, err)
 	}
+
+	// Disable IPv6 RA / SLAAC on the container interface.
+	if err := util.DisableIPv6RAOnInterface(containerIfaceName); err != nil {
+		klog.ErrorS(err, "Failed to disable IPv6 RA/autoconf on interface", "interface", containerIfaceName)
+	}
+
 	err = ic.netlink.LinkSetUp(link)
 	if err != nil {
 		return fmt.Errorf("failed to set link up to VF netdevice %s: %w", containerIfaceName, err)
@@ -480,6 +486,11 @@ func (ic *ifConfigurator) configureContainerLinkVeth(
 		}()
 		containerIface.Mac = mac.String()
 		hostIface.Mac = hostVeth.HardwareAddr.String()
+
+		// Disable IPv6 RA / SLAAC on the container interface.
+		if err := util.DisableIPv6RAOnInterface(containerIfaceName); err != nil {
+			klog.ErrorS(err, "Failed to disable IPv6 RA/autoconf on interface", "interface", containerIfaceName)
+		}
 
 		// Disable TX checksum offloading when it's configured explicitly.
 		if ic.disableTXChecksumOffload {

--- a/pkg/agent/cniserver/interface_configuration_linux.go
+++ b/pkg/agent/cniserver/interface_configuration_linux.go
@@ -102,9 +102,11 @@ func (ic *ifConfigurator) configureVFLinkAndIPAM(link netlink.Link, containerID 
 		return fmt.Errorf("failed to set MTU for VF netdevice %s: %w", containerIfaceName, err)
 	}
 
-	// Disable IPv6 RA / SLAAC on the container interface.
-	if err := util.DisableIPv6RAOnInterface(containerIfaceName); err != nil {
-		klog.ErrorS(err, "Failed to disable IPv6 RA/autoconf on interface", "interface", containerIfaceName)
+	// Disable IPv6 RA / SLAAC on the container interface if IPAM is configured for the interface.
+	if len(result.IPs) > 0 {
+		if err := util.DisableIPv6RAOnInterface(containerIfaceName); err != nil {
+			klog.ErrorS(err, "Failed to disable IPv6 RA/autoconf on interface", "interface", containerIfaceName)
+		}
 	}
 
 	err = ic.netlink.LinkSetUp(link)
@@ -487,9 +489,11 @@ func (ic *ifConfigurator) configureContainerLinkVeth(
 		containerIface.Mac = mac.String()
 		hostIface.Mac = hostVeth.HardwareAddr.String()
 
-		// Disable IPv6 RA / SLAAC on the container interface.
-		if err := util.DisableIPv6RAOnInterface(containerIfaceName); err != nil {
-			klog.ErrorS(err, "Failed to disable IPv6 RA/autoconf on interface", "interface", containerIfaceName)
+		// Disable IPv6 RA / SLAAC on the container interface if IPAM is configured for the interface.
+		if len(result.IPs) > 0 {
+			if err := util.DisableIPv6RAOnInterface(containerIfaceName); err != nil {
+				klog.ErrorS(err, "Failed to disable IPv6 RA/autoconf on interface", "interface", containerIfaceName)
+			}
 		}
 
 		// Disable TX checksum offloading when it's configured explicitly.

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -357,23 +357,27 @@ func EnsureIPv6EnabledOnInterface(ifaceName string) error {
 	return sysctl.EnsureSysctlNetValue(path, 0)
 }
 
-func EnsureIPv6AcceptRAOnInterface(ifaceName string, value int) error {
-	path := fmt.Sprintf("ipv6/conf/%s/accept_ra", ifaceName)
-	return sysctl.EnsureSysctlNetValue(path, value)
-}
-
-func EnsureIPv6AutoconfOnInterface(ifaceName string, value int) error {
-	path := fmt.Sprintf("ipv6/conf/%s/autoconf", ifaceName)
-	return sysctl.EnsureSysctlNetValue(path, value)
+func ensureIPv6SysctlDisabledIfExists(path string) error {
+	val, err := sysctl.GetSysctlNet(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if val != 0 {
+		return sysctl.SetSysctlNet(path, 0)
+	}
+	return nil
 }
 
 // DisableIPv6RAOnInterface disables IPv6 Router Advertisement (RA) processing and SLAAC autoconfiguration
 // on the specified interface.
 func DisableIPv6RAOnInterface(ifaceName string) error {
-	if err := EnsureIPv6AcceptRAOnInterface(ifaceName, 0); err != nil && !os.IsNotExist(err) {
+	if err := ensureIPv6SysctlDisabledIfExists(fmt.Sprintf("ipv6/conf/%s/accept_ra", ifaceName)); err != nil {
 		return err
 	}
-	if err := EnsureIPv6AutoconfOnInterface(ifaceName, 0); err != nil && !os.IsNotExist(err) {
+	if err := ensureIPv6SysctlDisabledIfExists(fmt.Sprintf("ipv6/conf/%s/autoconf", ifaceName)); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -357,6 +357,28 @@ func EnsureIPv6EnabledOnInterface(ifaceName string) error {
 	return sysctl.EnsureSysctlNetValue(path, 0)
 }
 
+func EnsureIPv6AcceptRAOnInterface(ifaceName string, value int) error {
+	path := fmt.Sprintf("ipv6/conf/%s/accept_ra", ifaceName)
+	return sysctl.EnsureSysctlNetValue(path, value)
+}
+
+func EnsureIPv6AutoconfOnInterface(ifaceName string, value int) error {
+	path := fmt.Sprintf("ipv6/conf/%s/autoconf", ifaceName)
+	return sysctl.EnsureSysctlNetValue(path, value)
+}
+
+// DisableIPv6RAOnInterface disables IPv6 Router Advertisement (RA) processing and SLAAC autoconfiguration
+// on the specified interface.
+func DisableIPv6RAOnInterface(ifaceName string) error {
+	if err := EnsureIPv6AcceptRAOnInterface(ifaceName, 0); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := EnsureIPv6AutoconfOnInterface(ifaceName, 0); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 func EnsureARPAnnounceOnInterface(ifaceName string, value int) error {
 	path := fmt.Sprintf("ipv4/conf/%s/arp_announce", ifaceName)
 	return sysctl.EnsureSysctlNetValue(path, value)

--- a/test/e2e-secondary-network/secondary_network_test.go
+++ b/test/e2e-secondary-network/secondary_network_test.go
@@ -846,6 +846,11 @@ func TestSecondaryInterfaceDisableIPv6RA(t *testing.T) {
 	testData := &testData{e2eTestData: e2eTestData, networkType: networkTypeVLAN, pods: []*testPodInfo{pod}}
 	require.NoError(t, testData.createPods(t, e2eTestData.GetTestNamespace()))
 
+	_, err = e2eTestData.PodWaitFor(defaultTimeout, pod.podName, e2eTestData.GetTestNamespace(), func(p *corev1.Pod) (bool, error) {
+		return p.Status.Phase == corev1.PodRunning, nil
+	})
+	require.NoError(t, err, "Pod %s failed to reach Running state", pod.podName)
+
 	cmd := []string{"sysctl", "-n", "net.ipv6.conf.eth1.accept_ra", "net.ipv6.conf.eth1.autoconf"}
 	stdout, stderr, err := e2eTestData.RunCommandFromPod(e2eTestData.GetTestNamespace(), pod.podName, containerName, cmd)
 	require.NoError(t, err, "Failed to run sysctl in Pod: %s", stderr)

--- a/test/e2e-secondary-network/secondary_network_test.go
+++ b/test/e2e-secondary-network/secondary_network_test.go
@@ -824,6 +824,39 @@ func TestSecondaryOVSBridgeName(t *testing.T) {
 	(&testData{e2eTestData: e2eTestData}).verifySecondaryOVSBridgeName(t, *expectedSecondaryBridgeName)
 }
 
+// TestSecondaryInterfaceDisableIPv6RA verifies that when Antrea CNI configures a secondary
+// interface for a Pod via Multus + NetworkAttachmentDefinition, IPv6 accept_ra and autoconf sysctl
+// parameters are disabled (set to 0) on the secondary interface inside the container.
+func TestSecondaryInterfaceDisableIPv6RA(t *testing.T) {
+	if antreae2e.NodeCount() < 1 {
+		t.Fatal("The test requires at least 1 Node")
+	}
+	e2eTestData, err := antreae2e.SetupTest(t)
+	require.NoError(t, err)
+	defer antreae2e.TeardownTest(t, e2eTestData)
+
+	nodeName := antreae2e.NodeName(0)
+	pod := &testPodInfo{
+		podName:           "secondary-ipv6-ra-pod",
+		nodeName:          nodeName,
+		interfaceNetworks: map[string]string{"eth1": "vlan-net1"},
+		macAddresses:      map[string]string{"eth1": "aa:bb:cc:dd:ee:fe"},
+	}
+
+	testData := &testData{e2eTestData: e2eTestData, networkType: networkTypeVLAN, pods: []*testPodInfo{pod}}
+	require.NoError(t, testData.createPods(t, e2eTestData.GetTestNamespace()))
+
+	cmd := []string{"sysctl", "-n", "net.ipv6.conf.eth1.accept_ra", "net.ipv6.conf.eth1.autoconf"}
+	stdout, stderr, err := e2eTestData.RunCommandFromPod(e2eTestData.GetTestNamespace(), pod.podName, containerName, cmd)
+	require.NoError(t, err, "Failed to run sysctl in Pod: %s", stderr)
+
+	values := strings.Fields(strings.TrimSpace(stdout))
+	require.GreaterOrEqual(t, len(values), 2, "Unexpected sysctl output: %s", stdout)
+
+	assert.Equal(t, "0", values[0], "Expected net.ipv6.conf.eth1.accept_ra to be 0")
+	assert.Equal(t, "0", values[1], "Expected net.ipv6.conf.eth1.autoconf to be 0")
+}
+
 // TestVLANNetworkNodePools exercises VLAN secondary networks when Nodes are labeled
 // antrea.io/node-pool=pool1|pool2 (see antrea-node-configs-nodepools.yml and ci/kind/test-secondary-network-kind.sh).
 // Each pod uses eth1 as its first (and only) secondary interface; Antrea maps NADs to Node uplinks eth2/eth3

--- a/test/e2e/secondary_network_ipam_test.go
+++ b/test/e2e/secondary_network_ipam_test.go
@@ -16,11 +16,8 @@ package e2e
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"antrea.io/antrea/v2/pkg/agent/config"
@@ -280,74 +277,4 @@ func TestSecondaryNetworkIPAM(t *testing.T) {
 	executeCNI(t, data, true, true, "net3", 0, testOutput2)
 	// Release the first IP.
 	executeCNI(t, data, false, true, "net1", 0, "")
-}
-
-// TestContainerInterfaceDisableIPv6RA tests that when Antrea CNI configures a container interface
-// in a network namespace, IPv6 accept_ra and autoconf sysctl parameters are disabled (set to 0).
-func TestContainerInterfaceDisableIPv6RA(t *testing.T) {
-	skipIfHasWindowsNodes(t)
-	skipIfAntreaIPAMTest(t)
-
-	data, err := setupTest(t)
-	if err != nil {
-		t.Fatalf("Error when setting up test: %v", err)
-	}
-	defer teardownTest(t, data)
-
-	node := nodeName(0)
-	netnsName := "test-ipv6-ra-netns"
-	netnsPath := "/var/run/netns/" + netnsName
-
-	// Create test network namespace on Node
-	cmd := fmt.Sprintf("ip netns add %s", netnsName)
-	code, stdout, stderr, err := data.RunCommandOnNode(node, cmd)
-	if err != nil || code != 0 {
-		t.Fatalf("Failed to create test netns: %v, stdout: %s, stderr: %s", err, stdout, stderr)
-	}
-	defer func() {
-		data.RunCommandOnNode(node, fmt.Sprintf("ip netns del %s", netnsName))
-	}()
-
-	testCniEnvs := map[string]string{
-		"CNI_COMMAND":     "ADD",
-		"CNI_CONTAINERID": "test-container-ipv6-ra",
-		"CNI_NETNS":       netnsPath,
-		"CNI_IFNAME":      "eth0",
-		"CNI_PATH":        "/opt/cni/bin",
-		"CNI_ARGS":        fmt.Sprintf("K8S_POD_NAMESPACE=%s;K8S_POD_NAME=test-pod-ipv6-ra", data.testNamespace),
-	}
-
-	testMainCniConfig := `{
-		"cniVersion": "0.4.0",
-		"name": "antrea",
-		"type": "antrea",
-		"ipam": {
-			"type": "host-local"
-		}
-	}`
-
-	defer func() {
-		testCniEnvs["CNI_COMMAND"] = "DEL"
-		data.RunCommandOnNodeExt(node, cniCmd, testCniEnvs, testMainCniConfig, true)
-	}()
-
-	code, stdout, stderr, err = data.RunCommandOnNodeExt(node, cniCmd, testCniEnvs, testMainCniConfig, true)
-	if err != nil || code != 0 {
-		t.Fatalf("CNI ADD failed with code %d, stdout:\n%s\nstderr: %s", code, stdout, stderr)
-	}
-
-	// Verify accept_ra and autoconf sysctl values in the container netns
-	checkCmd := fmt.Sprintf("ip netns exec %s sysctl -n net.ipv6.conf.eth0.accept_ra net.ipv6.conf.eth0.autoconf", netnsName)
-	code, stdout, stderr, err = data.RunCommandOnNode(node, checkCmd)
-	if err != nil || code != 0 {
-		t.Fatalf("Failed to check sysctl in netns: %v, stdout: %s, stderr: %s", err, stdout, stderr)
-	}
-
-	values := strings.Fields(strings.TrimSpace(stdout))
-	if len(values) < 2 {
-		t.Fatalf("Unexpected sysctl output: %s", stdout)
-	}
-
-	assert.Equal(t, "0", values[0], "accept_ra on container interface should be 0")
-	assert.Equal(t, "0", values[1], "autoconf on container interface should be 0")
 }

--- a/test/e2e/secondary_network_ipam_test.go
+++ b/test/e2e/secondary_network_ipam_test.go
@@ -16,8 +16,11 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"antrea.io/antrea/v2/pkg/agent/config"
@@ -277,4 +280,71 @@ func TestSecondaryNetworkIPAM(t *testing.T) {
 	executeCNI(t, data, true, true, "net3", 0, testOutput2)
 	// Release the first IP.
 	executeCNI(t, data, false, true, "net1", 0, "")
+}
+
+// TestContainerInterfaceDisableIPv6RA tests that when Antrea CNI configures a container interface
+// in a network namespace, IPv6 accept_ra and autoconf sysctl parameters are disabled (set to 0).
+func TestContainerInterfaceDisableIPv6RA(t *testing.T) {
+	skipIfHasWindowsNodes(t)
+	skipIfAntreaIPAMTest(t)
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	node := nodeName(0)
+	netnsName := "test-ipv6-ra-netns"
+	netnsPath := "/var/run/netns/" + netnsName
+
+	// Create test network namespace on Node
+	cmd := fmt.Sprintf("ip netns add %s", netnsName)
+	code, stdout, stderr, err := data.RunCommandOnNode(node, cmd)
+	if err != nil || code != 0 {
+		t.Fatalf("Failed to create test netns: %v, stdout: %s, stderr: %s", err, stdout, stderr)
+	}
+	defer func() {
+		data.RunCommandOnNode(node, fmt.Sprintf("ip netns del %s", netnsName))
+	}()
+
+	testCniEnvs := map[string]string{
+		"CNI_COMMAND":     "ADD",
+		"CNI_CONTAINERID": "test-container-ipv6-ra",
+		"CNI_NETNS":       netnsPath,
+		"CNI_IFNAME":      "eth0",
+		"CNI_PATH":        "/opt/cni/bin",
+		"CNI_ARGS":        "K8S_POD_NAMESPACE=default;K8S_POD_NAME=test-pod-ipv6-ra",
+	}
+
+	testMainCniConfig := `{
+		"cniVersion": "0.4.0",
+		"name": "antrea",
+		"type": "antrea"
+	}`
+
+	defer func() {
+		testCniEnvs["CNI_COMMAND"] = "DEL"
+		data.RunCommandOnNodeExt(node, cniCmd, testCniEnvs, testMainCniConfig, true)
+	}()
+
+	code, stdout, stderr, err = data.RunCommandOnNodeExt(node, cniCmd, testCniEnvs, testMainCniConfig, true)
+	if err != nil || code != 0 {
+		t.Fatalf("CNI ADD failed with code %d, stdout:\n%s\nstderr: %s", code, stdout, stderr)
+	}
+
+	// Verify accept_ra and autoconf sysctl values in the container netns
+	checkCmd := fmt.Sprintf("ip netns exec %s sysctl -n net.ipv6.conf.eth0.accept_ra net.ipv6.conf.eth0.autoconf", netnsName)
+	code, stdout, stderr, err = data.RunCommandOnNode(node, checkCmd)
+	if err != nil || code != 0 {
+		t.Fatalf("Failed to check sysctl in netns: %v, stdout: %s, stderr: %s", err, stdout, stderr)
+	}
+
+	values := strings.Fields(strings.TrimSpace(stdout))
+	if len(values) < 2 {
+		t.Fatalf("Unexpected sysctl output: %s", stdout)
+	}
+
+	assert.Equal(t, "0", values[0], "accept_ra on container interface should be 0")
+	assert.Equal(t, "0", values[1], "autoconf on container interface should be 0")
 }

--- a/test/e2e/secondary_network_ipam_test.go
+++ b/test/e2e/secondary_network_ipam_test.go
@@ -314,13 +314,16 @@ func TestContainerInterfaceDisableIPv6RA(t *testing.T) {
 		"CNI_NETNS":       netnsPath,
 		"CNI_IFNAME":      "eth0",
 		"CNI_PATH":        "/opt/cni/bin",
-		"CNI_ARGS":        "K8S_POD_NAMESPACE=default;K8S_POD_NAME=test-pod-ipv6-ra",
+		"CNI_ARGS":        fmt.Sprintf("K8S_POD_NAMESPACE=%s;K8S_POD_NAME=test-pod-ipv6-ra", data.testNamespace),
 	}
 
 	testMainCniConfig := `{
 		"cniVersion": "0.4.0",
 		"name": "antrea",
-		"type": "antrea"
+		"type": "antrea",
+		"ipam": {
+			"type": "host-local"
+		}
 	}`
 
 	defer func() {

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -388,13 +388,13 @@ func (tester *cmdAddDelTester) checkContainerNetworking(tc testCase) {
 	// Check that IPv6 RA and SLAAC are disabled on the container interface.
 	err = tester.targetNS.Do(func(_ ns.NetNS) error {
 		acceptRA, err := sysctl.GetSysctlNet(fmt.Sprintf("ipv6/conf/%s/accept_ra", IFName))
-		if err == nil {
-			testAssert.Equal(0, acceptRA)
-		}
+		testRequire.Nil(err)
+		testAssert.Equal(0, acceptRA)
+
 		autoconf, err := sysctl.GetSysctlNet(fmt.Sprintf("ipv6/conf/%s/autoconf", IFName))
-		if err == nil {
-			testAssert.Equal(0, autoconf)
-		}
+		testRequire.Nil(err)
+		testAssert.Equal(0, autoconf)
+
 		return nil
 	})
 	testRequire.Nil(err)

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -57,6 +57,7 @@ import (
 	openflowtest "antrea.io/antrea/v2/pkg/agent/openflow/testing"
 	routetest "antrea.io/antrea/v2/pkg/agent/route/testing"
 	"antrea.io/antrea/v2/pkg/agent/util"
+	"antrea.io/antrea/v2/pkg/agent/util/sysctl"
 	cnimsg "antrea.io/antrea/v2/pkg/apis/cni/v1beta1"
 	"antrea.io/antrea/v2/pkg/ovs/ovsconfig"
 	ovsconfigtest "antrea.io/antrea/v2/pkg/ovs/ovsconfig/testing"
@@ -383,6 +384,20 @@ func (tester *cmdAddDelTester) checkContainerNetworking(tc testCase) {
 		testRequire.Nil(err)
 		testRequire.NotNil(expectedRoute)
 	}
+
+	// Check that IPv6 RA and SLAAC are disabled on the container interface.
+	err = tester.targetNS.Do(func(_ ns.NetNS) error {
+		acceptRA, err := sysctl.GetSysctlNet(fmt.Sprintf("ipv6/conf/%s/accept_ra", IFName))
+		if err == nil {
+			testAssert.Equal(0, acceptRA)
+		}
+		autoconf, err := sysctl.GetSysctlNet(fmt.Sprintf("ipv6/conf/%s/autoconf", IFName))
+		if err == nil {
+			testAssert.Equal(0, autoconf)
+		}
+		return nil
+	})
+	testRequire.Nil(err)
 }
 
 func (tester *cmdAddDelTester) cmdAddTest(tc testCase, dataDir string) (*current.Result, error) {

--- a/test/integration/agent/net_linux_test.go
+++ b/test/integration/agent/net_linux_test.go
@@ -15,6 +15,7 @@
 package agent
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"antrea.io/antrea/v2/pkg/agent/util"
+	"antrea.io/antrea/v2/pkg/agent/util/sysctl"
 )
 
 func createTestInterface(t *testing.T, name string) string {
@@ -61,4 +63,21 @@ func getTestInterfaceAddresses(t *testing.T, name string) []*net.IPNet {
 func addTestInterfaceAddress(t *testing.T, name string, addr *net.IPNet) {
 	link, _ := netlink.LinkByName(name)
 	require.NoError(t, netlink.AddrAdd(link, &netlink.Addr{IPNet: addr}))
+}
+
+func TestDisableIPv6RAOnInterface(t *testing.T) {
+	ifaceName := randName()
+	createTestInterface(t, ifaceName)
+	defer deleteTestInterface(t, ifaceName)
+
+	err := util.DisableIPv6RAOnInterface(ifaceName)
+	require.NoError(t, err)
+
+	acceptRA, err := sysctl.GetSysctlNet(fmt.Sprintf("ipv6/conf/%s/accept_ra", ifaceName))
+	require.NoError(t, err)
+	assert.Equal(t, 0, acceptRA)
+
+	autoconf, err := sysctl.GetSysctlNet(fmt.Sprintf("ipv6/conf/%s/autoconf", ifaceName))
+	require.NoError(t, err)
+	assert.Equal(t, 0, autoconf)
 }


### PR DESCRIPTION
When a secondary network (or primary Pod network) resides in a Layer-2
domain where Router Advertisements (RA) are broadcast, Linux kernel
automatically generates an additional SLAAC IPv6 address on the Pod's
interface. This results in two global IPv6 addresses (one static from
IPAM, one dynamic from SLAAC), causing source IP selection ambiguity.

This change disables `accept_ra` and `autoconf` via sysctl when
configuring container interfaces (both veth and SR-IOV VF) to prevent
unwanted SLAAC IPv6 address autoconfiguration.