### PR TITLE
Add BGP timers and graceful restart to BGPPolicy

### DIFF
--- a/build/charts/antrea/crds/bgppolicy.yaml
+++ b/build/charts/antrea/crds/bgppolicy.yaml
@@ -141,8 +141,8 @@ spec:
                         minimum: 3
                         maximum: 65535
                         default: 90
-                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
-                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from one
+                      # third of holdTimeSeconds. See docs/bgp-policy.md for why a fixed default is wrong here.
                       keepaliveIntervalSeconds:
                         type: integer
                         format: int32

--- a/build/charts/antrea/crds/bgppolicy.yaml
+++ b/build/charts/antrea/crds/bgppolicy.yaml
@@ -97,6 +97,12 @@ spec:
                     required:
                       - address
                       - asn
+                    x-kubernetes-validations:
+                      # holdTimeSeconds is defaulted, so the rule reads it without a has() guard. Only the hard
+                      # floor is enforced: a keepalive interval at or above the hold time can never refresh the
+                      # peer's hold timer in time. The RFC 4271 one third ratio is guidance in docs/bgp-policy.md.
+                      - rule: "!has(self.keepaliveIntervalSeconds) || self.keepaliveIntervalSeconds < self.holdTimeSeconds"
+                        message: "keepaliveIntervalSeconds must be less than holdTimeSeconds"
                     properties:
                       address:
                         type: string
@@ -120,12 +126,40 @@ spec:
                         minimum: 1
                         maximum: 255
                         default: 1
+                      gracefulRestartEnabled:
+                        type: boolean
+                        default: true
                       gracefulRestartTimeSeconds:
                         type: integer
                         format: int32
                         minimum: 1
                         maximum: 3600
                         default: 120
+                      holdTimeSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 3
+                        maximum: 65535
+                        default: 90
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
+                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      keepaliveIntervalSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 65534
+                      connectRetrySeconds:
+                        type: integer
+                        format: int32
+                        minimum: 2
+                        maximum: 65535
+                        default: 120
+                      idleHoldTimeAfterResetSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 3600
+                        default: 30
       additionalPrinterColumns:
         - description: Local BGP AS number
           jsonPath: .spec.localASN

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -549,6 +549,12 @@ spec:
                     required:
                       - address
                       - asn
+                    x-kubernetes-validations:
+                      # holdTimeSeconds is defaulted, so the rule reads it without a has() guard. Only the hard
+                      # floor is enforced: a keepalive interval at or above the hold time can never refresh the
+                      # peer's hold timer in time. The RFC 4271 one third ratio is guidance in docs/bgp-policy.md.
+                      - rule: "!has(self.keepaliveIntervalSeconds) || self.keepaliveIntervalSeconds < self.holdTimeSeconds"
+                        message: "keepaliveIntervalSeconds must be less than holdTimeSeconds"
                     properties:
                       address:
                         type: string
@@ -572,12 +578,40 @@ spec:
                         minimum: 1
                         maximum: 255
                         default: 1
+                      gracefulRestartEnabled:
+                        type: boolean
+                        default: true
                       gracefulRestartTimeSeconds:
                         type: integer
                         format: int32
                         minimum: 1
                         maximum: 3600
                         default: 120
+                      holdTimeSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 3
+                        maximum: 65535
+                        default: 90
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
+                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      keepaliveIntervalSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 65534
+                      connectRetrySeconds:
+                        type: integer
+                        format: int32
+                        minimum: 2
+                        maximum: 65535
+                        default: 120
+                      idleHoldTimeAfterResetSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 3600
+                        default: 30
       additionalPrinterColumns:
         - description: Local BGP AS number
           jsonPath: .spec.localASN

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -593,8 +593,8 @@ spec:
                         minimum: 3
                         maximum: 65535
                         default: 90
-                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
-                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from one
+                      # third of holdTimeSeconds. See docs/bgp-policy.md for why a fixed default is wrong here.
                       keepaliveIntervalSeconds:
                         type: integer
                         format: int32

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -538,6 +538,12 @@ spec:
                     required:
                       - address
                       - asn
+                    x-kubernetes-validations:
+                      # holdTimeSeconds is defaulted, so the rule reads it without a has() guard. Only the hard
+                      # floor is enforced: a keepalive interval at or above the hold time can never refresh the
+                      # peer's hold timer in time. The RFC 4271 one third ratio is guidance in docs/bgp-policy.md.
+                      - rule: "!has(self.keepaliveIntervalSeconds) || self.keepaliveIntervalSeconds < self.holdTimeSeconds"
+                        message: "keepaliveIntervalSeconds must be less than holdTimeSeconds"
                     properties:
                       address:
                         type: string
@@ -561,12 +567,40 @@ spec:
                         minimum: 1
                         maximum: 255
                         default: 1
+                      gracefulRestartEnabled:
+                        type: boolean
+                        default: true
                       gracefulRestartTimeSeconds:
                         type: integer
                         format: int32
                         minimum: 1
                         maximum: 3600
                         default: 120
+                      holdTimeSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 3
+                        maximum: 65535
+                        default: 90
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
+                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      keepaliveIntervalSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 65534
+                      connectRetrySeconds:
+                        type: integer
+                        format: int32
+                        minimum: 2
+                        maximum: 65535
+                        default: 120
+                      idleHoldTimeAfterResetSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 3600
+                        default: 30
       additionalPrinterColumns:
         - description: Local BGP AS number
           jsonPath: .spec.localASN

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -582,8 +582,8 @@ spec:
                         minimum: 3
                         maximum: 65535
                         default: 90
-                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
-                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from one
+                      # third of holdTimeSeconds. See docs/bgp-policy.md for why a fixed default is wrong here.
                       keepaliveIntervalSeconds:
                         type: integer
                         format: int32

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -545,6 +545,12 @@ spec:
                     required:
                       - address
                       - asn
+                    x-kubernetes-validations:
+                      # holdTimeSeconds is defaulted, so the rule reads it without a has() guard. Only the hard
+                      # floor is enforced: a keepalive interval at or above the hold time can never refresh the
+                      # peer's hold timer in time. The RFC 4271 one third ratio is guidance in docs/bgp-policy.md.
+                      - rule: "!has(self.keepaliveIntervalSeconds) || self.keepaliveIntervalSeconds < self.holdTimeSeconds"
+                        message: "keepaliveIntervalSeconds must be less than holdTimeSeconds"
                     properties:
                       address:
                         type: string
@@ -568,12 +574,40 @@ spec:
                         minimum: 1
                         maximum: 255
                         default: 1
+                      gracefulRestartEnabled:
+                        type: boolean
+                        default: true
                       gracefulRestartTimeSeconds:
                         type: integer
                         format: int32
                         minimum: 1
                         maximum: 3600
                         default: 120
+                      holdTimeSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 3
+                        maximum: 65535
+                        default: 90
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
+                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      keepaliveIntervalSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 65534
+                      connectRetrySeconds:
+                        type: integer
+                        format: int32
+                        minimum: 2
+                        maximum: 65535
+                        default: 120
+                      idleHoldTimeAfterResetSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 3600
+                        default: 30
       additionalPrinterColumns:
         - description: Local BGP AS number
           jsonPath: .spec.localASN

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -589,8 +589,8 @@ spec:
                         minimum: 3
                         maximum: 65535
                         default: 90
-                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
-                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from one
+                      # third of holdTimeSeconds. See docs/bgp-policy.md for why a fixed default is wrong here.
                       keepaliveIntervalSeconds:
                         type: integer
                         format: int32

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -545,6 +545,12 @@ spec:
                     required:
                       - address
                       - asn
+                    x-kubernetes-validations:
+                      # holdTimeSeconds is defaulted, so the rule reads it without a has() guard. Only the hard
+                      # floor is enforced: a keepalive interval at or above the hold time can never refresh the
+                      # peer's hold timer in time. The RFC 4271 one third ratio is guidance in docs/bgp-policy.md.
+                      - rule: "!has(self.keepaliveIntervalSeconds) || self.keepaliveIntervalSeconds < self.holdTimeSeconds"
+                        message: "keepaliveIntervalSeconds must be less than holdTimeSeconds"
                     properties:
                       address:
                         type: string
