### PR TITLE
Fix MemberClusterSetReconciler data race

### DIFF
--- a/multicluster/controllers/multicluster/member/clusterset_controller.go
+++ b/multicluster/controllers/multicluster/member/clusterset_controller.go
@@ -56,7 +56,7 @@ type MemberClusterSetReconciler struct {
 	namespace                string
 	clusterCalimCRDAvailable bool
 
-	// commonAreaLock protects the access to RemoteCommonArea.
+	// commonAreaLock protects the access to the ClusterSet state and RemoteCommonArea.
 	commonAreaLock       sync.RWMutex
 	commonAreaCreationCh chan struct{}
 
@@ -327,14 +327,18 @@ func (r *MemberClusterSetReconciler) getSecretForLeader(secretName string, secre
 }
 
 func (r *MemberClusterSetReconciler) updateStatus() {
-	if r.clusterID == common.InvalidClusterID {
+	r.commonAreaLock.RLock()
+	clusterID := r.clusterID
+	clusterSetID := r.clusterSetID
+	r.commonAreaLock.RUnlock()
+	if clusterID == common.InvalidClusterID {
 		// Nothing to do.
 		return
 	}
 
 	namespacedName := types.NamespacedName{
 		Namespace: r.namespace,
-		Name:      string(r.clusterSetID),
+		Name:      string(clusterSetID),
 	}
 	clusterSet := &mcv1alpha2.ClusterSet{}
 	err := r.Get(context.TODO(), namespacedName, clusterSet)

--- a/multicluster/controllers/multicluster/member/clusterset_controller_test.go
+++ b/multicluster/controllers/multicluster/member/clusterset_controller_test.go
@@ -16,6 +16,7 @@ package member
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -223,6 +224,47 @@ func TestMemberClusterStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMemberClusterStatusConcurrentStateUpdate(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
+	reconciler := MemberClusterSetReconciler{
+		Client:       fakeClient,
+		clusterSetID: "clusterset1",
+		clusterID:    "east",
+		namespace:    "mcs1",
+	}
+
+	startCh := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-startCh
+		for i := 0; i < 1000; i++ {
+			reconciler.commonAreaLock.Lock()
+			if i%2 == 0 {
+				reconciler.clusterSetID = "clusterset1"
+				reconciler.clusterID = "east"
+			} else {
+				reconciler.clusterSetID = "clusterset2"
+				reconciler.clusterID = "west"
+			}
+			reconciler.commonAreaLock.Unlock()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-startCh
+		for i := 0; i < 1000; i++ {
+			reconciler.updateStatus()
+		}
+	}()
+	close(startCh)
+	wg.Wait()
+
+	assert.Equal(t, common.ClusterSetID("clusterset2"), reconciler.clusterSetID)
+	assert.Equal(t, common.ClusterID("west"), reconciler.clusterID)
 }
 
 func TestMemberCreateOrUpdateRemoteCommonArea(t *testing.T) {


### PR DESCRIPTION
The periodic status updater read ClusterSet identifiers while reconciliation could change them, causing unsynchronized access. Snapshot both identifiers under commonAreaLock and add a regression test which exercises concurrent status and reconciliation state updates.