### PR TITLE
Retry NodeLatencyMonitor socket creation

### DIFF
--- a/pkg/agent/monitortool/monitor.go
+++ b/pkg/agent/monitortool/monitor.go
@@ -18,6 +18,7 @@ package monitortool
 
 import (
 	"context"
+	"math"
 	"math/rand/v2"
 	"net"
 	"sync"
@@ -29,6 +30,7 @@ import (
 	"golang.org/x/net/ipv6"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -44,12 +46,14 @@ import (
 var icmpEchoID = rand.Int32N(1 << 16)
 
 const (
-	ipv4ProtocolICMPRaw = "ip4:icmp"
-	ipv6ProtocolICMPRaw = "ip6:ipv6-icmp"
-	protocolICMP        = 1
-	protocolICMPv6      = 58
-	minReportInterval   = 10 * time.Second
-	reportJitter        = time.Second
+	ipv4ProtocolICMPRaw    = "ip4:icmp"
+	ipv6ProtocolICMPRaw    = "ip6:ipv6-icmp"
+	protocolICMP           = 1
+	protocolICMPv6         = 58
+	minReportInterval      = 10 * time.Second
+	reportJitter           = time.Second
+	minSocketRetryInterval = 5 * time.Second
+	maxSocketRetryInterval = 5 * time.Minute
 )
 
 type PacketListener interface {
@@ -418,8 +422,9 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 	klog.InfoS("NodeLatencyMonitor is running")
 	var pingTicker, reportTicker *time.Ticker
 	var pingTickerCh, reportTickerCh <-chan time.Time
+	var socketRetryTimer wait.Timer
+	var socketRetryTimerCh <-chan time.Time
 	var ipv4Socket, ipv6Socket net.PacketConn
-	var err error
 
 	defer func() {
 		if ipv4Socket != nil {
@@ -433,6 +438,9 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 		}
 		if reportTicker != nil {
 			reportTicker.Stop()
+		}
+		if socketRetryTimer != nil {
+			socketRetryTimer.Stop()
 		}
 	}()
 
@@ -460,6 +468,66 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 	}
 
 	wg := sync.WaitGroup{}
+	ensureSocketsReady := func(isRetry bool) bool {
+		socketsReady := true
+		if ipv4Socket == nil && m.isIPv4Enabled {
+			socket, err := m.listener.ListenPacket(ipv4ProtocolICMPRaw, "0.0.0.0")
+			if err != nil {
+				if isRetry {
+					klog.V(4).InfoS("Failed to create ICMP socket for IPv4, will retry", "err", err)
+				} else {
+					klog.ErrorS(err, "Failed to create ICMP socket for IPv4, will retry")
+				}
+				socketsReady = false
+			} else {
+				ipv4Socket = socket
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					m.recvPings(socket, true)
+				}()
+			}
+		}
+		if ipv6Socket == nil && m.isIPv6Enabled {
+			socket, err := m.listener.ListenPacket(ipv6ProtocolICMPRaw, "::")
+			if err != nil {
+				if isRetry {
+					klog.V(4).InfoS("Failed to create ICMP socket for IPv6, will retry", "err", err)
+				} else {
+					klog.ErrorS(err, "Failed to create ICMP socket for IPv6, will retry")
+				}
+				socketsReady = false
+			} else {
+				ipv6Socket = socket
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					m.recvPings(socket, false)
+				}()
+			}
+		}
+		return socketsReady
+	}
+	stopSocketRetryTimer := func() {
+		if socketRetryTimer != nil {
+			socketRetryTimer.Stop()
+		}
+		socketRetryTimer = nil
+		socketRetryTimerCh = nil
+	}
+	startSocketRetryTimer := func() {
+		if socketRetryTimer != nil {
+			return
+		}
+		socketRetryTimer = (wait.Backoff{
+			Duration: minSocketRetryInterval,
+			Factor:   2,
+			Steps:    math.MaxInt32,
+			Cap:      maxSocketRetryInterval,
+		}).Timer()
+		socketRetryTimerCh = socketRetryTimer.C()
+	}
+
 	// Start the pingAll goroutine
 	for {
 		select {
@@ -472,6 +540,12 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 			m.latencyStore.DeleteStaleNodeIPs()
 		case <-reportTickerCh:
 			m.report()
+		case <-socketRetryTimerCh:
+			if ensureSocketsReady(true) {
+				stopSocketRetryTimer()
+			} else {
+				socketRetryTimer.Next()
+			}
 		case <-stopCh:
 			return
 		case latencyConfig := <-m.latencyConfigChanged:
@@ -482,35 +556,11 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 				updatePingTicker(latencyConfig.Interval)
 				updateReportTicker(latencyConfig.Interval)
 
-				// If the recvPing socket is closed,
-				// recreate it if it is closed (CR is deleted).
-				if ipv4Socket == nil && m.isIPv4Enabled {
-					// Create a new socket for IPv4 when it is IPv4-only
-					ipv4Socket, err = m.listener.ListenPacket(ipv4ProtocolICMPRaw, "0.0.0.0")
-					if err != nil {
-						klog.ErrorS(err, "Failed to create ICMP socket for IPv4")
-						return
-					}
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
-						m.recvPings(ipv4Socket, true)
-					}()
-				}
-				if ipv6Socket == nil && m.isIPv6Enabled {
-					// Create a new socket for IPv6 when it is IPv6-only
-					ipv6Socket, err = m.listener.ListenPacket(ipv6ProtocolICMPRaw, "::")
-					if err != nil {
-						klog.ErrorS(err, "Failed to create ICMP socket for IPv6")
-						return
-					}
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
-						m.recvPings(ipv6Socket, false)
-					}()
+				if socketRetryTimer == nil && !ensureSocketsReady(false) {
+					startSocketRetryTimer()
 				}
 			} else {
+				stopSocketRetryTimer()
 				if pingTicker != nil {
 					pingTicker.Stop()
 					pingTicker = nil

--- a/pkg/agent/monitortool/monitor.go
+++ b/pkg/agent/monitortool/monitor.go
@@ -373,7 +373,7 @@ func (m *NodeLatencyMonitor) pingAll(ipv4Socket, ipv6Socket net.PacketConn) {
 			if err := m.sendPing(ipv4Socket, toIP); err != nil {
 				klog.ErrorS(err, "Cannot send ICMP message to Node IP", "IP", toIP)
 			}
-		} else if toIP.To16() != nil && ipv6Socket != nil {
+		} else if toIP.To4() == nil && ipv6Socket != nil {
 			if err := m.sendPing(ipv6Socket, toIP); err != nil {
 				klog.ErrorS(err, "Cannot send ICMP message to Node IP", "IP", toIP)
 			}
@@ -469,41 +469,35 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 
 	wg := sync.WaitGroup{}
 	ensureSocketsReady := func(isRetry bool) bool {
-		socketsReady := true
-		if ipv4Socket == nil && m.isIPv4Enabled {
-			socket, err := m.listener.ListenPacket(ipv4ProtocolICMPRaw, "0.0.0.0")
+		newSocket := func(network, address string, isIPv4 bool) net.PacketConn {
+			socket, err := m.listener.ListenPacket(network, address)
 			if err != nil {
 				if isRetry {
-					klog.V(4).InfoS("Failed to create ICMP socket for IPv4, will retry", "err", err)
+					klog.V(4).InfoS("Failed to create ICMP socket, will retry", "network", network, "err", err)
 				} else {
-					klog.ErrorS(err, "Failed to create ICMP socket for IPv4, will retry")
+					klog.ErrorS(err, "Failed to create ICMP socket, will retry", "network", network)
 				}
+				return nil
+			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				m.recvPings(socket, isIPv4)
+			}()
+			return socket
+		}
+
+		socketsReady := true
+		if ipv4Socket == nil && m.isIPv4Enabled {
+			ipv4Socket = newSocket(ipv4ProtocolICMPRaw, "0.0.0.0", true)
+			if ipv4Socket == nil {
 				socketsReady = false
-			} else {
-				ipv4Socket = socket
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					m.recvPings(socket, true)
-				}()
 			}
 		}
 		if ipv6Socket == nil && m.isIPv6Enabled {
-			socket, err := m.listener.ListenPacket(ipv6ProtocolICMPRaw, "::")
-			if err != nil {
-				if isRetry {
-					klog.V(4).InfoS("Failed to create ICMP socket for IPv6, will retry", "err", err)
-				} else {
-					klog.ErrorS(err, "Failed to create ICMP socket for IPv6, will retry")
-				}
+			ipv6Socket = newSocket(ipv6ProtocolICMPRaw, "::", false)
+			if ipv6Socket == nil {
 				socketsReady = false
-			} else {
-				ipv6Socket = socket
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					m.recvPings(socket, false)
-				}()
 			}
 		}
 		return socketsReady
@@ -522,8 +516,10 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 		socketRetryTimer = (wait.Backoff{
 			Duration: minSocketRetryInterval,
 			Factor:   2,
-			Steps:    math.MaxInt32,
-			Cap:      maxSocketRetryInterval,
+			// Steps must be greater than 1 for Backoff.Timer to use a variable timer.
+			// A large value lets Cap, rather than Steps, bound the retry interval.
+			Steps: math.MaxInt32,
+			Cap:   maxSocketRetryInterval,
 		}).Timer()
 		socketRetryTimerCh = socketRetryTimer.C()
 	}

--- a/pkg/agent/monitortool/monitor_test.go
+++ b/pkg/agent/monitortool/monitor_test.go
@@ -727,6 +727,110 @@ func TestNodeAddUpdateDelete(t *testing.T) {
 	}
 }
 
+func TestMonitorLoopRetriesSocketCreation(t *testing.T) {
+	testCases := []struct {
+		name      string
+		network   string
+		address   string
+		localAddr net.Addr
+		isIPv4    bool
+	}{
+		{
+			name:      "IPv4",
+			network:   ipv4ProtocolICMPRaw,
+			address:   "0.0.0.0",
+			localAddr: testAddrIPv4,
+			isIPv4:    true,
+		},
+		{
+			name:      "IPv6",
+			network:   ipv6ProtocolICMPRaw,
+			address:   "::",
+			localAddr: testAddrIPv6,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
+				stopCh := ctx.Done()
+				m := newTestMonitor(t, nodeConfigDualStack, config.TrafficEncapModeEncap, nil, []runtime.Object{nlm})
+				m.isIPv4Enabled = tc.isIPv4
+				m.isIPv6Enabled = !tc.isIPv4
+				m.crdInformerFactory.Start(stopCh)
+				m.informerFactory.Start(stopCh)
+				m.crdInformerFactory.WaitForCacheSync(stopCh)
+				m.informerFactory.WaitForCacheSync(stopCh)
+
+				recoveredSocket := nettest.NewPacketConn(tc.localAddr, nil, nil)
+				m.mockListener.EXPECT().ListenPacket(tc.network, tc.address).Return(nil, assert.AnError)
+				m.mockListener.EXPECT().ListenPacket(tc.network, tc.address).Return(nil, assert.AnError)
+				m.mockListener.EXPECT().ListenPacket(tc.network, tc.address).Return(recoveredSocket, nil)
+
+				go m.Run(stopCh)
+				synctest.Wait()
+				assert.False(t, m.ctrl.Satisfied())
+
+				time.Sleep(minSocketRetryInterval)
+				synctest.Wait()
+				assert.False(t, m.ctrl.Satisfied())
+
+				updatedNLM := nlm.DeepCopy()
+				updatedNLM.Generation = 1
+				updatedNLM.Spec.PingIntervalSeconds = 90
+				_, err := m.crdClientset.CrdV1alpha1().NodeLatencyMonitors().Update(ctx, updatedNLM, metav1.UpdateOptions{})
+				require.NoError(t, err)
+				synctest.Wait()
+				assert.False(t, m.ctrl.Satisfied())
+
+				// The retry interval doubles after the second failure. Advancing by only
+				// the initial interval must not trigger another attempt.
+				time.Sleep(minSocketRetryInterval)
+				synctest.Wait()
+				assert.False(t, m.ctrl.Satisfied())
+
+				time.Sleep(minSocketRetryInterval)
+				synctest.Wait()
+				require.True(t, m.ctrl.Satisfied())
+				assert.False(t, recoveredSocket.IsClosed())
+			})
+		})
+	}
+}
+
+func TestMonitorLoopStopsSocketRetryWhenDisabled(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		stopCh := ctx.Done()
+		m := newTestMonitor(t, nodeConfigIPv4, config.TrafficEncapModeEncap, nil, []runtime.Object{nlm})
+		m.crdInformerFactory.Start(stopCh)
+		m.informerFactory.Start(stopCh)
+		m.crdInformerFactory.WaitForCacheSync(stopCh)
+		m.informerFactory.WaitForCacheSync(stopCh)
+
+		recoveredSocket := nettest.NewPacketConn(testAddrIPv4, nil, nil)
+		m.mockListener.EXPECT().ListenPacket(ipv4ProtocolICMPRaw, "0.0.0.0").Return(nil, assert.AnError)
+		m.mockListener.EXPECT().ListenPacket(ipv4ProtocolICMPRaw, "0.0.0.0").Return(recoveredSocket, nil)
+
+		go m.Run(stopCh)
+		synctest.Wait()
+		assert.False(t, m.ctrl.Satisfied())
+
+		require.NoError(t, m.crdClientset.CrdV1alpha1().NodeLatencyMonitors().Delete(ctx, nlm.Name, metav1.DeleteOptions{}))
+		synctest.Wait()
+		time.Sleep(2 * minSocketRetryInterval)
+		synctest.Wait()
+		assert.False(t, m.ctrl.Satisfied())
+
+		_, err := m.crdClientset.CrdV1alpha1().NodeLatencyMonitors().Create(ctx, nlm.DeepCopy(), metav1.CreateOptions{})
+		require.NoError(t, err)
+		synctest.Wait()
+		require.True(t, m.ctrl.Satisfied())
+		assert.False(t, recoveredSocket.IsClosed())
+	})
+}
+
 func TestMonitorLoop(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()

--- a/pkg/agent/monitortool/monitor_test.go
+++ b/pkg/agent/monitortool/monitor_test.go
@@ -460,6 +460,53 @@ func TestSendPing(t *testing.T) {
 	}
 }
 
