### PR TITLE
Fix CPU hot loop in NDP and ARP responders

### DIFF
--- a/pkg/agent/ipassigner/responder/arp_responder.go
+++ b/pkg/agent/ipassigner/responder/arp_responder.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
 	"sync"
+	"syscall"
 	"time"
 
 	"antrea.io/arp"
@@ -75,7 +77,8 @@ func (r *arpResponder) handleARPRequest(client *arp.Client, iface *net.Interface
 		return nil
 	}
 	if err := client.Reply(pkt, iface.HardwareAddr, pkt.TargetIP); err != nil {
-		return fmt.Errorf("failed to reply ARP packet for IP %s: %v", pkt.TargetIP, err)
+		klog.ErrorS(err, "Failed to reply ARP packet", "ip", pkt.TargetIP, "interface", r.linkName)
+		return nil
 	}
 	klog.V(4).InfoS("Sent ARP response", "ip", pkt.TargetIP, "interface", r.linkName)
 	return nil
@@ -105,8 +108,10 @@ func (r *arpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 	}
 	defer client.Close()
 
-	stopWaitCh := make(chan struct{})
-	defer close(stopWaitCh)
+	// readLoopDone notifies the background link watcher goroutine to exit
+	// when the read loop terminates.
+	readLoopDone := make(chan struct{})
+	defer close(readLoopDone)
 
 	klog.InfoS("ARP responder started", "interface", transportInterface.Name, "index", transportInterface.Index)
 	defer klog.InfoS("ARP responder stopped", "interface", transportInterface.Name, "index", transportInterface.Index)
@@ -117,7 +122,7 @@ func (r *arpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 			case <-stopCh:
 				client.Close()
 				return
-			case <-stopWaitCh:
+			case <-readLoopDone:
 				return
 			case <-r.linkEventCh:
 				newTransportInterface, err := net.InterfaceByName(r.linkName)
@@ -136,13 +141,19 @@ func (r *arpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 	}()
 
 	for {
-		if err := r.handleARPRequest(client, transportInterface); err != nil {
-			if errors.Is(err, net.ErrClosed) {
-				return
-			}
-			klog.ErrorS(err, "Failed to handle ARP request", "deviceName", r.linkName)
+		err := r.handleARPRequest(client, transportInterface)
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, net.ErrClosed) || errors.Is(err, os.ErrClosed) || errors.Is(err, syscall.EBADF) {
 			return
 		}
+		var opErr *net.OpError
+		if errors.As(err, &opErr) {
+			klog.ErrorS(err, "Socket error in ARP responder, restarting", "deviceName", r.linkName)
+			return
+		}
+		klog.V(2).InfoS("Skipping invalid ARP packet", "err", err, "deviceName", r.linkName)
 	}
 }
 

--- a/pkg/agent/ipassigner/responder/arp_responder.go
+++ b/pkg/agent/ipassigner/responder/arp_responder.go
@@ -15,6 +15,7 @@
 package responder
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -102,18 +103,21 @@ func (r *arpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 		klog.ErrorS(err, "Failed to dial ARP client", "deviceName", r.linkName)
 		return
 	}
