### PR TITLE
Fix lock release timing during CNI CmdAdd rollback

### DIFF
--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -69,7 +69,6 @@ type containerAccessArbitrator struct {
 	mutex             sync.Mutex
 	cond              *sync.Cond
 	busyContainerKeys map[string]bool // used as a set of container keys
-	waiters           int             // goroutines blocked in lockContainer; used by tests
 }
 
 func newContainerAccessArbitrator() *containerAccessArbitrator {
@@ -91,9 +90,7 @@ func (arbitrator *containerAccessArbitrator) lockContainer(containerKey string) 
 		if !ok {
 			break
 		}
-		arbitrator.waiters++
 		arbitrator.cond.Wait()
-		arbitrator.waiters--
 	}
 	arbitrator.busyContainerKeys[containerKey] = true
 }

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -458,6 +458,10 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 	}
 	isInfraContainer := isInfraContainer(netNS)
 
+	// Serialize CNI calls for one Pod.
+	s.containerAccess.lockContainer(infraContainer)
+	defer s.containerAccess.unlockContainer(infraContainer)
+
 	success := false
 	defer func() {
 		// Rollback to delete configurations if ADD fails.
@@ -472,10 +476,6 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 			}
 		}
 	}()
-
-	// Serialize CNI calls for one Pod.
-	s.containerAccess.lockContainer(infraContainer)
-	defer s.containerAccess.unlockContainer(infraContainer)
 
 	if s.isChaining {
 		resp, err := s.interceptAdd(cniConfig)
@@ -539,10 +539,6 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 }
 
 func (s *CNIServer) cmdDel(_ context.Context, cniConfig *CNIConfig) (*cnipb.CniCmdResponse, error) {
-	infraContainer := cniConfig.getInfraContainer()
-	s.containerAccess.lockContainer(infraContainer)
-	defer s.containerAccess.unlockContainer(infraContainer)
-
 	if cniConfig.secondaryNetworkIPAM {
 		klog.InfoS("Antrea IPAM del", "CNI", cniConfig.Type, "network", cniConfig.Name)
 		return s.ipamDel(cniConfig)
@@ -575,6 +571,7 @@ func (s *CNIServer) cmdDel(_ context.Context, cniConfig *CNIConfig) (*cnipb.CniC
 	}
 
 	// Release IP to IPAM driver
+	infraContainer := cniConfig.getInfraContainer()
 	if err := ipam.ExecIPAMDelete(cniConfig.CniCmdArgs, cniConfig.K8sArgs, cniConfig.IPAM.Type, infraContainer); err != nil {
 		klog.ErrorS(err, "Failed to delete IP addresses for container", "container", cniConfig.ContainerId)
 		return s.ipamFailureResponse(err), nil
@@ -597,6 +594,10 @@ func (s *CNIServer) CmdDel(ctx context.Context, request *cnipb.CniCmdRequest) (*
 	if err := validateRuntime(netNS); err != nil {
 		return nil, fmt.Errorf("failed to validate container runtime for CmdDel request: %w", err)
 	}
+
+	infraContainer := cniConfig.getInfraContainer()
+	s.containerAccess.lockContainer(infraContainer)
+	defer s.containerAccess.unlockContainer(infraContainer)
 
 	return s.cmdDel(ctx, cniConfig)
 }

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -69,6 +69,7 @@ type containerAccessArbitrator struct {
 	mutex             sync.Mutex
 	cond              *sync.Cond
 	busyContainerKeys map[string]bool // used as a set of container keys
+	waiters           int             // goroutines blocked in lockContainer; used by tests
 }
 
 func newContainerAccessArbitrator() *containerAccessArbitrator {
@@ -90,7 +91,9 @@ func (arbitrator *containerAccessArbitrator) lockContainer(containerKey string) 
 		if !ok {
 			break
 		}
+		arbitrator.waiters++
 		arbitrator.cond.Wait()
+		arbitrator.waiters--
 	}
 	arbitrator.busyContainerKeys[containerKey] = true
 }
@@ -538,6 +541,10 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 	return resultToResponse(cniResult), nil
 }
 
+// cmdDel deletes the Pod's network configuration. The caller must hold the
+// containerAccess lock for the Pod's infra container: it is invoked both by
+// CmdDel and by the CmdAdd rollback path, which must not release the lock
+// between the failed ADD and the rollback.
 func (s *CNIServer) cmdDel(_ context.Context, cniConfig *CNIConfig) (*cnipb.CniCmdResponse, error) {
 	if cniConfig.secondaryNetworkIPAM {
 		klog.InfoS("Antrea IPAM del", "CNI", cniConfig.Type, "network", cniConfig.Name)

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -903,4 +903,3 @@ func (arbitrator *containerAccessArbitrator) isLocked(containerKey string) bool 
 	defer arbitrator.mutex.Unlock()
 	return arbitrator.busyContainerKeys[containerKey]
 }
-

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containernetworking/cni/pkg/invoke"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/gofrs/uuid/v5"
@@ -297,7 +298,7 @@ func TestIPAMService(t *testing.T) {
 
 		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil, fmt.Errorf("IPAM add error"))
 		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(args ...interface{}) (bool, error) {
+			func(_ *invoke.Args, _ *types.K8sArgs, _ []byte) (bool, error) {
 				close(rollbackStarted)
 				// Wait for concurrent routine to test lock status.
 				<-lockTested

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -287,6 +287,45 @@ func TestIPAMService(t *testing.T) {
 		checkErrorResponse(t, response, cnipb.ErrorCode_IPAM_FAILURE, "IPAM add error")
 	})
 
+	t.Run("Lock held during ADD rollback", func(t *testing.T) {
+		ipamMock, cniServer, requestMsg := setup(t)
+		cniConfig, _ := cniServer.validateRequestMessage(requestMsg)
+		infraContainer := cniConfig.getInfraContainer()
+
+		rollbackStarted := make(chan struct{})
+		lockTested := make(chan struct{})
+
+		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil, fmt.Errorf("IPAM add error"))
+		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(args ...interface{}) (bool, error) {
+				close(rollbackStarted)
+				// Wait for concurrent routine to test lock status.
+				<-lockTested
+				return true, nil
+			},
+		)
+
+		go func() {
+			<-rollbackStarted
+			// Verify that while rollback is in progress, the container is locked in containerAccess.
+			cniServer.containerAccess.mutex.Lock()
+			isBusy := cniServer.containerAccess.busyContainerKeys[infraContainer]
+			cniServer.containerAccess.mutex.Unlock()
+			assert.True(t, isBusy, "Container should remain locked during CmdAdd rollback")
+			close(lockTested)
+		}()
+
+		response, err := cniServer.CmdAdd(cxt, requestMsg)
+		require.Nil(t, err, "expected no rpc error")
+		checkErrorResponse(t, response, cnipb.ErrorCode_IPAM_FAILURE, "IPAM add error")
+
+		// After CmdAdd returns, container lock should be released.
+		cniServer.containerAccess.mutex.Lock()
+		isBusy := cniServer.containerAccess.busyContainerKeys[infraContainer]
+		cniServer.containerAccess.mutex.Unlock()
+		assert.False(t, isBusy, "Container should be unlocked after CmdAdd finishes")
+	})
+
 	t.Run("Error on DEL", func(t *testing.T) {
 		ipamMock, cniServer, requestMsg := setup(t)
 		// Prepare cached IPAM result which will be deleted later.

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -21,9 +21,8 @@ import (
 	"net"
 	"reflect"
 	"strings"
-	"sync"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/containernetworking/cni/pkg/invoke"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -290,56 +289,76 @@ func TestIPAMService(t *testing.T) {
 		checkErrorResponse(t, response, cnipb.ErrorCode_IPAM_FAILURE, "IPAM add error")
 	})
 
-	t.Run("Lock held during ADD rollback", func(t *testing.T) {
+	t.Run("Container lock held across ADD rollback", func(t *testing.T) {
+		// The rollback for a failed ADD must run with the container lock still held,
+		// or a concurrent CNI DEL could interleave with it. The rollback's IPAM DEL
+		// runs synchronously on the CmdAdd goroutine, so it can inspect the arbitrator.
 		ipamMock, cniServer, requestMsg := setup(t)
 		cniConfig, response := cniServer.validateRequestMessage(requestMsg)
 		require.Nil(t, response, "expected valid request message")
 		infraContainer := cniConfig.getInfraContainer()
 
-		var events []string
-		var eventsMutex sync.Mutex
-		recordEvent := func(name string) {
-			eventsMutex.Lock()
-			defer eventsMutex.Unlock()
-			events = append(events, name)
-		}
-
-		competitorAcquired := make(chan struct{})
-
+		delCalled := false
+		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil, fmt.Errorf("IPAM add error"))
 		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ *invoke.Args, _ *types.K8sArgs, _ []byte) (bool, error) {
-				recordEvent("rollback_del")
+				delCalled = true
+				assert.True(t, cniServer.containerAccess.isLocked(infraContainer),
+					"container lock must be held for the whole ADD rollback")
 				return true, nil
-			},
-		)
-
-		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(_ *invoke.Args, _ *types.K8sArgs, _ []byte) (bool, *ipam.IPAMResult, error) {
-				go func() {
-					cniServer.containerAccess.lockContainer(infraContainer)
-					recordEvent("competitor_lock")
-					cniServer.containerAccess.unlockContainer(infraContainer)
-					close(competitorAcquired)
-				}()
-
-				require.Eventually(t, func() bool {
-					cniServer.containerAccess.mutex.Lock()
-					defer cniServer.containerAccess.mutex.Unlock()
-					return cniServer.containerAccess.waiters == 1
-				}, 5*time.Second, 10*time.Millisecond)
-
-				return true, nil, fmt.Errorf("IPAM add error")
 			},
 		)
 
 		resp, err := cniServer.CmdAdd(cxt, requestMsg)
 		require.Nil(t, err, "expected no rpc error")
 		checkErrorResponse(t, resp, cnipb.ErrorCode_IPAM_FAILURE, "IPAM add error")
+		require.True(t, delCalled, "expected rollback to invoke IPAM DEL")
+		assert.False(t, cniServer.containerAccess.isLocked(infraContainer),
+			"container lock must be released once CmdAdd returns")
+	})
 