+func TestPingAllWithPartialSocketAvailability(t *testing.T) {
+	testCases := []struct {
+		name      string
+		isIPv4    bool
+		localAddr net.Addr
+		targetIP  string
+	}{
+		{
+			name:      "IPv4 socket only",
+			isIPv4:    true,
+			localAddr: testAddrIPv4,
+			targetIP:  "10.0.2.1",
+		},
+		{
+			name:      "IPv6 socket only",
+			localAddr: testAddrIPv6,
+			targetIP:  "2001:ab03:cd04:55ee:100b::1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMonitor(t, nodeConfigDualStack, config.TrafficEncapModeEncap, nil, nil)
+			m.latencyStore.addNode(node2)
+
+			outCh := make(chan *nettest.Packet, 2)
+			socket := nettest.NewPacketConn(tc.localAddr, nil, outCh)
+			t.Cleanup(func() {
+				require.NoError(t, socket.Close())
+			})
+			var ipv4Socket, ipv6Socket net.PacketConn
+			if tc.isIPv4 {
+				ipv4Socket = socket
+			} else {
+				ipv6Socket = socket
+			}
+
+			m.pingAll(ipv4Socket, ipv6Socket)
+
+			require.Len(t, outCh, 1)
+			packet := <-outCh
+			assert.Equal(t, tc.targetIP, packet.Addr.String())
+			assert.Equal(t, []string{tc.targetIP}, m.latencyStore.getNodeIPLatencyKeys())
+		})
+	}
+}
+
 // TestRecvPings tests that ICMP messages are handled correctly when received. We only consider the
 // "normal" case here. The ICMP parsing and validation logic is tested comprehensively in
 // TestHandlePing.


### PR DESCRIPTION
Keep Node latency monitoring active when raw ICMP socket creation
fails. Retry missing IPv4 or IPv6 sockets with capped exponential
backoff so a transient host error does not leave monitoring disabled
for the lifetime of the Agent.

Stop retries when monitoring is disabled and reduce repeated failure
logging. Add regression coverage for both IP families, backoff timing,
configuration updates, and lifecycle transitions.

Signed-off-by: Lan Luo <lan.luo@broadcom.com>