-	reloadCh := make(chan struct{})
+	defer client.Close()
+
+	stopWaitCh := make(chan struct{})
+	defer close(stopWaitCh)
 
 	klog.InfoS("ARP responder started", "interface", transportInterface.Name, "index", transportInterface.Index)
 	defer klog.InfoS("ARP responder stopped", "interface", transportInterface.Name, "index", transportInterface.Index)
 
 	go func() {
-		defer client.Close()
-		defer close(reloadCh)
-
 		for {
 			select {
 			case <-stopCh:
+				client.Close()
+				return
+			case <-stopWaitCh:
 				return
 			case <-r.linkEventCh:
 				newTransportInterface, err := net.InterfaceByName(r.linkName)
@@ -123,6 +127,7 @@ func (r *arpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 				}
 				if transportInterface.Index != newTransportInterface.Index {
 					klog.InfoS("Transport interface index changed, restarting ARP responder", "name", transportInterface.Name, "oldIndex", transportInterface.Index, "newIndex", newTransportInterface.Index)
+					client.Close()
 					return
 				}
 				klog.V(4).InfoS("Transport interface not changed")
@@ -131,14 +136,12 @@ func (r *arpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 	}()
 
 	for {
-		select {
-		case <-reloadCh:
-			return
-		default:
-			err := r.handleARPRequest(client, transportInterface)
-			if err != nil {
-				klog.ErrorS(err, "Failed to handle ARP request", "deviceName", r.linkName)
+		if err := r.handleARPRequest(client, transportInterface); err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
 			}
+			klog.ErrorS(err, "Failed to handle ARP request", "deviceName", r.linkName)
+			return
 		}
 	}
 }

--- a/pkg/agent/ipassigner/responder/arp_responder.go
+++ b/pkg/agent/ipassigner/responder/arp_responder.go
@@ -33,12 +33,17 @@ import (
 type arpResponder struct {
 	once        sync.Once
 	linkName    string
+	dial        func(*net.Interface) (*arp.Client, error)
 	assignedIPs sets.Set[netip.Addr]
 	mutex       sync.Mutex
 	linkEventCh chan struct{}
 }
 
 var _ Responder = (*arpResponder)(nil)
+
+func defaultARPDial(transportInterface *net.Interface) (*arp.Client, error) {
+	return arp.Dial(transportInterface)
+}
 
 func (r *arpResponder) InterfaceName() string {
 	return r.linkName
@@ -101,7 +106,11 @@ func (r *arpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 		klog.ErrorS(err, "Failed to get interface by name", "deviceName", r.linkName)
 		return
 	}
-	client, err := arp.Dial(transportInterface)
+	dial := r.dial
+	if dial == nil {
+		dial = defaultARPDial
+	}
+	client, err := dial(transportInterface)
 	if err != nil {
 		klog.ErrorS(err, "Failed to dial ARP client", "deviceName", r.linkName)
 		return

--- a/pkg/agent/ipassigner/responder/arp_responder_test.go
+++ b/pkg/agent/ipassigner/responder/arp_responder_test.go
@@ -150,6 +150,37 @@ func TestARPResponder_HandleARPRequest(t *testing.T) {
 	}
 }
 
+func TestARPResponder_HandleARPRequest_MalformedPacket(t *testing.T) {
+	loopbackIdx, err := loopbackIndex()
+	if err != nil {
+		t.Skipf("Skipping test: loopback interface not available: %v", err)
+	}
+
+	localHWAddr := net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}
+	remoteHWAddr := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	localIface := newFakeNetworkInterface(loopbackIdx, localHWAddr)
+	localAddr := &packet.Addr{HardwareAddr: localHWAddr}
+	remoteAddr := &packet.Addr{HardwareAddr: remoteHWAddr}
+
+	localConn, remoteConn := nettest.PacketConnPipe(localAddr, remoteAddr, 1)
+	localARPClient, err := newFakeARPClient(localIface, localConn)
+	require.NoError(t, err)
+
+	// Send truncated/malformed bytes on wire to simulate packet corruption
+	truncatedFrame := []byte{0x00, 0x01, 0x08, 0x00}
+	_, err = remoteConn.WriteTo(truncatedFrame, localAddr)
+	require.NoError(t, err)
+
+	r := arpResponder{
+		linkName:    localIface.Name,
+		assignedIPs: sets.New[netip.Addr](),
+	}
+
+	// Malformed packet returns error from client.Read, which outer loop catches and skips
+	err = r.handleARPRequest(localARPClient, localIface)
+	assert.Error(t, err)
+}
+
 func Test_arpResponder_addIP(t *testing.T) {
 	hwAddr := []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
 	iface := newFakeNetworkInterface(1, hwAddr)

--- a/pkg/agent/ipassigner/responder/arp_responder_test.go
+++ b/pkg/agent/ipassigner/responder/arp_responder_test.go
@@ -15,6 +15,7 @@
 package responder
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -178,7 +179,9 @@ func TestARPResponder_HandleARPRequest_MalformedPacket(t *testing.T) {
 
 	// Malformed packet returns error from client.Read, which outer loop catches and skips
 	err = r.handleARPRequest(localARPClient, localIface)
-	assert.Error(t, err)
+	require.Error(t, err)
+	var opErr *net.OpError
+	assert.False(t, errors.As(err, &opErr), "malformed frame must not be classified as a socket error (*net.OpError)")
 }
 
 func Test_arpResponder_addIP(t *testing.T) {

--- a/pkg/agent/ipassigner/responder/arp_responder_test.go
+++ b/pkg/agent/ipassigner/responder/arp_responder_test.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"sync"
 	"testing"
+	"time"
 
 	"antrea.io/arp"
 	"antrea.io/ethernet"
@@ -31,7 +33,19 @@ import (
 	"antrea.io/antrea/v2/pkg/agent/util/nettest"
 )
 
-func newFakeARPClient(iface *net.Interface, conn *nettest.PacketConn) (*arp.Client, error) {
+type idempotentPacketConn struct {
+	*nettest.PacketConn
+	closeOnce sync.Once
+}
+
+func (c *idempotentPacketConn) Close() error {
+	c.closeOnce.Do(func() {
+		_ = c.PacketConn.Close()
+	})
+	return nil
+}
+
+func newFakeARPClient(iface *net.Interface, conn net.PacketConn) (*arp.Client, error) {
 	return arp.New(iface, conn)
 }
 
@@ -40,16 +54,11 @@ func newFakeARPClient(iface *net.Interface, conn *nettest.PacketConn) (*arp.Clie
 // at the loopback index makes Addrs() return a valid IPv4 address, satisfying
 // arp.New (since commit 6706a29) without borrowing an entirely separate struct.
 func loopbackIndex() (int, error) {
-	ifaces, err := net.Interfaces()
+	iface, err := loopbackInterface()
 	if err != nil {
-		return 0, fmt.Errorf("failed to list network interfaces: %w", err)
+		return 0, err
 	}
-	for _, iface := range ifaces {
-		if iface.Flags&net.FlagLoopback != 0 {
-			return iface.Index, nil
-		}
-	}
-	return 0, fmt.Errorf("no loopback interface found")
+	return iface.Index, nil
 }
 
 // newFakeNetworkInterface creates a fake net.Interface with the given index and
@@ -278,4 +287,113 @@ func Test_arpResponder_removeIP(t *testing.T) {
 			assert.Equal(t, tt.expectedAssignedIPs, r.assignedIPs)
 		})
 	}
+}
+
+func testInterface() (*net.Interface, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list network interfaces: %w", err)
+	}
+	for _, iface := range ifaces {
+		if len(iface.HardwareAddr) == 6 {
+			addrs, err := iface.Addrs()
+			if err == nil {
+				for _, addr := range addrs {
+					if ipNet, ok := addr.(*net.IPNet); ok && ipNet.IP.To4() != nil {
+						return &iface, nil
+					}
+				}
+			}
+		}
+	}
+	for _, iface := range ifaces {
+		if len(iface.HardwareAddr) == 6 {
+			return &iface, nil
+		}
+	}
+	return loopbackInterface()
+}
+
+func Test_arpResponder_dialAndHandleRequests(t *testing.T) {
+	testIface, err := testInterface()
+	if err != nil {
+		t.Skipf("Skipping test: no network interface available: %v", err)
+	}
+	if len(testIface.HardwareAddr) != 6 {
+		t.Skipf("Skipping test: interface %s does not have a 6-byte MAC address: %v", testIface.Name, testIface.HardwareAddr)
+	}
+
+	localHWAddr := testIface.HardwareAddr
+	remoteHWAddr := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	localIPAddr := netip.MustParseAddr("192.168.10.1")
+	remoteIPAddr := netip.MustParseAddr("192.168.10.2")
+
+	localIface := newFakeNetworkInterface(testIface.Index, localHWAddr)
+	localIface.Name = testIface.Name
+	remoteIface := newFakeNetworkInterface(testIface.Index, remoteHWAddr)
+	localAddr := &packet.Addr{HardwareAddr: localHWAddr}
+	remoteAddr := &packet.Addr{HardwareAddr: remoteHWAddr}
+
+	pipeLocal, pipeRemote := nettest.PacketConnPipe(localAddr, remoteAddr, 5)
+	localConn := &idempotentPacketConn{PacketConn: pipeLocal}
+	remoteConn := &idempotentPacketConn{PacketConn: pipeRemote}
+
+	localARPClient, err := newFakeARPClient(localIface, localConn)
+	require.NoError(t, err)
+	remoteARPClient, err := newFakeARPClient(remoteIface, remoteConn)
+	require.NoError(t, err)
+
+	dialCalled := false
+	r := &arpResponder{
+		linkName:    testIface.Name,
+		assignedIPs: sets.New[netip.Addr](localIPAddr),
+		linkEventCh: make(chan struct{}, 1),
+		dial: func(_ *net.Interface) (*arp.Client, error) {
+			dialCalled = true
+			return localARPClient, nil
+		},
+	}
+
+	// 1. Send a truncated/malformed frame first. The loop should handle the error and continue.
+	truncatedFrame := []byte{0x00, 0x01, 0x08, 0x00}
+	_, err = remoteConn.WriteTo(truncatedFrame, localAddr)
+	require.NoError(t, err)
+
+	// 2. Send a valid ARP request afterwards.
+	request, err := arp.NewPacket(arp.OperationRequest, remoteHWAddr, remoteIPAddr, ethernet.Broadcast, localIPAddr)
+	require.NoError(t, err)
+	require.NoError(t, remoteARPClient.WriteTo(request, localAddr.HardwareAddr))
+
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		r.dialAndHandleRequests(stopCh)
+	}()
+
+	// Verify that the valid ARP request was processed despite the preceding malformed packet.
+	expectedReply, err := arp.NewPacket(arp.OperationReply, localHWAddr, localIPAddr, remoteHWAddr, remoteIPAddr)
+	require.NoError(t, err)
+	expectedBytes := getEthernetForARPPacket(expectedReply, remoteHWAddr)
+
+	require.Eventually(t, func() bool {
+		replyB, addr, err := remoteConn.Receive()
+		if err != nil {
+			return false
+		}
+		return assert.ObjectsAreEqual(remoteAddr, addr) && assert.ObjectsAreEqual(expectedBytes, replyB)
+	}, 5*time.Second, 50*time.Millisecond, "Expected ARP reply to be sent even after encountering a malformed frame")
+
+	// 3. Trigger socket closure error to terminate dialAndHandleRequests.
+	// Closing localConn causes client.Read() to fail with *net.OpError, triggering loop exit.
+	_ = localConn.Close()
+
+	select {
+	case <-doneCh:
+		// Succeeded: loop exited on socket error without hanging or panicking.
+	case <-time.After(5 * time.Second):
+		t.Fatalf("dialAndHandleRequests did not exit after socket closure")
+	}
+
+	assert.True(t, dialCalled, "dial seam must be invoked")
 }

--- a/pkg/agent/ipassigner/responder/factory.go
+++ b/pkg/agent/ipassigner/responder/factory.go
@@ -62,6 +62,7 @@ func NewNDPResponder(transportInterfaceName string, linkMonitor linkmonitor.Inte
 		multicastGroups: make(map[netip.Addr]int),
 		assignedIPs:     sets.New[netip.Addr](),
 		linkEventCh:     make(chan struct{}, 1),
+		dial:            defaultNDPDial,
 	}
 	if linkMonitor != nil {
 		linkMonitor.AddEventHandler(n.onLinkUpdate, transportInterfaceName)

--- a/pkg/agent/ipassigner/responder/factory.go
+++ b/pkg/agent/ipassigner/responder/factory.go
@@ -41,6 +41,7 @@ func NewARPResponder(transportInterfaceName string, linkMonitor linkmonitor.Inte
 		linkName:    transportInterfaceName,
 		assignedIPs: sets.New[netip.Addr](),
 		linkEventCh: make(chan struct{}, 1),
+		dial:        defaultARPDial,
 	}
 	if linkMonitor != nil {
 		linkMonitor.AddEventHandler(a.onLinkUpdate, transportInterfaceName)

--- a/pkg/agent/ipassigner/responder/ndp_responder.go
+++ b/pkg/agent/ipassigner/responder/ndp_responder.go
@@ -47,6 +47,7 @@ type ndpResponder struct {
 	once            sync.Once
 	linkName        string
 	conn            ndpConn
+	dial            func(*net.Interface) (ndpConn, error)
 	linkEventCh     chan struct{}
 	assignedIPs     sets.Set[netip.Addr]
 	multicastGroups map[netip.Addr]int
@@ -54,6 +55,11 @@ type ndpResponder struct {
 }
 
 var _ Responder = (*ndpResponder)(nil)
+
+func defaultNDPDial(transportInterface *net.Interface) (ndpConn, error) {
+	conn, _, err := ndp.Listen(transportInterface, ndp.LinkLocal)
+	return conn, err
+}
 
 func parseIPv6SolicitedNodeMulticastAddress(ip netip.Addr) netip.Addr {
 	target := ip.As16()
@@ -136,7 +142,11 @@ func (r *ndpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 	// which may take time to allow the address to be used for socket binding. EADDRNOTAVAIL (bind: cannot assign requested address)
 	// may be returned for such cases.
 	klog.InfoS("Binding NDP responder on interface", "interface", r.linkName)
-	conn, _, err := ndp.Listen(transportInterface, ndp.LinkLocal)
+	dial := r.dial
+	if dial == nil {
+		dial = defaultNDPDial
+	}
+	conn, err := dial(transportInterface)
 	if err != nil {
 		klog.ErrorS(err, "Failed to create NDP responder", "interface", r.linkName)
 		return

--- a/pkg/agent/ipassigner/responder/ndp_responder.go
+++ b/pkg/agent/ipassigner/responder/ndp_responder.go
@@ -15,6 +15,7 @@
 package responder
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -137,6 +138,7 @@ func (r *ndpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 		klog.ErrorS(err, "Failed to create NDP responder", "interface", r.linkName)
 		return
 	}
+	defer conn.Close()
 
 	r.mutex.Lock()
 	r.conn = conn
@@ -146,19 +148,25 @@ func (r *ndpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 		}
 	}
 	r.mutex.Unlock()
+	defer func() {
+		r.mutex.Lock()
+		r.conn = nil
+		r.mutex.Unlock()
+	}()
 
-	reloadCh := make(chan struct{})
+	stopWaitCh := make(chan struct{})
+	defer close(stopWaitCh)
 
 	klog.InfoS("NDP responder started", "interface", transportInterface.Name, "index", transportInterface.Index)
 	defer klog.InfoS("NDP responder stopped", "interface", transportInterface.Name, "index", transportInterface.Index)
 
 	go func() {
-		defer conn.Close()
-		defer close(reloadCh)
-
 		for {
 			select {
 			case <-stopCh:
+				conn.Close()
+				return
+			case <-stopWaitCh:
 				return
 			case <-r.linkEventCh:
 				newTransportInterface, err := net.InterfaceByName(r.linkName)
@@ -168,6 +176,7 @@ func (r *ndpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 				}
 				if transportInterface.Index != newTransportInterface.Index {
 					klog.InfoS("Transport interface index changed, restarting NDP responder", "name", transportInterface.Name, "oldIndex", transportInterface.Index, "newIndex", newTransportInterface.Index)
+					conn.Close()
 					return
 				}
 				klog.V(4).InfoS("Transport interface not changed")
@@ -176,14 +185,12 @@ func (r *ndpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 	}()
 
 	for {
-		select {
-		case <-reloadCh:
-			return
-		default:
-			err := r.handleNeighborSolicitation(conn, transportInterface)
-			if err != nil {
-				klog.ErrorS(err, "Failed to handle Neighbor Solicitation", "deviceName", r.linkName)
+		if err := r.handleNeighborSolicitation(conn, transportInterface); err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
 			}
+			klog.ErrorS(err, "Failed to handle Neighbor Solicitation", "deviceName", r.linkName)
+			return
 		}
 	}
 }

--- a/pkg/agent/ipassigner/responder/ndp_responder.go
+++ b/pkg/agent/ipassigner/responder/ndp_responder.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
 	"sync"
+	"syscall"
 	"time"
 
 	"antrea.io/ndp"
@@ -105,7 +107,8 @@ func (r *ndpResponder) handleNeighborSolicitation(conn ndpConn, link *net.Interf
 		},
 	}
 	if err := conn.WriteTo(na, nil, srcIP); err != nil {
-		return err
+		klog.ErrorS(err, "Failed to send Neighbor Advertisement", "ip", ns.TargetAddress, "interface", r.linkName)
+		return nil
 	}
 	klog.V(4).InfoS("Sent Neighbor Advertisement", "ip", ns.TargetAddress.String(), "interface", r.linkName)
 	return nil
@@ -151,11 +154,14 @@ func (r *ndpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 	defer func() {
 		r.mutex.Lock()
 		r.conn = nil
+		clear(r.multicastGroups)
 		r.mutex.Unlock()
 	}()
 
-	stopWaitCh := make(chan struct{})
-	defer close(stopWaitCh)
+	// readLoopDone notifies the background link watcher goroutine to exit
+	// when the read loop terminates.
+	readLoopDone := make(chan struct{})
+	defer close(readLoopDone)
 
 	klog.InfoS("NDP responder started", "interface", transportInterface.Name, "index", transportInterface.Index)
 	defer klog.InfoS("NDP responder stopped", "interface", transportInterface.Name, "index", transportInterface.Index)
@@ -166,7 +172,7 @@ func (r *ndpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 			case <-stopCh:
 				conn.Close()
 				return
-			case <-stopWaitCh:
+			case <-readLoopDone:
 				return
 			case <-r.linkEventCh:
 				newTransportInterface, err := net.InterfaceByName(r.linkName)
@@ -185,13 +191,19 @@ func (r *ndpResponder) dialAndHandleRequests(stopCh <-chan struct{}) {
 	}()
 
 	for {
-		if err := r.handleNeighborSolicitation(conn, transportInterface); err != nil {
-			if errors.Is(err, net.ErrClosed) {
-				return
-			}
-			klog.ErrorS(err, "Failed to handle Neighbor Solicitation", "deviceName", r.linkName)
+		err := r.handleNeighborSolicitation(conn, transportInterface)
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, net.ErrClosed) || errors.Is(err, os.ErrClosed) || errors.Is(err, syscall.EBADF) {
 			return
 		}
+		var opErr *net.OpError
+		if errors.As(err, &opErr) {
+			klog.ErrorS(err, "Socket error in NDP responder, restarting", "deviceName", r.linkName)
+			return
+		}
+		klog.V(2).InfoS("Skipping invalid NDP packet", "err", err, "deviceName", r.linkName)
 	}
 }
 

--- a/pkg/agent/ipassigner/responder/ndp_responder_test.go
+++ b/pkg/agent/ipassigner/responder/ndp_responder_test.go
@@ -17,7 +17,9 @@ package responder
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"net/netip"
+	"syscall"
 	"testing"
 
 	"antrea.io/ndp"
@@ -62,6 +64,7 @@ func TestNDPResponder_handleNeighborSolicitation(t *testing.T) {
 		requestMessage []byte
 		requestIP      netip.Addr
 		assignedIPs    []netip.Addr
+		writeErr       error
 		expectError    bool
 		expectedReply  []byte
 	}{
@@ -110,6 +113,7 @@ func TestNDPResponder_handleNeighborSolicitation(t *testing.T) {
 			assignedIPs: []netip.Addr{
 				netip.MustParseAddr("fe80::a1"),
 			},
+			writeErr:      fmt.Errorf("write buffer full: ENOBUFS"),
 			expectError:   false, // Write error must be swallowed and logged, not propagated
 			expectedReply: nil,
 		},
@@ -139,8 +143,8 @@ func TestNDPResponder_handleNeighborSolicitation(t *testing.T) {
 			buffer := bytes.NewBuffer(nil)
 			fakeConn := &fakeNDPConn{
 				writeTo: func(msg ndp.Message, _ *ipv6.ControlMessage, _ netip.Addr) error {
-					if tt.name == "write failure is ignored without propagating error" {
-						return fmt.Errorf("write buffer full: ENOBUFS")
+					if tt.writeErr != nil {
+						return tt.writeErr
 					}
 					bs, err := ndp.MarshalMessage(msg)
 					assert.NoError(t, err)
@@ -162,7 +166,9 @@ func TestNDPResponder_handleNeighborSolicitation(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				if tt.expectedReply != nil {
+				if len(tt.expectedReply) == 0 {
+					assert.Empty(t, buffer.Bytes())
+				} else {
 					assert.Equal(t, tt.expectedReply, buffer.Bytes())
 				}
 			}
@@ -406,24 +412,75 @@ func Test_ndpResponder_removeIP(t *testing.T) {
 	}
 }
 
-func Test_ndpResponder_clearMulticastGroupsOnExit(t *testing.T) {
-	group := netip.MustParseAddr("ff02::1:ff11:2233")
-	r := &ndpResponder{
-		linkName: "eth0",
-		conn:     &fakeNDPConn{},
-		multicastGroups: map[netip.Addr]int{
-			group: 2,
+func loopbackInterface() (*net.Interface, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list network interfaces: %w", err)
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 {
+			return &iface, nil
+		}
+	}
+	return nil, fmt.Errorf("no loopback interface found")
+}
+
+func Test_ndpResponder_rejoinMulticastGroupsOnReconnect(t *testing.T) {
+	lo, err := loopbackInterface()
+	if err != nil {
+		t.Skipf("Skipping test: loopback interface not available: %v", err)
+	}
+
+	ip1 := netip.MustParseAddr("2022::beaf")
+	expectedGroup := parseIPv6SolicitedNodeMulticastAddress(ip1)
+
+	var conn1Joined, conn2Joined []netip.Addr
+	conn1 := &fakeNDPConn{
+		joinGroup: func(group netip.Addr) error {
+			conn1Joined = append(conn1Joined, group)
+			return nil
+		},
+		readFrom: func() (ndp.Message, *ipv6.ControlMessage, netip.Addr, error) {
+			// Fatal socket error to terminate dialAndHandleRequests read loop
+			return nil, nil, netip.Addr{}, syscall.EBADF
+		},
+	}
+	conn2 := &fakeNDPConn{
+		joinGroup: func(group netip.Addr) error {
+			conn2Joined = append(conn2Joined, group)
+			return nil
+		},
+		readFrom: func() (ndp.Message, *ipv6.ControlMessage, netip.Addr, error) {
+			return nil, nil, netip.Addr{}, syscall.EBADF
 		},
 	}
 
-	// Simulate cleanup defer on exit
-	func() {
-		r.mutex.Lock()
-		r.conn = nil
-		clear(r.multicastGroups)
-		r.mutex.Unlock()
-	}()
+	dialCount := 0
+	r := &ndpResponder{
+		linkName:        lo.Name,
+		assignedIPs:     sets.New[netip.Addr](ip1),
+		multicastGroups: make(map[netip.Addr]int),
+		linkEventCh:     make(chan struct{}, 1),
+		dial: func(_ *net.Interface) (ndpConn, error) {
+			dialCount++
+			if dialCount == 1 {
+				return conn1, nil
+			}
+			return conn2, nil
+		},
+	}
 
+	stopCh := make(chan struct{})
+
+	// 1st run: dial conn1, join multicast group, read loop encounters EBADF and exits, defer cleans up r.conn and multicastGroups
+	r.dialAndHandleRequests(stopCh)
+	assert.Equal(t, []netip.Addr{expectedGroup}, conn1Joined)
+	assert.Nil(t, r.conn, "r.conn should be reset to nil on exit")
+	assert.Empty(t, r.multicastGroups, "r.multicastGroups must be cleared on socket exit")
+
+	// 2nd run (reconnect): dial conn2; because multicastGroups was cleared on exit, JoinGroup must be called again on the new socket
+	r.dialAndHandleRequests(stopCh)
+	assert.Equal(t, []netip.Addr{expectedGroup}, conn2Joined, "multicast groups must be rejoined on the new socket connection")
 	assert.Nil(t, r.conn)
 	assert.Empty(t, r.multicastGroups)
 }

--- a/pkg/agent/ipassigner/responder/ndp_responder_test.go
+++ b/pkg/agent/ipassigner/responder/ndp_responder_test.go
@@ -16,6 +16,7 @@ package responder
 
 import (
 	"bytes"
+	"fmt"
 	"net/netip"
 	"testing"
 
@@ -94,6 +95,25 @@ func TestNDPResponder_handleNeighborSolicitation(t *testing.T) {
 			},
 		},
 		{
+			name: "write failure is ignored without propagating error",
+			requestMessage: []byte{
+				0x87,       // type - 135 for Neighbor Solicitation
+				0x00,       // code
+				0x00, 0x00, // checksum
+				0x00, 0x00, 0x00, 0x00, // reserved bits.
+				0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xa1, // IPv6 address
+				0x01,                               // option - 1 for Source Link-layer Address
+				0x01,                               // length (units of 8 octets including type and length fields)
+				0x00, 0x11, 0x22, 0x33, 0x44, 0x66, // hardware address
+			},
+			requestIP: netip.MustParseAddr("fe80::c1"),
+			assignedIPs: []netip.Addr{
+				netip.MustParseAddr("fe80::a1"),
+			},
+			expectError:   false, // Write error must be swallowed and logged, not propagated
+			expectedReply: nil,
+		},
+		{
 			name: "request to not assigned IP",
 			requestMessage: []byte{
 				0x87,       // type - 135 for Neighbor Solicitation
@@ -119,6 +139,9 @@ func TestNDPResponder_handleNeighborSolicitation(t *testing.T) {
 			buffer := bytes.NewBuffer(nil)
 			fakeConn := &fakeNDPConn{
 				writeTo: func(msg ndp.Message, _ *ipv6.ControlMessage, _ netip.Addr) error {
+					if tt.name == "write failure is ignored without propagating error" {
+						return fmt.Errorf("write buffer full: ENOBUFS")
+					}
 					bs, err := ndp.MarshalMessage(msg)
 					assert.NoError(t, err)
 					buffer.Write(bs)
@@ -139,7 +162,9 @@ func TestNDPResponder_handleNeighborSolicitation(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expectedReply, buffer.Bytes())
+				if tt.expectedReply != nil {
+					assert.Equal(t, tt.expectedReply, buffer.Bytes())
+				}
 			}
 		})
 	}
@@ -379,4 +404,26 @@ func Test_ndpResponder_removeIP(t *testing.T) {
 			assert.Equal(t, tt.expectedMulticastGroups, r.multicastGroups)
 		})
 	}
+}
+
+func Test_ndpResponder_clearMulticastGroupsOnExit(t *testing.T) {
+	group := netip.MustParseAddr("ff02::1:ff11:2233")
+	r := &ndpResponder{
+		linkName: "eth0",
+		conn:     &fakeNDPConn{},
+		multicastGroups: map[netip.Addr]int{
+			group: 2,
+		},
+	}
+
+	// Simulate cleanup defer on exit
+	func() {
+		r.mutex.Lock()
+		r.conn = nil
+		clear(r.multicastGroups)
+		r.mutex.Unlock()
+	}()
+
+	assert.Nil(t, r.conn)
+	assert.Empty(t, r.multicastGroups)
 }


### PR DESCRIPTION
## Summary
Fixes a 100% CPU spinning hot loop in NDP (`ndpResponder`) and ARP (`arpResponder`) request handling loops, and improves error classification, state lifecycle management, and test coverage.

### Key Changes
1. **CPU Hot Loop Elimination**:
   - Previously, `dialAndHandleRequests` ran a `for { select { default: } }` loop. When the socket closed or a read error occurred, the `default:` branch spun continuously with zero delay without allowing `wait.NonSlidingUntil` to back off and rebind.
   - Removed the non-blocking `default` branch and simplified the event loop.
2. **Error Classification & Fault Tolerance**:
   - Differentiated between transient packet-level decode/parse errors (which are logged at V(2) and skipped via `continue` to avoid single-packet DoS) and fatal socket errors (`*net.OpError`, which trigger loop termination and reconnection).
   - Handled raw socket / `os.File` closure types by checking `os.ErrClosed` and `syscall.EBADF` alongside standard `net.ErrClosed`.
   - Isolated reply failures (`client.Reply`, `WriteTo`) so individual send errors do not tear down the listener loop.
3. **Multicast State Synchronization on Reconnection**:
   - Added `clear(r.multicastGroups)` in the exit `defer` of `dialAndHandleRequests`. When a socket disconnects, the kernel drops multicast group memberships; clearing the user-space reference counts ensures all assigned IPv6 addresses re-register solicited-node multicast groups upon reconnection.
4. **Goroutine Leak Prevention**:
   - Introduced a `readLoopDone` channel to signal and terminate the background link event watcher goroutine when the primary reader loop exits.
5. **Testability & Regression Guards**:
   - **NDP Dial Seam & Multicast Test**: Introduced an injectable `dial func(*net.Interface) (ndpConn, error)` seam to test socket error exits, `defer` cleanups, and multi-run reconnection behavior in unit tests. Added `Test_ndpResponder_rejoinMulticastGroupsOnReconnect` validating that multicast groups are genuinely rejoined across reconnect cycles.
   - **ARP Dial Seam & Loop Test**: Introduced an injectable `dial func(*net.Interface) (*arp.Client, error)` seam to `arpResponder` mirroring NDP. Added `Test_arpResponder_dialAndHandleRequests` verifying the full loop execution (skipping malformed packets, replying to valid requests, and cleanly exiting upon socket closure) with `idempotentPacketConn` to avoid double-close panics.
   - Strengthened ARP malformed packet error predicate assertions (`assert.False(t, errors.As(err, &opErr))`) and cleaned up table-driven test error injection.

## Test Plan
- Ran all unit tests: `go test -v ./pkg/agent/ipassigner/responder/...` (32 passed).
- Verified zero data races: `go test -race ./pkg/agent/ipassigner/responder/...`.
- Verified cross-compilation across Linux and Windows:
  - `GOOS=linux go test -c ./pkg/agent/ipassigner/responder/`
  - `GOOS=windows go test -c ./pkg/agent/ipassigner/responder/`