@@ -568,12 +574,40 @@ spec:
                         minimum: 1
                         maximum: 255
                         default: 1
+                      gracefulRestartEnabled:
+                        type: boolean
+                        default: true
                       gracefulRestartTimeSeconds:
                         type: integer
                         format: int32
                         minimum: 1
                         maximum: 3600
                         default: 120
+                      holdTimeSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 3
+                        maximum: 65535
+                        default: 90
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
+                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      keepaliveIntervalSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 65534
+                      connectRetrySeconds:
+                        type: integer
+                        format: int32
+                        minimum: 2
+                        maximum: 65535
+                        default: 120
+                      idleHoldTimeAfterResetSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 3600
+                        default: 30
       additionalPrinterColumns:
         - description: Local BGP AS number
           jsonPath: .spec.localASN

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -589,8 +589,8 @@ spec:
                         minimum: 3
                         maximum: 65535
                         default: 90
-                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
-                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from one
+                      # third of holdTimeSeconds. See docs/bgp-policy.md for why a fixed default is wrong here.
                       keepaliveIntervalSeconds:
                         type: integer
                         format: int32

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -545,6 +545,12 @@ spec:
                     required:
                       - address
                       - asn
+                    x-kubernetes-validations:
+                      # holdTimeSeconds is defaulted, so the rule reads it without a has() guard. Only the hard
+                      # floor is enforced: a keepalive interval at or above the hold time can never refresh the
+                      # peer's hold timer in time. The RFC 4271 one third ratio is guidance in docs/bgp-policy.md.
+                      - rule: "!has(self.keepaliveIntervalSeconds) || self.keepaliveIntervalSeconds < self.holdTimeSeconds"
+                        message: "keepaliveIntervalSeconds must be less than holdTimeSeconds"
                     properties:
                       address:
                         type: string
@@ -568,12 +574,40 @@ spec:
                         minimum: 1
                         maximum: 255
                         default: 1
+                      gracefulRestartEnabled:
+                        type: boolean
+                        default: true
                       gracefulRestartTimeSeconds:
                         type: integer
                         format: int32
                         minimum: 1
                         maximum: 3600
                         default: 120
+                      holdTimeSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 3
+                        maximum: 65535
+                        default: 90
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
+                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      keepaliveIntervalSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 65534
+                      connectRetrySeconds:
+                        type: integer
+                        format: int32
+                        minimum: 2
+                        maximum: 65535
+                        default: 120
+                      idleHoldTimeAfterResetSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 3600
+                        default: 30
       additionalPrinterColumns:
         - description: Local BGP AS number
           jsonPath: .spec.localASN

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -589,8 +589,8 @@ spec:
                         minimum: 3
                         maximum: 65535
                         default: 90
-                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
-                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from one
+                      # third of holdTimeSeconds. See docs/bgp-policy.md for why a fixed default is wrong here.
                       keepaliveIntervalSeconds:
                         type: integer
                         format: int32

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -545,6 +545,12 @@ spec:
                     required:
                       - address
                       - asn
+                    x-kubernetes-validations:
+                      # holdTimeSeconds is defaulted, so the rule reads it without a has() guard. Only the hard
+                      # floor is enforced: a keepalive interval at or above the hold time can never refresh the
+                      # peer's hold timer in time. The RFC 4271 one third ratio is guidance in docs/bgp-policy.md.
+                      - rule: "!has(self.keepaliveIntervalSeconds) || self.keepaliveIntervalSeconds < self.holdTimeSeconds"
+                        message: "keepaliveIntervalSeconds must be less than holdTimeSeconds"
                     properties:
                       address:
                         type: string
@@ -568,12 +574,40 @@ spec:
                         minimum: 1
                         maximum: 255
                         default: 1
+                      gracefulRestartEnabled:
+                        type: boolean
+                        default: true
                       gracefulRestartTimeSeconds:
                         type: integer
                         format: int32
                         minimum: 1
                         maximum: 3600
                         default: 120
+                      holdTimeSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 3
+                        maximum: 65535
+                        default: 90
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
+                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      keepaliveIntervalSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 65534
+                      connectRetrySeconds:
+                        type: integer
+                        format: int32
+                        minimum: 2
+                        maximum: 65535
+                        default: 120
+                      idleHoldTimeAfterResetSeconds:
+                        type: integer
+                        format: int32
+                        minimum: 1
+                        maximum: 3600
+                        default: 30
       additionalPrinterColumns:
         - description: Local BGP AS number
           jsonPath: .spec.localASN

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -589,8 +589,8 @@ spec:
                         minimum: 3
                         maximum: 65535
                         default: 90
-                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from the
-                      # effective hold time. See docs/bgp-policy.md for why a fixed default is wrong here.
+                      # Deliberately not defaulted: the BGP process derives an unset keepalive interval from one
+                      # third of holdTimeSeconds. See docs/bgp-policy.md for why a fixed default is wrong here.
                       keepaliveIntervalSeconds:
                         type: integer
                         format: int32

