### PR TITLE
Clean up failed support bundle archives

### DIFF
--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -235,7 +235,17 @@ func (r *supportBundleREST) collect(ctx context.Context, dumpers ...func(string)
 	if err != nil {
 		return nil, fmt.Errorf("error when creating output tarfile: %w", err)
 	}
-	defer outputFile.Close()
+	removeOutputFile := true
+	defer func() {
+		if err := outputFile.Close(); err != nil {
+			klog.ErrorS(err, "Error when closing output tar file")
+		}
+		if removeOutputFile {
+			if err := defaultFS.Remove(outputFile.Name()); err != nil {
+				klog.ErrorS(err, "Error when removing output tar file", "file", outputFile.Name())
+			}
+		}
+	}()
 	hashSum, err := compress.PackDir(defaultFS, basedir, outputFile)
 	if err != nil {
 		return nil, fmt.Errorf("error when packaging supportBundle: %w", err)
@@ -243,7 +253,6 @@ func (r *supportBundleREST) collect(ctx context.Context, dumpers ...func(string)
 
 	select {
 	case <-ctx.Done():
-		_ = defaultFS.Remove(outputFile.Name())
 		return nil, fmt.Errorf("collecting is canceled")
 	default:
 	}
@@ -254,6 +263,7 @@ func (r *supportBundleREST) collect(ctx context.Context, dumpers ...func(string)
 	}
 	creationTime := metav1.Now()
 	deletionTime := metav1.NewTime(creationTime.Add(bundleExpireDuration))
+	removeOutputFile = false
 	return &systemv1beta1.SupportBundle{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              r.mode,

--- a/pkg/apiserver/registry/system/supportbundle/rest_test.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest_test.go
@@ -17,6 +17,7 @@ package supportbundle
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -44,6 +45,23 @@ import (
 
 type testExec struct {
 	exectesting.FakeExec
+}
+
+type errorOpeningFS struct {
+	afero.Fs
+	outputFile string
+}
+
+func (fs *errorOpeningFS) Open(string) (afero.File, error) {
+	return nil, fmt.Errorf("injected open error")
+}
+
+func (fs *errorOpeningFS) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	f, err := fs.Fs.OpenFile(name, flag, perm)
+	if err == nil && strings.Contains(name, "bundle_") {
+		fs.outputFile = name
+	}
+	return f, err
 }
 
 func (te *testExec) Command(cmd string, args ...string) exec.Cmd {
@@ -146,6 +164,24 @@ func TestCollect(t *testing.T) {
 	exist, err := afero.Exists(defaultFS, collectedBundle.Filepath)
 	require.NoError(t, err)
 	require.True(t, exist)
+}
+
+func TestCollectRemovesOutputFileOnPackDirFailure(t *testing.T) {
+	memFS := afero.NewMemMapFs()
+	failingFS := &errorOpeningFS{Fs: memFS}
+	defaultFS = failingFS
+	defer func() {
+		defaultFS = afero.NewOsFs()
+	}()
+
+	storage := NewControllerStorage()
+	_, err := storage.SupportBundle.collect(context.Background())
+	require.ErrorContains(t, err, "error when packaging supportBundle")
+
+	require.NotEmpty(t, failingFS.outputFile)
+	exists, err := afero.Exists(memFS, failingFS.outputFile)
+	require.NoError(t, err)
+	assert.False(t, exists)
 }
 
 func TestControllerStorage(t *testing.T) {


### PR DESCRIPTION
Remove the temporary archive when support bundle collection fails after creating it. This prevents orphaned files when packaging cannot complete.

Add a regression test which injects a packaging failure and verifies that the temporary archive is removed.