### PR TITLE
Skip PacketCapture tests on Windows

### DIFF
--- a/pkg/agent/packetcapture/packetcapture_controller_test.go
+++ b/pkg/agent/packetcapture/packetcapture_controller_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 // Copyright 2024 Antrea Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
PacketCapture is supported only on Linux. Restrict its controller unit tests to the supported platform so Windows CI does not exercise a controller that production cannot start.

Fix UT failure: https://github.com/antrea-io/antrea/actions/runs/32343310383/job/96346733352?pr=8291