-		<-competitorAcquired
+	t.Run("cmdDel does not take the container lock", func(t *testing.T) {
+		// cmdDel is caller-locked: CmdAdd's rollback calls it while already holding the
+		// container lock, so cmdDel must not try to acquire it itself.
+		// We run this in a synctest bubble so that "cmdDel made no progress" is observed
+		// deterministically instead of by waiting on a timeout: lockContainer blocks in
+		// sync.Cond.Wait, which is a durably blocking operation, so synctest.Wait returns
+		// as soon as cmdDel is parked there.
+		synctest.Test(t, func(t *testing.T) {
+			ipamMock, cniServer, requestMsg := setup(t)
+			cniConfig, response := cniServer.validateRequestMessage(requestMsg)
+			require.Nil(t, response, "expected valid request message")
+			infraContainer := cniConfig.getInfraContainer()
 
-		require.Equal(t, []string{"rollback_del", "competitor_lock"}, events,
-			"Rollback Del must execute before competitor acquires container lock")
+			ipamMock.EXPECT().Del(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+
+			cniServer.containerAccess.lockContainer(infraContainer)
+			done := make(chan struct{})
+			var delResp *cnipb.CniCmdResponse
+			var delErr error
+			go func() {
+				defer close(done)
+				delResp, delErr = cniServer.cmdDel(cxt, cniConfig)
+			}()
+
+			// Returns once the goroutine above has either completed or blocked.
+			synctest.Wait()
+			var completed bool
+			select {
+			case <-done:
+				completed = true
+			default:
+			}
+
+			// Release the lock unconditionally, so that the goroutine can always run to
+			// completion and the bubble is empty by the time this function returns.
+			cniServer.containerAccess.unlockContainer(infraContainer)
+			<-done
+			assert.True(t, completed,
+				"cmdDel must not block while the caller holds the container lock: it must not acquire the lock itself")
+			require.NoError(t, delErr)
+			require.NotNil(t, delResp)
+		})
 	})
 
 	t.Run("Error on DEL", func(t *testing.T) {
@@ -876,3 +895,12 @@ func init() {
 	gateway := &config.GatewayConfig{Name: "", IPv4: gwIPv4, IPv6: gwIPv6, MAC: gwMAC}
 	testNodeConfig = &config.NodeConfig{Name: nodeName, PodIPv4CIDR: nodePodCIDRv4, PodIPv6CIDR: nodePodCIDRv6, GatewayConfig: gateway}
 }
+
+// isLocked reports whether containerKey is currently held. Defined in the test
+// file so that production code carries no test-only state.
+func (arbitrator *containerAccessArbitrator) isLocked(containerKey string) bool {
+	arbitrator.mutex.Lock()
+	defer arbitrator.mutex.Unlock()
+	return arbitrator.busyContainerKeys[containerKey]
+}
+

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -21,7 +21,9 @@ import (
 	"net"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/containernetworking/cni/pkg/invoke"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -290,41 +292,54 @@ func TestIPAMService(t *testing.T) {
 
 	t.Run("Lock held during ADD rollback", func(t *testing.T) {
 		ipamMock, cniServer, requestMsg := setup(t)
-		cniConfig, _ := cniServer.validateRequestMessage(requestMsg)
+		cniConfig, response := cniServer.validateRequestMessage(requestMsg)
+		require.Nil(t, response, "expected valid request message")
 		infraContainer := cniConfig.getInfraContainer()
 
-		rollbackStarted := make(chan struct{})
-		lockTested := make(chan struct{})
+		var events []string
+		var eventsMutex sync.Mutex
+		recordEvent := func(name string) {
+			eventsMutex.Lock()
+			defer eventsMutex.Unlock()
+			events = append(events, name)
+		}
 
-		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil, fmt.Errorf("IPAM add error"))
+		competitorAcquired := make(chan struct{})
+
 		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ *invoke.Args, _ *types.K8sArgs, _ []byte) (bool, error) {
-				close(rollbackStarted)
-				// Wait for concurrent routine to test lock status.
-				<-lockTested
+				recordEvent("rollback_del")
 				return true, nil
 			},
 		)
 
-		go func() {
-			<-rollbackStarted
-			// Verify that while rollback is in progress, the container is locked in containerAccess.
-			cniServer.containerAccess.mutex.Lock()
-			isBusy := cniServer.containerAccess.busyContainerKeys[infraContainer]
-			cniServer.containerAccess.mutex.Unlock()
-			assert.True(t, isBusy, "Container should remain locked during CmdAdd rollback")
-			close(lockTested)
-		}()
+		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ *invoke.Args, _ *types.K8sArgs, _ []byte) (bool, *ipam.IPAMResult, error) {
+				go func() {
+					cniServer.containerAccess.lockContainer(infraContainer)
+					recordEvent("competitor_lock")
+					cniServer.containerAccess.unlockContainer(infraContainer)
+					close(competitorAcquired)
+				}()
 
-		response, err := cniServer.CmdAdd(cxt, requestMsg)
+				require.Eventually(t, func() bool {
+					cniServer.containerAccess.mutex.Lock()
+					defer cniServer.containerAccess.mutex.Unlock()
+					return cniServer.containerAccess.waiters == 1
+				}, 5*time.Second, 10*time.Millisecond)
+
+				return true, nil, fmt.Errorf("IPAM add error")
+			},
+		)
+
+		resp, err := cniServer.CmdAdd(cxt, requestMsg)
 		require.Nil(t, err, "expected no rpc error")
-		checkErrorResponse(t, response, cnipb.ErrorCode_IPAM_FAILURE, "IPAM add error")
+		checkErrorResponse(t, resp, cnipb.ErrorCode_IPAM_FAILURE, "IPAM add error")
 
-		// After CmdAdd returns, container lock should be released.
-		cniServer.containerAccess.mutex.Lock()
-		isBusy := cniServer.containerAccess.busyContainerKeys[infraContainer]
-		cniServer.containerAccess.mutex.Unlock()
-		assert.False(t, isBusy, "Container should be unlocked after CmdAdd finishes")
+		<-competitorAcquired
+
+		require.Equal(t, []string{"rollback_del", "competitor_lock"}, events,
+			"Rollback Del must execute before competitor acquires container lock")
 	})
 
 	t.Run("Error on DEL", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adjust defer declaration order in `CmdAdd()` so that the container lock is held continuously across the entire failure rollback execution.
- Move container locking from the internal `cmdDel()` helper to the public `CmdDel()` RPC handler to prevent non-reentrant deadlocks during `CmdAdd` rollback.
- Add a unit test in `server_test.go` confirming the container lock remains active while rollback is in flight and is properly released upon return.

## Test plan
- [x] Unit test `Lock held during ADD rollback` in `pkg/agent/cniserver/server_test.go`
- [x] Cross-compilation verified for Linux (`GOOS=linux`) and Windows (`GOOS=windows`)