--- a/docs/bgp-policy.md
+++ b/docs/bgp-policy.md
@@ -18,6 +18,8 @@
   - [Combined Advertisements of Service, Pod, and Egress IPs](#combined-advertisements-of-service-pod-and-egress-ips)
   - [Advertise Egress IPs to external BGP peers with more than one hop](#advertise-egress-ips-to-external-bgp-peers-with-more-than-one-hop)
   - [Advertise Pod IPs through BGP Confederation](#advertise-pod-ips-through-bgp-confederation)
+  - [Tune the BGP timers for faster failure detection](#tune-the-bgp-timers-for-faster-failure-detection)
+  - [Leaving room for jitter](#leaving-room-for-jitter)
 - [Using antctl](#using-antctl)
 - [Limitations](#limitations)
 <!-- /toc -->
@@ -128,8 +130,41 @@ The `bgpPeers` field lists the BGP peers to which the advertisements are sent.
 - `port`: The port number on which the BGP peer listens. The default value is 179.
 - `multihopTTL`: The Time To Live (TTL) value used in BGP packets sent to the BGP peer, with a range of 1 to 255.
   The default value is 1.
+- `gracefulRestartEnabled`: Whether to advertise the BGP graceful restart capability to the BGP peer. The default value
+  is `true`. When it is set to `false`, the capability is not advertised and `gracefulRestartTimeSeconds` has no effect.
 - `gracefulRestartTimeSeconds`: Specifies how long the BGP peer waits for the BGP session to re-establish after a
   restart before deleting stale routes, with a range of 1 to 3600 seconds. The default value is 120 seconds.
+
+The following fields configure the BGP timers of the session with the peer.
+
+- `holdTimeSeconds`: The hold time proposed to the BGP peer when the session is established, i.e. how long the peer
+  should wait without receiving a KEEPALIVE or an UPDATE message from the Node before tearing the session down. The
+  effective hold time is the smaller of the two values proposed by the two BGP speakers. The range is 3 to 65535
+  seconds. The default value is 90 seconds.
+- `keepaliveIntervalSeconds`: The interval at which KEEPALIVE messages are sent to the BGP peer. The range is 1 to
+  65534 seconds. It must be less than `holdTimeSeconds`, otherwise the peer's hold timer can never be refreshed in
+  time; a BGPPolicy that breaks this rule is rejected. Because `holdTimeSeconds` defaults to 90 seconds, setting only
+  `keepaliveIntervalSeconds` to 90 or more is rejected as well.
+
+  This is the one timer with no default value. When it is left unset, the BGP process derives the interval from the
+  effective hold time, taking one third of it, so the interval follows whatever hold time the two speakers negotiate.
+  Lowering only `holdTimeSeconds` therefore speeds up the KEEPALIVEs to match, which a fixed default would prevent.
+- `connectRetrySeconds`: How long to wait before retrying to connect to the BGP peer after a failed connection attempt.
+  The range is 2 to 65535 seconds. The default value is 120 seconds.
+- `idleHoldTimeAfterResetSeconds`: How long the session stays in the Idle state after it is reset, before a new
+  connection to the BGP peer is attempted. The range is 1 to 3600 seconds. The default value is 30 seconds.
+
+[RFC 4271](https://datatracker.ietf.org/doc/html/rfc4271#section-10) suggests a keepalive interval of one third of the
+hold time. That ratio is not enforced, because a thinner one still gives a working session; it only leaves less room
+for a burst of lost messages. See
+[Leaving room for jitter](#leaving-room-for-jitter) for how to choose the two values together.
+
+**Note**: `holdTimeSeconds` and `keepaliveIntervalSeconds` are negotiated when the BGP session is established, so
+changing either of them on an existing peer makes the antrea-agent tear the session down and re-establish it, which
+briefly interrupts the advertisements to that peer. The other timers and the graceful restart fields are applied
+without interrupting an established session.
+
+See example [Tune the BGP timers for faster failure detection](#tune-the-bgp-timers-for-faster-failure-detection).
 
 ## BGP router ID
 
@@ -264,6 +299,67 @@ spec:
       asn: 64513
       port: 179
 ```
+
+### Tune the BGP timers for faster failure detection
+
+The following BGPPolicy detects the loss of a peer after 10 seconds instead of the default 90, by sending a KEEPALIVE
+message every 3 seconds, and retries a failed connection every 5 seconds:
+
+```yaml
+apiVersion: crd.antrea.io/v1alpha1
+kind: BGPPolicy
+metadata:
+  name: example-bgp-policy-timers
+spec:
+  nodeSelector:
+    matchLabels:
+      bgp: enabled
+  localASN: 64512
+  advertisements:
+    service:
+      ipTypes: [LoadBalancerIP]
+  bgpPeers:
+    - address: 192.168.77.200
+      asn: 65001
+      holdTimeSeconds: 10
+      keepaliveIntervalSeconds: 3
+      connectRetrySeconds: 5
+      idleHoldTimeAfterResetSeconds: 5
+```
+
+Make sure the peer is configured to propose a compatible hold time: the effective hold time is the smaller of the two
+proposed values, so a peer proposing 90 seconds does not shorten its own detection time just because this Node proposes
+10.
+
+### Leaving room for jitter
+
+The peer resets its hold timer every time it receives a KEEPALIVE or an UPDATE, so what decides whether a session
+survives is not the interval on its own, but the largest gap between two messages the peer actually receives. With a
+keepalive interval of 3 seconds:
+
+| KEEPALIVEs lost in a row | Gap | Hold time 9 | Hold time 10 |
+| --- | --- | --- | --- |
+| 0 | 3s | 6s to spare | 7s to spare |
+| 1 | 6s | 3s to spare | 4s to spare |
+| 2 | 9s | exactly the deadline | 1s to spare |
+
+The BGP process sends KEEPALIVE messages on a fixed interval, with no jitter and no margin, and it expires the hold
+timer at exactly the negotiated value. So a hold time of 9 with an interval of 3 — the ratio RFC 4271 suggests — makes
+the loss of two consecutive KEEPALIVEs a race: the third is sent 9 seconds after the last one the peer received and
+arrives one network delay later, while the peer's hold timer fires at 9 seconds exactly. Scheduling delays and network
+latency only ever make a message later, never earlier, so the race is biased towards the session being torn down. A
+hold time of 10 turns it into a full second of margin, for one extra second of detection time. That is why the example
+above uses 10 and 3 rather than 9 and 3.
+
+This is not a quirk of small numbers: the default 90 and 30 has exactly the same geometry, and two consecutive missed
+KEEPALIVEs land on the deadline there too. What changes with aggressive timers is the absolute margin. At 90 and 30 a
+session survives unless 60 consecutive seconds of KEEPALIVEs are lost, whereas at 9 and 3 six seconds are enough, which
+a short CPU starvation of the antrea-agent or a brief reconvergence can produce. Short timers are exactly where jitter
+matters, so prefer a hold time slightly above three times the keepalive interval rather than exactly at it. A hold time
+of four times the interval, for example 12 and 3, survives a burst of three lost messages.
+
+Antrea only rejects a keepalive interval greater than or equal to the hold time, because such a session can never stay
+up. Everything above is guidance rather than a constraint, so a thinner ratio is accepted if your network calls for it.
 
 ## Using antctl
 

--- a/docs/bgp-policy.md
+++ b/docs/bgp-policy.md
@@ -146,23 +146,34 @@ The following fields configure the BGP timers of the session with the peer.
   time; a BGPPolicy that breaks this rule is rejected. Because `holdTimeSeconds` defaults to 90 seconds, setting only
   `keepaliveIntervalSeconds` to 90 or more is rejected as well.
 
-  This is the one timer with no default value. When it is left unset, the BGP process derives the interval from the
-  effective hold time, taking one third of it, so the interval follows whatever hold time the two speakers negotiate.
-  Lowering only `holdTimeSeconds` therefore speeds up the KEEPALIVEs to match, which a fixed default would prevent.
+  This is the one timer with no default value. When it is left unset, the BGP process derives the interval from one
+  third of `holdTimeSeconds`, so lowering only the hold time speeds up the KEEPALIVEs to match. A fixed default would
+  also be rejected by the rule above as soon as `holdTimeSeconds` was lowered below it.
+
+  The hold time is negotiated but the keepalive interval is not. Each speaker proposes a hold time in its OPEN message
+  and the smaller of the two takes effect ([RFC 4271 section 4.2](https://www.rfc-editor.org/rfc/rfc4271.html#section-4.2)).
+  The BGP process then recomputes the keepalive interval as one third of the negotiated hold time for the speaker that
+  proposed the larger value, [discarding `keepaliveIntervalSeconds` even when it is
+  set](https://github.com/osrg/gobgp/blob/v4.8.0/pkg/server/fsm.go#L690-L694). A peer proposing a smaller hold time
+  than this Node therefore also decides this Node's keepalive interval.
 - `connectRetrySeconds`: How long to wait before retrying to connect to the BGP peer after a failed connection attempt.
   The range is 2 to 65535 seconds. The default value is 120 seconds.
-- `idleHoldTimeAfterResetSeconds`: How long the session stays in the Idle state after it is reset, before a new
-  connection to the BGP peer is attempted. The range is 1 to 3600 seconds. The default value is 30 seconds.
+- `idleHoldTimeAfterResetSeconds`: How long the session stays in the Idle state before a new connection to the BGP peer
+  is attempted, after the antrea-agent itself resets the session. It does not apply to a session lost because the hold
+  timer expired or because the peer closed it, and the antrea-agent currently never resets a session on its own. The
+  range is 1 to 3600 seconds. The default value is 30 seconds.
 
 [RFC 4271](https://datatracker.ietf.org/doc/html/rfc4271#section-10) suggests a keepalive interval of one third of the
 hold time. That ratio is not enforced, because a thinner one still gives a working session; it only leaves less room
 for a burst of lost messages. See
 [Leaving room for jitter](#leaving-room-for-jitter) for how to choose the two values together.
 
-**Note**: `holdTimeSeconds` and `keepaliveIntervalSeconds` are negotiated when the BGP session is established, so
-changing either of them on an existing peer makes the antrea-agent tear the session down and re-establish it, which
-briefly interrupts the advertisements to that peer. The other timers and the graceful restart fields are applied
-without interrupting an established session.
+**Note**: `holdTimeSeconds` and `keepaliveIntervalSeconds` are fixed when the session is established, so changing
+either of them on an existing peer makes the antrea-agent tear the session down and re-establish it, which briefly
+interrupts the advertisements to that peer. `gracefulRestartEnabled` and `gracefulRestartTimeSeconds` are advertised in
+the same OPEN message, so changing them re-establishes the session as well. `connectRetrySeconds` applies only while
+the session is down, so it never interrupts an established one, and `idleHoldTimeAfterResetSeconds` is only read when a
+reset happens, so it does not interrupt one either.
 
 See example [Tune the BGP timers for faster failure detection](#tune-the-bgp-timers-for-faster-failure-detection).
 
@@ -324,7 +335,6 @@ spec:
       holdTimeSeconds: 10
       keepaliveIntervalSeconds: 3
       connectRetrySeconds: 5
-      idleHoldTimeAfterResetSeconds: 5
 ```
 
 Make sure the peer is configured to propose a compatible hold time: the effective hold time is the smaller of the two

--- a/pkg/agent/bgp/gobgp/gobgp.go
+++ b/pkg/agent/bgp/gobgp/gobgp.go
@@ -315,13 +315,47 @@ func convertPeerConfigToGoBGPPeer(peerConfig bgp.PeerConfig) (*gobgpapi.Peer, er
 			MultihopTtl: uint32(*peerConfig.MultihopTTL),
 		}
 	}
-	if peerConfig.GracefulRestartTimeSeconds != nil {
-		peer.GracefulRestart = &gobgpapi.GracefulRestart{
-			Enabled:     true,
-			RestartTime: uint32(*peerConfig.GracefulRestartTimeSeconds),
+	// Graceful restart is enabled unless it is explicitly disabled. The MpGracefulRestart capability configured for
+	// the address family above is only advertised when graceful restart is enabled for the peer, so disabling it
+	// here is enough to stop advertising the capability altogether.
+	if peerConfig.GracefulRestartEnabled == nil || *peerConfig.GracefulRestartEnabled {
+		peer.GracefulRestart = &gobgpapi.GracefulRestart{Enabled: true}
+		if peerConfig.GracefulRestartTimeSeconds != nil {
+			peer.GracefulRestart.RestartTime = uint32(*peerConfig.GracefulRestartTimeSeconds)
 		}
 	}
+	if timers := convertPeerConfigToGoBGPTimersConfig(peerConfig); timers != nil {
+		peer.Timers = &gobgpapi.Timers{Config: timers}
+	}
 	return peer, nil
+}
+
+// convertPeerConfigToGoBGPTimersConfig returns the goBGP timers configuration for the peer, or nil when no timer is
+// configured. Timers that are left unset are omitted so that the BGP process applies its own defaults: in particular,
+// an unset keepalive interval is derived from the effective hold time rather than from a fixed value.
+func convertPeerConfigToGoBGPTimersConfig(peerConfig bgp.PeerConfig) *gobgpapi.TimersConfig {
+	timers := &gobgpapi.TimersConfig{}
+	configured := false
+	if peerConfig.HoldTimeSeconds != nil {
+		timers.HoldTime = uint64(*peerConfig.HoldTimeSeconds)
+		configured = true
+	}
+	if peerConfig.KeepaliveIntervalSeconds != nil {
+		timers.KeepaliveInterval = uint64(*peerConfig.KeepaliveIntervalSeconds)
+		configured = true
+	}
+	if peerConfig.ConnectRetrySeconds != nil {
+		timers.ConnectRetry = uint64(*peerConfig.ConnectRetrySeconds)
+		configured = true
+	}
+	if peerConfig.IdleHoldTimeAfterResetSeconds != nil {
+		timers.IdleHoldTimeAfterReset = uint64(*peerConfig.IdleHoldTimeAfterResetSeconds)
+		configured = true
+	}
+	if !configured {
+		return nil
+	}
+	return timers
 }
 
 func convertGoBGPSessionStateToSessionState(s gobgpapi.PeerState_SessionState) bgp.SessionState {

--- a/pkg/agent/bgp/gobgp/gobgp.go
+++ b/pkg/agent/bgp/gobgp/gobgp.go
@@ -332,7 +332,7 @@ func convertPeerConfigToGoBGPPeer(peerConfig bgp.PeerConfig) (*gobgpapi.Peer, er
 
 // convertPeerConfigToGoBGPTimersConfig returns the goBGP timers configuration for the peer, or nil when no timer is
 // configured. Timers that are left unset are omitted so that the BGP process applies its own defaults: in particular,
-// an unset keepalive interval is derived from the effective hold time rather than from a fixed value.
+// an unset keepalive interval is derived from one third of the hold time rather than from a fixed value.
 func convertPeerConfigToGoBGPTimersConfig(peerConfig bgp.PeerConfig) *gobgpapi.TimersConfig {
 	timers := &gobgpapi.TimersConfig{}
 	configured := false

--- a/pkg/agent/bgp/gobgp/gobgp_test.go
+++ b/pkg/agent/bgp/gobgp/gobgp_test.go
@@ -154,7 +154,98 @@ func TestConvertPeerConfigToGoBGPPeer(t *testing.T) {
 	assert.Equal(t, uint32(179), peer.GetTransport().GetRemotePort())
 	assert.Equal(t, uint32(2), peer.GetEbgpMultihop().GetMultihopTtl())
 	assert.Equal(t, uint32(120), peer.GetGracefulRestart().GetRestartTime())
+	assert.True(t, peer.GetGracefulRestart().GetEnabled())
+	// No timer is configured, so the BGP process is left to apply its own defaults.
+	assert.Nil(t, peer.GetTimers())
+}
 
+func TestConvertPeerConfigToGoBGPPeerTimers(t *testing.T) {
+	tests := []struct {
+		name           string
+		peer           *v1alpha1.BGPPeer
+		expectedTimers *gobgpapi.TimersConfig
+	}{
+		{
+			name: "no timer configured",
+			peer: &v1alpha1.BGPPeer{Address: "192.168.0.1", ASN: 65000},
+		},
+		{
+			name: "all timers configured",
+			peer: &v1alpha1.BGPPeer{
+				Address:                       "192.168.0.1",
+				ASN:                           65000,
+				HoldTimeSeconds:               ptr.To(int32(30)),
+				KeepaliveIntervalSeconds:      ptr.To(int32(10)),
+				ConnectRetrySeconds:           ptr.To(int32(15)),
+				IdleHoldTimeAfterResetSeconds: ptr.To(int32(20)),
+			},
+			expectedTimers: &gobgpapi.TimersConfig{
+				HoldTime:               30,
+				KeepaliveInterval:      10,
+				ConnectRetry:           15,
+				IdleHoldTimeAfterReset: 20,
+			},
+		},
+		{
+			name: "only the hold time configured",
+			peer: &v1alpha1.BGPPeer{
+				Address:         "192.168.0.1",
+				ASN:             65000,
+				HoldTimeSeconds: ptr.To(int32(30)),
+			},
+			// The keepalive interval is left unset so that the BGP process derives it from the hold time.
+			expectedTimers: &gobgpapi.TimersConfig{HoldTime: 30},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peer, err := convertPeerConfigToGoBGPPeer(bgp.PeerConfig{BGPPeer: tt.peer})
+			require.NoError(t, err)
+			if tt.expectedTimers == nil {
+				assert.Nil(t, peer.GetTimers())
+				return
+			}
+			require.NotNil(t, peer.GetTimers())
+			assert.Equal(t, tt.expectedTimers.GetHoldTime(), peer.GetTimers().GetConfig().GetHoldTime())
+			assert.Equal(t, tt.expectedTimers.GetKeepaliveInterval(), peer.GetTimers().GetConfig().GetKeepaliveInterval())
+			assert.Equal(t, tt.expectedTimers.GetConnectRetry(), peer.GetTimers().GetConfig().GetConnectRetry())
+			assert.Equal(t, tt.expectedTimers.GetIdleHoldTimeAfterReset(), peer.GetTimers().GetConfig().GetIdleHoldTimeAfterReset())
+		})
+	}
+}
+
+func TestConvertPeerConfigToGoBGPPeerGracefulRestart(t *testing.T) {
+	tests := []struct {
+		name                string
+		peer                *v1alpha1.BGPPeer
+		expectedEnabled     bool
+		expectedRestartTime uint32
+	}{
+		{
+			name:                "enabled by default",
+			peer:                &v1alpha1.BGPPeer{Address: "192.168.0.1", ASN: 65000, GracefulRestartTimeSeconds: ptr.To(int32(120))},
+			expectedEnabled:     true,
+			expectedRestartTime: 120,
+		},
+		{
+			name:                "explicitly enabled",
+			peer:                &v1alpha1.BGPPeer{Address: "192.168.0.1", ASN: 65000, GracefulRestartEnabled: ptr.To(true), GracefulRestartTimeSeconds: ptr.To(int32(180))},
+			expectedEnabled:     true,
+			expectedRestartTime: 180,
+		},
+		{
+			name: "disabled, so the restart time is ignored",
+			peer: &v1alpha1.BGPPeer{Address: "192.168.0.1", ASN: 65000, GracefulRestartEnabled: ptr.To(false), GracefulRestartTimeSeconds: ptr.To(int32(120))},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peer, err := convertPeerConfigToGoBGPPeer(bgp.PeerConfig{BGPPeer: tt.peer})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedEnabled, peer.GetGracefulRestart().GetEnabled())
+			assert.Equal(t, tt.expectedRestartTime, peer.GetGracefulRestart().GetRestartTime())
+		})
+	}
 }
 
 func TestConvertGoBGPSessionStateToSessionState(t *testing.T) {

--- a/pkg/agent/controller/bgp/controller.go
+++ b/pkg/agent/controller/bgp/controller.go
@@ -493,6 +493,23 @@ func (c *Controller) reconcileBGPPeers(ctx context.Context, bgpPeers []v1alpha1.
 	}
 	for key := range peerToUpdateKeys {
 		peerConfig := curPeerConfigs[key]
+		// The hold time and the keepalive interval are negotiated in the OPEN messages, so an established BGP
+		// session keeps using the values agreed when it was established. Updating the peer in place would store
+		// the new values without ever applying them, so the peer is removed and re-added to force a new OPEN
+		// exchange. The other timers are read by the BGP process every time it needs them, and the graceful
+		// restart configuration is re-negotiated by the BGP process itself, so neither needs a session reset.
+		if negotiatedBGPTimersChanged(prePeerConfigs[key], peerConfig) {
+			klog.InfoS("Re-establishing the BGP session to apply the updated BGP timers", "peer", peerConfig.Address, "asn", peerConfig.ASN)
+			if err := bgpServer.RemovePeer(ctx, prePeerConfigs[key]); err != nil {
+				return err
+			}
+			delete(c.bgpPolicyState.peerConfigs, key)
+			if err := bgpServer.AddPeer(ctx, peerConfig); err != nil {
+				return err
+			}
+			c.bgpPolicyState.peerConfigs[key] = peerConfig
+			continue
+		}
 		if err := bgpServer.UpdatePeer(ctx, peerConfig); err != nil {
 			return err
 		}
@@ -507,6 +524,14 @@ func (c *Controller) reconcileBGPPeers(ctx context.Context, bgpPeers []v1alpha1.
 	}
 
 	return nil
+}
+
+// negotiatedBGPTimersChanged returns whether any of the BGP timers that are negotiated when the BGP session is
+// established have changed for a peer, in which case the session must be re-established for the new values to be
+// proposed to the peer.
+func negotiatedBGPTimersChanged(prePeerConfig, curPeerConfig bgp.PeerConfig) bool {
+	return !ptr.Equal(prePeerConfig.HoldTimeSeconds, curPeerConfig.HoldTimeSeconds) ||
+		!ptr.Equal(prePeerConfig.KeepaliveIntervalSeconds, curPeerConfig.KeepaliveIntervalSeconds)
 }
 
 func (c *Controller) reconcileBGPAdvertisements(ctx context.Context, bgpAdvertisements v1alpha1.Advertisements) error {

--- a/pkg/agent/controller/bgp/controller.go
+++ b/pkg/agent/controller/bgp/controller.go
@@ -493,11 +493,8 @@ func (c *Controller) reconcileBGPPeers(ctx context.Context, bgpPeers []v1alpha1.
 	}
 	for key := range peerToUpdateKeys {
 		peerConfig := curPeerConfigs[key]
-		// The hold time and the keepalive interval are negotiated in the OPEN messages, so an established BGP
-		// session keeps using the values agreed when it was established. Updating the peer in place would store
-		// the new values without ever applying them, so the peer is removed and re-added to force a new OPEN
-		// exchange. The other timers are read by the BGP process every time it needs them, and the graceful
-		// restart configuration is re-negotiated by the BGP process itself, so neither needs a session reset.
+		// The hold time and the keepalive interval are only proposed in the OPEN message, so the session must be
+		// re-established for a new value to take effect.
 		if negotiatedBGPTimersChanged(prePeerConfigs[key], peerConfig) {
 			klog.InfoS("Re-establishing the BGP session to apply the updated BGP timers", "peer", peerConfig.Address, "asn", peerConfig.ASN)
 			if err := bgpServer.RemovePeer(ctx, prePeerConfigs[key]); err != nil {
@@ -526,9 +523,8 @@ func (c *Controller) reconcileBGPPeers(ctx context.Context, bgpPeers []v1alpha1.
 	return nil
 }
 
-// negotiatedBGPTimersChanged returns whether any of the BGP timers that are negotiated when the BGP session is
-// established have changed for a peer, in which case the session must be re-established for the new values to be
-// proposed to the peer.
+// negotiatedBGPTimersChanged returns whether the hold time or the keepalive interval of a peer has changed. Both are
+// only proposed in the OPEN message, so the session must be re-established for a new value to take effect.
 func negotiatedBGPTimersChanged(prePeerConfig, curPeerConfig bgp.PeerConfig) bool {
 	return !ptr.Equal(prePeerConfig.HoldTimeSeconds, curPeerConfig.HoldTimeSeconds) ||
 		!ptr.Equal(prePeerConfig.KeepaliveIntervalSeconds, curPeerConfig.KeepaliveIntervalSeconds)

--- a/pkg/agent/controller/bgp/controller_test.go
+++ b/pkg/agent/controller/bgp/controller_test.go
@@ -112,6 +112,27 @@ var (
 	updatedIPv4Peer2Config = generateBGPPeerConfig(&updatedIPv4Peer2, peer2AuthPassword)
 	updatedIPv6Peer2Config = generateBGPPeerConfig(&updatedIPv6Peer2, peer2AuthPassword)
 
+	// ipv4Peer1WithNegotiatedTimers changes timers that are negotiated in the OPEN messages, so applying it
+	// requires the BGP session to be re-established.
+	ipv4Peer1WithNegotiatedTimers = func() v1alpha1.BGPPeer {
+		peer := generateBGPPeer(ipv4Peer1Addr, peer1ASN, 179, 120)
+		peer.HoldTimeSeconds = ptr.To(int32(30))
+		peer.KeepaliveIntervalSeconds = ptr.To(int32(10))
+		return peer
+	}()
+	ipv4Peer1WithNegotiatedTimersConfig = generateBGPPeerConfig(&ipv4Peer1WithNegotiatedTimers, peer1AuthPassword)
+
+	// ipv4Peer1WithOtherTimers changes only settings that the BGP process re-reads on its own, so applying it
+	// does not require the BGP session to be re-established.
+	ipv4Peer1WithOtherTimers = func() v1alpha1.BGPPeer {
+		peer := generateBGPPeer(ipv4Peer1Addr, peer1ASN, 179, 120)
+		peer.ConnectRetrySeconds = ptr.To(int32(15))
+		peer.IdleHoldTimeAfterResetSeconds = ptr.To(int32(20))
+		peer.GracefulRestartEnabled = ptr.To(false)
+		return peer
+	}()
+	ipv4Peer1WithOtherTimersConfig = generateBGPPeerConfig(&ipv4Peer1WithOtherTimers, peer1AuthPassword)
+
 	peer3ASN          = int32(65533)
 	peer3AuthPassword = "bgp-peer3" // #nosec G101
 	ipv4Peer3Addr     = "192.168.77.253"
@@ -1124,6 +1145,91 @@ func TestBGPPolicyUpdate(t *testing.T) {
 				mockBGPServer.RemovePeer(gomock.Any(), ipv6Peer1Config)
 				mockBGPServer.UpdatePeer(gomock.Any(), updatedIPv4Peer2Config)
 				mockBGPServer.UpdatePeer(gomock.Any(), updatedIPv6Peer2Config)
+			},
+		},
+		{
+			name: "Effective BGPPolicy, update the negotiated BGP timers of a BGPPeer",
+			policyToUpdate: generateBGPPolicy(bgpPolicyName1,
+				creationTimestamp,
+				nodeLabels1,
+				179,
+				65000,
+				true,
+				false,
+				true,
+				false,
+				true,
+				[]v1alpha1.BGPPeer{ipv4Peer1WithNegotiatedTimers,
+					ipv4Peer2,
+					ipv6Peer1,
+					ipv6Peer2},
+				&v1alpha1.Confederation{Identifier: 100, MemberASNs: []int32{65001}}),
+			expectedState: generateBGPPolicyState(bgpPolicyName1,
+				179,
+				65000,
+				nodeAnnotations1[types.NodeBGPRouterIDAnnotationKey],
+				[]bgp.Route{
+					clusterIPv4Route2,
+					clusterIPv6Route2,
+					loadBalancerIPv4Route,
+					loadBalancerIPv6Route,
+					podIPv4CIDRRoute,
+					podIPv6CIDRRoute,
+				},
+				[]bgp.PeerConfig{ipv4Peer1WithNegotiatedTimersConfig,
+					ipv6Peer1Config,
+					ipv4Peer2Config,
+					ipv6Peer2Config,
+				},
+				&confederationConfig{100, sets.New[uint32](uint32(65001))},
+			),
+			expectedCalls: func(mockBGPServer *bgptest.MockInterfaceMockRecorder) {
+				// The hold time and the keepalive interval are negotiated when the session is established, so
+				// the peer is removed and re-added instead of being updated in place.
+				mockBGPServer.RemovePeer(gomock.Any(), ipv4Peer1Config)
+				mockBGPServer.AddPeer(gomock.Any(), ipv4Peer1WithNegotiatedTimersConfig)
+			},
+		},
+		{
+			name: "Effective BGPPolicy, update the non-negotiated BGP timers of a BGPPeer",
+			policyToUpdate: generateBGPPolicy(bgpPolicyName1,
+				creationTimestamp,
+				nodeLabels1,
+				179,
+				65000,
+				true,
+				false,
+				true,
+				false,
+				true,
+				[]v1alpha1.BGPPeer{ipv4Peer1WithOtherTimers,
+					ipv4Peer2,
+					ipv6Peer1,
+					ipv6Peer2},
+				&v1alpha1.Confederation{Identifier: 100, MemberASNs: []int32{65001}}),
+			expectedState: generateBGPPolicyState(bgpPolicyName1,
+				179,
+				65000,
+				nodeAnnotations1[types.NodeBGPRouterIDAnnotationKey],
+				[]bgp.Route{
+					clusterIPv4Route2,
+					clusterIPv6Route2,
+					loadBalancerIPv4Route,
+					loadBalancerIPv6Route,
+					podIPv4CIDRRoute,
+					podIPv6CIDRRoute,
+				},
+				[]bgp.PeerConfig{ipv4Peer1WithOtherTimersConfig,
+					ipv6Peer1Config,
+					ipv4Peer2Config,
+					ipv6Peer2Config,
+				},
+				&confederationConfig{100, sets.New[uint32](uint32(65001))},
+			),
+			expectedCalls: func(mockBGPServer *bgptest.MockInterfaceMockRecorder) {
+				// These settings are re-read by the BGP process, so the peer is updated in place and the
+				// session is left alone.
+				mockBGPServer.UpdatePeer(gomock.Any(), ipv4Peer1WithOtherTimersConfig)
 			},
 		},
 		{

--- a/pkg/agent/controller/bgp/controller_test.go
+++ b/pkg/agent/controller/bgp/controller_test.go
@@ -112,8 +112,8 @@ var (
 	updatedIPv4Peer2Config = generateBGPPeerConfig(&updatedIPv4Peer2, peer2AuthPassword)
 	updatedIPv6Peer2Config = generateBGPPeerConfig(&updatedIPv6Peer2, peer2AuthPassword)
 
-	// ipv4Peer1WithNegotiatedTimers changes timers that are negotiated in the OPEN messages, so applying it
-	// requires the BGP session to be re-established.
+	// ipv4Peer1WithNegotiatedTimers changes the hold time and the keepalive interval, which are only proposed in the
+	// OPEN message, so applying it requires the antrea-agent to re-establish the BGP session.
 	ipv4Peer1WithNegotiatedTimers = func() v1alpha1.BGPPeer {
 		peer := generateBGPPeer(ipv4Peer1Addr, peer1ASN, 179, 120)
 		peer.HoldTimeSeconds = ptr.To(int32(30))
@@ -122,8 +122,9 @@ var (
 	}()
 	ipv4Peer1WithNegotiatedTimersConfig = generateBGPPeerConfig(&ipv4Peer1WithNegotiatedTimers, peer1AuthPassword)
 
-	// ipv4Peer1WithOtherTimers changes only settings that the BGP process re-reads on its own, so applying it
-	// does not require the BGP session to be re-established.
+	// ipv4Peer1WithOtherTimers changes only settings that the antrea-agent applies by updating the peer in place:
+	// the BGP process re-reads the timers on its own, and re-establishes the session itself when the graceful
+	// restart configuration changes.
 	ipv4Peer1WithOtherTimers = func() v1alpha1.BGPPeer {
 		peer := generateBGPPeer(ipv4Peer1Addr, peer1ASN, 179, 120)
 		peer.ConnectRetrySeconds = ptr.To(int32(15))
@@ -1184,8 +1185,8 @@ func TestBGPPolicyUpdate(t *testing.T) {
 				&confederationConfig{100, sets.New[uint32](uint32(65001))},
 			),
 			expectedCalls: func(mockBGPServer *bgptest.MockInterfaceMockRecorder) {
-				// The hold time and the keepalive interval are negotiated when the session is established, so
-				// the peer is removed and re-added instead of being updated in place.
+				// The hold time and the keepalive interval are only proposed in the OPEN message, so the peer is
+				// removed and re-added instead of being updated in place.
 				mockBGPServer.RemovePeer(gomock.Any(), ipv4Peer1Config)
 				mockBGPServer.AddPeer(gomock.Any(), ipv4Peer1WithNegotiatedTimersConfig)
 			},

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -361,20 +361,23 @@ type BGPPeer struct {
 	// suggests one third of the hold time, which is not enforced: a thinner ratio leaves less room for a burst of
 	// lost messages, but still works. The range of the value is from 1 to 65534.
 	//
-	// Unlike the other timers, this field has no default value, so that it stays unset unless it is configured
-	// explicitly. The BGP process derives an unset keepalive interval from the effective hold time, which is the
-	// smaller of the values proposed by the two BGP speakers, so the derived interval follows whatever hold time is
-	// negotiated. A fixed default would replace that derivation with a constant, and a peer that only lowered
-	// holdTimeSeconds would keep sending KEEPALIVEs too slowly to hold the session up.
+	// Unlike the other timers, this field has no default value. When it is unset, the BGP process derives the
+	// interval from one third of holdTimeSeconds, so that lowering only the hold time also speeds up the
+	// KEEPALIVEs. A fixed default would also be rejected by the validation rule as soon as holdTimeSeconds was
+	// lowered below it. The hold time is negotiated but the keepalive interval is not: when the peer proposes a
+	// smaller hold time than this Node, the BGP process recomputes the interval as one third of the negotiated
+	// hold time, discarding this field even when it is set.
 	KeepaliveIntervalSeconds *int32 `json:"keepaliveIntervalSeconds,omitempty"`
 
 	// ConnectRetrySeconds specifies how long to wait before retrying to connect to the BGP peer after a failed
 	// connection attempt. The range of the value is from 2 to 65535, and the default value is 120.
 	ConnectRetrySeconds *int32 `json:"connectRetrySeconds,omitempty"`
 
-	// IdleHoldTimeAfterResetSeconds specifies how long the BGP session stays in the Idle state after it is reset,
-	// before a new connection to the BGP peer is attempted. The range of the value is from 1 to 3600, and the
-	// default value is 30.
+	// IdleHoldTimeAfterResetSeconds specifies how long the BGP session stays in the Idle state before a new
+	// connection to the BGP peer is attempted, after the antrea-agent itself resets the session. It does not apply
+	// to a session that is lost because the hold timer expired or because the peer closed it, and the antrea-agent
+	// currently never resets a session on its own. The range of the value is from 1 to 3600, and the default value
+	// is 30.
 	IdleHoldTimeAfterResetSeconds *int32 `json:"idleHoldTimeAfterResetSeconds,omitempty"`
 }
 

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -341,9 +341,41 @@ type BGPPeer struct {
 	// and the default value is 1.
 	MultihopTTL *int32 `json:"multihopTTL,omitempty"`
 
+	// GracefulRestartEnabled specifies whether to advertise the BGP graceful restart capability to the BGP peer. When
+	// it is disabled, gracefulRestartTimeSeconds has no effect. The default value is true.
+	GracefulRestartEnabled *bool `json:"gracefulRestartEnabled,omitempty"`
+
 	// GracefulRestartTimeSeconds specifies how long the BGP peer would wait for the BGP session to re-establish after
 	// a restart before deleting stale routes. The range of the value is from 1 to 3600, and the default value is 120.
 	GracefulRestartTimeSeconds *int32 `json:"gracefulRestartTimeSeconds,omitempty"`
+
+	// HoldTimeSeconds specifies the hold time proposed to the BGP peer when the BGP session is established, i.e. how
+	// long the peer should wait without receiving a KEEPALIVE or an UPDATE message from this Node before tearing the
+	// session down. The effective hold time is the smaller of the two values proposed by the two BGP speakers. It
+	// must be greater than keepaliveIntervalSeconds. The range of the value is from 3 to 65535, and the default
+	// value is 90.
+	HoldTimeSeconds *int32 `json:"holdTimeSeconds,omitempty"`
+
+	// KeepaliveIntervalSeconds specifies the interval at which KEEPALIVE messages are sent to the BGP peer. It must
+	// be less than holdTimeSeconds, otherwise the peer's hold timer can never be refreshed in time. RFC 4271
+	// suggests one third of the hold time, which is not enforced: a thinner ratio leaves less room for a burst of
+	// lost messages, but still works. The range of the value is from 1 to 65534.
+	//
+	// Unlike the other timers, this field has no default value, so that it stays unset unless it is configured
+	// explicitly. The BGP process derives an unset keepalive interval from the effective hold time, which is the
+	// smaller of the values proposed by the two BGP speakers, so the derived interval follows whatever hold time is
+	// negotiated. A fixed default would replace that derivation with a constant, and a peer that only lowered
+	// holdTimeSeconds would keep sending KEEPALIVEs too slowly to hold the session up.
+	KeepaliveIntervalSeconds *int32 `json:"keepaliveIntervalSeconds,omitempty"`
+
+	// ConnectRetrySeconds specifies how long to wait before retrying to connect to the BGP peer after a failed
+	// connection attempt. The range of the value is from 2 to 65535, and the default value is 120.
+	ConnectRetrySeconds *int32 `json:"connectRetrySeconds,omitempty"`
+
+	// IdleHoldTimeAfterResetSeconds specifies how long the BGP session stays in the Idle state after it is reset,
+	// before a new connection to the BGP peer is attempted. The range of the value is from 1 to 3600, and the
+	// default value is 30.
+	IdleHoldTimeAfterResetSeconds *int32 `json:"idleHoldTimeAfterResetSeconds,omitempty"`
 }
 
 type PodReference struct {

--- a/pkg/apis/crd/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/crd/v1alpha1/zz_generated.deepcopy.go
@@ -152,8 +152,33 @@ func (in *BGPPeer) DeepCopyInto(out *BGPPeer) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.GracefulRestartEnabled != nil {
+		in, out := &in.GracefulRestartEnabled, &out.GracefulRestartEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.GracefulRestartTimeSeconds != nil {
 		in, out := &in.GracefulRestartTimeSeconds, &out.GracefulRestartTimeSeconds
+		*out = new(int32)
+		**out = **in
+	}
+	if in.HoldTimeSeconds != nil {
+		in, out := &in.HoldTimeSeconds, &out.HoldTimeSeconds
+		*out = new(int32)
+		**out = **in
+	}
+	if in.KeepaliveIntervalSeconds != nil {
+		in, out := &in.KeepaliveIntervalSeconds, &out.KeepaliveIntervalSeconds
+		*out = new(int32)
+		**out = **in
+	}
+	if in.ConnectRetrySeconds != nil {
+		in, out := &in.ConnectRetrySeconds, &out.ConnectRetrySeconds
+		*out = new(int32)
+		**out = **in
+	}
+	if in.IdleHoldTimeAfterResetSeconds != nil {
+		in, out := &in.IdleHoldTimeAfterResetSeconds, &out.IdleHoldTimeAfterResetSeconds
 		*out = new(int32)
 		**out = **in
 	}


### PR DESCRIPTION

Fixes #8312.

## What this changes

`BGPPolicy` could not set the timers of a BGP session. The BGP process used fixed values, so a
Node needed up to 90 seconds to notice a dead peer, and the peer needed up to 90 seconds to
notice a dead Node. The peer kept forwarding traffic towards broken routes for that whole window.
The graceful restart capability was also advertised unconditionally, with no way to turn it off.

This adds five optional fields to each entry of `spec.bgpPeers`.

| Field | Range | Default |
| --- | --- | --- |
| `holdTimeSeconds` | 3 to 65535 | 90 |
| `keepaliveIntervalSeconds` | 1 to 65534 | none, see below |
| `connectRetrySeconds` | 2 to 65535 | 120 |
| `idleHoldTimeAfterResetSeconds` | 1 to 3600 | 30 |
| `gracefulRestartEnabled` | boolean | `true` |

Every default matches what the BGP process already did, so an existing `BGPPolicy` behaves
exactly as before.

## Why `keepaliveIntervalSeconds` has no default

The BGP process derives an unset keepalive interval from the *effective* hold time, which is the
smaller of the two values the two speakers propose. The derived interval therefore tracks
whatever hold time is negotiated.

A fixed default would replace that derivation with a constant. Someone who lowered only
`holdTimeSeconds` would keep sending KEEPALIVE messages at the old rate, too slowly to hold the
session up. Leaving the field unset is the only way to keep the derivation, so it is the one
timer here without a default. Both the CRD and the Go type carry a comment saying so.

## Validation

One CEL rule enforces the single hard floor:

```text
!has(self.keepaliveIntervalSeconds) || self.keepaliveIntervalSeconds < self.holdTimeSeconds
```

A keepalive interval at or above the hold time can never refresh the peer's hold timer in time,
so such a session can never stay up. Because `holdTimeSeconds` is defaulted, it is always set by
the time the rule runs, and setting only `keepaliveIntervalSeconds` to 90 or more is rejected too.

RFC 4271 suggests a keepalive interval of one third of the hold time. The rule does not enforce
that ratio. A thinner ratio still gives a working session, it just leaves less room for a burst
of lost messages, so `docs/bgp-policy.md` carries that as guidance instead.

## Applying a change to a running session

BGP negotiates the hold time and the keepalive interval in the OPEN messages, so an established
session keeps using the values agreed when it started. Updating the peer in place would store the
new values without ever applying them, and the configuration would silently disagree with the
live session.

`negotiatedBGPTimersChanged` therefore reports whether either of those two fields changed. If one
did, the agent removes and re-adds the peer to force a new OPEN exchange, which briefly
interrupts advertisements to that peer and is logged. The other three timers are read by the BGP
process whenever it needs them, and the graceful restart configuration is renegotiated by the BGP
process itself, so neither needs a session reset.

## Graceful restart

`gracefulRestartEnabled` gates the whole `GracefulRestart` block for the peer. The
`MpGracefulRestart` capability configured on the address family is only advertised when graceful
restart is enabled for the peer, so gating that one block stops the capability being offered at
all. The field defaults to `true`, which is the current behaviour.

## Files changed

API and CRD:

- `pkg/apis/crd/v1alpha1/types.go`, `pkg/apis/crd/v1alpha1/zz_generated.deepcopy.go`
- `build/charts/antrea/crds/bgppolicy.yaml`
- `build/yamls/antrea.yml`, `antrea-aks.yml`, `antrea-crds.yml`, `antrea-eks.yml`,
  `antrea-gke.yml`, `antrea-ipsec.yml`

Agent:

- `pkg/agent/bgp/gobgp/gobgp.go`, `pkg/agent/bgp/gobgp/gobgp_test.go`
- `pkg/agent/controller/bgp/controller.go`, `pkg/agent/controller/bgp/controller_test.go`

Documentation:

- `docs/bgp-policy.md`

## Testing

### Unit tests

Unit tests in `gobgp_test.go` cover the conversion to the BGP process configuration with no timer
set, all timers set, and only the hold time set. They also cover graceful restart when it is
enabled by default, enabled explicitly, and disabled.

Unit tests in `controller_test.go` cover both update paths: a changed negotiated timer must remove
and re-add the peer, and a changed non-negotiated timer must update it in place.

### Verified against a live FRR peer

Three runs against the same FRR route reflector, taken from `show ip bgp neighbors` on the FRR side:
Antrea 2.7.0 without the change, then the same cluster with the change and every timer at its
default value, then with custom timers and graceful restart turned off.

| Observed on the FRR peer | 2.7.0, no change | Defaults | Custom |
| --- | --- | --- | --- |
| Negotiated hold time | 90 | 90 | **10** |
| Negotiated keepalive interval | 30 | 30 | **3** |
| Graceful restart capability | advertised and received | advertised and received | **advertised only** |
| Remote GR mode | Restart | Restart | **Disable** |
| Received restart time | 120 | 120 | **0** |
| Per-family GR state | present | present | **absent** |

The KEEPALIVE counters confirm the negotiated interval is the rate actually used, rather than a
value that was merely agreed:

| Run | Session uptime | KEEPALIVEs sent | Uptime ├╖ count | Negotiated interval |
| --- | --- | --- | --- | --- |
| 2.7.0, no change | 14:08:46 (50926 s) | 1698 | 30.0 s | 30 s |
| Custom | 00:01:11 (71 s) | 24 | 3.0 s | 3 s |

<details>
<summary><b>Run 1 - Antrea 2.7.0, no change</b></summary>

The peer spec has no timer fields, because they do not exist yet:

```yaml
bgpPeers:
  - address: 10.1.1.11
    asn: 64512
    gracefulRestartTimeSeconds: 120
    multihopTTL: 1
    port: 179
```

```text
  BGP state = Established, up for 14:08:46
  Hold time is 90, keepalive interval is 30 seconds
  Neighbor capabilities:
    Graceful Restart Capability: advertised and received
      Remote Restart timer is 120 seconds
      Address families by peer:
        IPv4 Unicast(not preserved)
  Graceful restart information:
    Local GR Mode: Helper*
    Remote GR Mode: Restart
    Timers:
      Configured Restart Time(sec): 120
      Received Restart Time(sec): 120
  Message statistics:
                         Sent       Rcvd
    Keepalives:          1698       1698
BGP Connect Retry Timer in Seconds: 120
```

</details>

<details>
<summary><b>Run 2 - with the change, every timer set explicitly to its default value</b></summary>

```yaml
bgpPeers:
  - address: 10.1.1.11
    asn: 64512
    connectRetrySeconds: 120
    gracefulRestartEnabled: true
    gracefulRestartTimeSeconds: 120
    holdTimeSeconds: 90
    idleHoldTimeAfterResetSeconds: 30
    keepaliveIntervalSeconds: 30
    multihopTTL: 1
    port: 179
```

```text
  BGP state = Established, up for 00:00:37
  Hold time is 90, keepalive interval is 30 seconds
  Neighbor capabilities:
    Graceful Restart Capability: advertised and received
      Remote Restart timer is 120 seconds
      Address families by peer:
        IPv4 Unicast(not preserved)
  Graceful restart information:
    Local GR Mode: Helper*
    Remote GR Mode: Restart
    Timers:
      Configured Restart Time(sec): 120
      Received Restart Time(sec): 120
  Message statistics:
                         Sent       Rcvd
    Keepalives:             2          2
BGP Connect Retry Timer in Seconds: 120
```

Every value the peer reports is identical to run 1, which is the compatibility claim above,
measured rather than asserted.

Each field was written out here rather than left to the API server. So this run shows the chosen
default *values* are the right ones; it does not exercise defaulting itself. The keepalive
interval is one of those written-out values, so the BGP process never derived it from the hold time.

</details>

<details>
<summary><b>Run 3 - with the change, custom timers and graceful restart off</b></summary>

```yaml
bgpPeers:
  - address: 10.1.1.11
    asn: 64512
    connectRetrySeconds: 90
    gracefulRestartEnabled: false
    gracefulRestartTimeSeconds: 120
    holdTimeSeconds: 10
    idleHoldTimeAfterResetSeconds: 45
    keepaliveIntervalSeconds: 3
    multihopTTL: 1
    port: 179
```

```text
  BGP state = Established, up for 00:01:11
  Hold time is 10, keepalive interval is 3 seconds
  Neighbor capabilities:
    Graceful Restart Capability: advertised
  Graceful restart information:
    Local GR Mode: Helper*
    Remote GR Mode: Disable
    Timers:
      Configured Restart Time(sec): 120
      Received Restart Time(sec): 0
  Message statistics:
                         Sent       Rcvd
    Keepalives:            24         24
BGP Connect Retry Timer in Seconds: 120
```

Three things to note.

The capability line reads `advertised` alone, where the first two runs read `advertised and
received`. FRR still offers graceful restart, but no longer receives it from Antrea, which is
`gracefulRestartEnabled: false` taking effect. `Remote GR Mode` drops to `Disable`, the received
restart time drops to 0, and the per-family graceful restart block disappears.

FRR derives its own keepalive interval from one third of the negotiated hold time, so it
independently arrives at 3 seconds for a hold time of 10. This is the same derivation that makes
a fixed default for `keepaliveIntervalSeconds` the wrong choice.

`10` and `3` were chosen over `9` and `3` on the jitter guidance in `docs/bgp-policy.md`.

</details>

### What these runs do not cover

`connectRetrySeconds` and `idleHoldTimeAfterResetSeconds` are local timers. BGP does not negotiate
them, so a peer cannot observe them. FRR reports `BGP Connect Retry Timer in Seconds: 120` in all
three runs because that is FRR's own value, not the one Antrea is using ΓÇö the unchanged 120 in
run 3 is expected, not a failure. Both fields are covered by the unit tests instead.

All three runs set the timers explicitly, so none of them leaves `keepaliveIntervalSeconds` unset
and lets the BGP process derive it. That path is covered by the "only the hold time configured"
case in `gobgp_test.go`, which asserts the keepalive interval is omitted from the BGP process
configuration, rather than by a live session.

## Compatibility

No field is required, and every default matches the previous behaviour, so upgrading changes
nothing for an existing `BGPPolicy`.

An agent restart rebuilds its BGP state from scratch, so the defaults materialising on existing
objects during an upgrade does not cause an extra session reset.

## AI assistance

Claude Opus 5, running in Claude Code, co-authored this change, and the commit carries a matching
`Co-authored-by` trailer. I reviewed the design and the code, and the verification recorded above
was run against a real cluster and a real FRR peer.

## Release note

```text
The BGPPolicy bgpPeers entries now accept holdTimeSeconds, keepaliveIntervalSeconds,
connectRetrySeconds and idleHoldTimeAfterResetSeconds to tune the BGP session timers, and
gracefulRestartEnabled to stop advertising the graceful restart capability.
```

---

