### PR TITLE
Clarify IPPool capacity reporting

### DIFF
--- a/build/charts/antrea/crds/ippool.yaml
+++ b/build/charts/antrea/crds/ippool.yaml
@@ -112,7 +112,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer
@@ -232,7 +235,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2394,7 +2394,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer
@@ -2514,7 +2517,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -2365,7 +2365,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer
@@ -2485,7 +2488,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2390,7 +2390,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer
@@ -2510,7 +2513,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2390,7 +2390,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer
@@ -2510,7 +2513,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2390,7 +2390,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer
@@ -2510,7 +2513,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2390,7 +2390,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer
@@ -2510,7 +2513,10 @@ spec:
                   type: object
               type: object
       additionalPrinterColumns:
-        - description: The number of total IPs
+        - description: >-
+            The total allocation capacity across all configured IP ranges. For
+            CIDR ranges, the first address, gateway, and applicable IPv4 broadcast
+            address are excluded. At most 65,536 candidate IPs are considered per range.
           jsonPath: .status.usage.total
           name: Total
           type: integer

--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -530,6 +530,18 @@ will of course always be excluded. On the other hand, when using a range with a
 start and end IP address, both of these IPs will be allocatable (except if one
 of them corresponds to the gateway).
 
+Antrea IPAM considers at most 65,536 candidate addresses from each IP range. For
+a range larger than this limit, the allocator considers only the first 65,536
+candidate addresses. This limit applies independently to each range, not to the
+IPPool as a whole. The `TOTAL` column of `kubectl get ippools` reports the sum of
+the allocator capacities (used plus free) across all configured ranges. For a
+CIDR range, this capacity excludes the first address and the gateway. It also
+excludes the IPv4 broadcast address when the `prefixLength` matches the CIDR
+mask size. `TOTAL` therefore represents the allocator capacity rather than the
+theoretical size of the CIDRs, and it can exceed 65,536 when an IPPool contains
+multiple ranges. For example, a single IPv6 `/64` CIDR whose gateway is among
+the managed addresses has a `TOTAL` of 65,535.
+
 ```yaml
 apiVersion: "crd.antrea.io/v1beta1"
 kind: IPPool


### PR DESCRIPTION
Document the per-range allocator limit and explain why the TOTAL value can be smaller than the theoretical CIDR size. Update the CRD printer column descriptions and generated manifests to match.