### PR TITLE
Honour endpoint readiness and decide BGP advertisement per prefix

### DIFF
--- a/docs/bgp-policy.md
+++ b/docs/bgp-policy.md
@@ -115,9 +115,13 @@ The `advertisements` field configures which IPs are advertised to BGP peers.
 - `service`: Specifies how to advertise Service IPs. The `ipTypes` field lists the types of Service IPs to be advertised,
   which can include `ClusterIP`, `ExternalIP`, and `LoadBalancerIP`.
   - All Nodes can advertise all ClusterIPs, respecting `internalTrafficPolicy`. If `internalTrafficPolicy` is set to
-    `Local`, a Node will only advertise ClusterIPs with at least one local Endpoint.
+    `Local`, a Node will only advertise ClusterIPs with at least one local endpoint that is ready, or
+    terminating but still serving.
   - All Nodes can advertise all ExternalIPs and LoadBalancerIPs, respecting `externalTrafficPolicy`. If
-    `externalTrafficPolicy` is set to `Local`, a Node will only advertise IPs with at least one local Endpoint.
+    `externalTrafficPolicy` is set to `Local`, a Node will only advertise IPs with at least one local
+    endpoint that is ready, or terminating but still serving.
+  - When several Services share an IP, a Node advertises it only if every Service with a `Local` policy has such an
+    endpoint on that Node.
 
 ### BGPPeers
 

--- a/pkg/agent/controller/bgp/controller.go
+++ b/pkg/agent/controller/bgp/controller.go
@@ -15,6 +15,7 @@
 package bgp
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -23,6 +24,7 @@ import (
 	"net"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -49,6 +51,7 @@ import (
 	"antrea.io/antrea/v2/pkg/agent/bgp/gobgp"
 	"antrea.io/antrea/v2/pkg/agent/config"
 	"antrea.io/antrea/v2/pkg/agent/types"
+	"antrea.io/antrea/v2/pkg/agent/util/endpointslice"
 	"antrea.io/antrea/v2/pkg/apis/crd/v1alpha1"
 	"antrea.io/antrea/v2/pkg/apis/crd/v1beta1"
 	crdinformersv1a1 "antrea.io/antrea/v2/pkg/client/informers/externalversions/crd/v1alpha1"
@@ -617,52 +620,88 @@ func (c *Controller) getRoutes(advertisements v1alpha1.Advertisements) map[bgp.R
 	return allRoutes
 }
 
+// serviceRoute is the route one Service contributes to a prefix. requiresLocal is true when the traffic policy of the
+// Service for that IP type is Local, in which case the Service must have a serving endpoint on this Node for the prefix
+// to be advertised.
+type serviceRoute struct {
+	svcRef          string
+	routeType       AdvertisedRouteType
+	requiresLocal   bool
+	hasLocalServing bool
+}
+
 func (c *Controller) addServiceRoutes(advertisement *v1alpha1.ServiceAdvertisement, allRoutes map[bgp.Route]RouteMetadata) {
 	ipTypes := sets.New(advertisement.IPTypes...)
 	services, _ := c.serviceLister.List(labels.Everything())
+
+	// Several Services may share an IP, so whether a prefix is advertised is decided once per prefix, after every
+	// Service contributing to it is known. Deciding per Service would let a Service which can deliver traffic on this
+	// Node advertise a prefix that another Service sharing the IP cannot deliver traffic for.
+	svcRoutes := make(map[string][]serviceRoute)
 
 	for _, svc := range services {
 		svcRef := svc.Namespace + "/" + svc.Name
 		internalLocal := svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == corev1.ServiceInternalTrafficPolicyLocal
 		externalLocal := svc.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyLocal
-		var hasLocalEndpoints bool
+		var hasLocalServing bool
 		if internalLocal || externalLocal {
-			hasLocalEndpoints = c.hasLocalEndpoints(svc)
+			hasLocalServing = c.hasLocalServingEndpoints(svc)
 		}
 		if ipTypes.Has(v1alpha1.ServiceIPTypeClusterIP) {
-			if internalLocal && hasLocalEndpoints || !internalLocal {
-				for _, clusterIP := range svc.Spec.ClusterIPs {
-					if c.enabledIPv4 && utilnet.IsIPv4String(clusterIP) {
-						addRoutes(allRoutes, clusterIP+ipv4Suffix, svcRef, ServiceClusterIP)
-					} else if c.enabledIPv6 && utilnet.IsIPv6String(clusterIP) {
-						addRoutes(allRoutes, clusterIP+ipv6Suffix, svcRef, ServiceClusterIP)
-					}
+			for _, clusterIP := range svc.Spec.ClusterIPs {
+				if c.enabledIPv4 && utilnet.IsIPv4String(clusterIP) {
+					addServiceRoute(svcRoutes, clusterIP+ipv4Suffix, svcRef, ServiceClusterIP, internalLocal, hasLocalServing)
+				} else if c.enabledIPv6 && utilnet.IsIPv6String(clusterIP) {
+					addServiceRoute(svcRoutes, clusterIP+ipv6Suffix, svcRef, ServiceClusterIP, internalLocal, hasLocalServing)
 				}
 			}
 		}
 		if ipTypes.Has(v1alpha1.ServiceIPTypeExternalIP) {
-			if externalLocal && hasLocalEndpoints || !externalLocal {
-				for _, externalIP := range svc.Spec.ExternalIPs {
-					if c.enabledIPv4 && utilnet.IsIPv4String(externalIP) {
-						addRoutes(allRoutes, externalIP+ipv4Suffix, svcRef, ServiceExternalIP)
-					} else if c.enabledIPv6 && utilnet.IsIPv6String(externalIP) {
-						addRoutes(allRoutes, externalIP+ipv6Suffix, svcRef, ServiceExternalIP)
-					}
+			for _, externalIP := range svc.Spec.ExternalIPs {
+				if c.enabledIPv4 && utilnet.IsIPv4String(externalIP) {
+					addServiceRoute(svcRoutes, externalIP+ipv4Suffix, svcRef, ServiceExternalIP, externalLocal, hasLocalServing)
+				} else if c.enabledIPv6 && utilnet.IsIPv6String(externalIP) {
+					addServiceRoute(svcRoutes, externalIP+ipv6Suffix, svcRef, ServiceExternalIP, externalLocal, hasLocalServing)
 				}
 			}
 		}
 		if ipTypes.Has(v1alpha1.ServiceIPTypeLoadBalancerIP) && svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
-			if externalLocal && hasLocalEndpoints || !externalLocal {
-				loadBalancerIPs := getIngressIPs(svc)
-				for _, loadBalancerIP := range loadBalancerIPs {
-					if c.enabledIPv4 && utilnet.IsIPv4String(loadBalancerIP) {
-						addRoutes(allRoutes, loadBalancerIP+ipv4Suffix, svcRef, ServiceLoadBalancerIP)
-					} else if c.enabledIPv6 && utilnet.IsIPv6String(loadBalancerIP) {
-						addRoutes(allRoutes, loadBalancerIP+ipv6Suffix, svcRef, ServiceLoadBalancerIP)
-					}
+			loadBalancerIPs := getIngressIPs(svc)
+			for _, loadBalancerIP := range loadBalancerIPs {
+				if c.enabledIPv4 && utilnet.IsIPv4String(loadBalancerIP) {
+					addServiceRoute(svcRoutes, loadBalancerIP+ipv4Suffix, svcRef, ServiceLoadBalancerIP, externalLocal, hasLocalServing)
+				} else if c.enabledIPv6 && utilnet.IsIPv6String(loadBalancerIP) {
+					addServiceRoute(svcRoutes, loadBalancerIP+ipv6Suffix, svcRef, ServiceLoadBalancerIP, externalLocal, hasLocalServing)
 				}
 			}
 		}
+	}
+
+	for prefix, routes := range svcRoutes {
+		blocked := false
+		for _, route := range routes {
+			if route.requiresLocal && !route.hasLocalServing {
+				blocked = true
+				break
+			}
+		}
+		if blocked {
+			continue
+		}
+		// The routes are sorted so that the metadata does not depend on the order in which the Services were listed,
+		// which is not stable.
+		slices.SortFunc(routes, func(a, b serviceRoute) int {
+			if res := cmp.Compare(a.svcRef, b.svcRef); res != 0 {
+				return res
+			}
+			return cmp.Compare(a.routeType, b.routeType)
+		})
+		svcRefs := make([]string, len(routes))
+		for i, route := range routes {
+			svcRefs[i] = route.svcRef
+		}
+		svcRefs = slices.Compact(svcRefs)
+		addRoutes(allRoutes, prefix, strings.Join(svcRefs, ","), routes[0].routeType)
 	}
 }
 
@@ -697,12 +736,21 @@ func addRoutes(allRoutes map[bgp.Route]RouteMetadata, prefix, k8sObjRef string, 
 	}
 }
 
-func (c *Controller) hasLocalEndpoints(svc *corev1.Service) bool {
+func addServiceRoute(svcRoutes map[string][]serviceRoute, prefix, svcRef string, routeType AdvertisedRouteType, requiresLocal, hasLocalServing bool) {
+	svcRoutes[prefix] = append(svcRoutes[prefix], serviceRoute{
+		svcRef:          svcRef,
+		routeType:       routeType,
+		requiresLocal:   requiresLocal,
+		hasLocalServing: hasLocalServing,
+	})
+}
+
+func (c *Controller) hasLocalServingEndpoints(svc *corev1.Service) bool {
 	labelSelector := labels.Set{discovery.LabelServiceName: svc.GetName()}.AsSelector()
 	items, _ := c.endpointSliceLister.EndpointSlices(svc.GetNamespace()).List(labelSelector)
 	for _, eps := range items {
 		for _, ep := range eps.Endpoints {
-			if ep.NodeName != nil && *ep.NodeName == c.nodeName {
+			if ep.NodeName != nil && *ep.NodeName == c.nodeName && endpointslice.CanServe(ep) {
 				return true
 			}
 		}

--- a/pkg/agent/controller/bgp/controller_test.go
+++ b/pkg/agent/controller/bgp/controller_test.go
@@ -2354,11 +2354,12 @@ func generateNode(name string, labels, annotations map[string]string) *corev1.No
 	}
 }
 
-func generateEndpointSlice(svcName string,
+func generateEndpointSliceWithConditions(svcName string,
 	suffix string,
 	isLocal bool,
 	isIPv6 bool,
-	endpointIP string) *discovery.EndpointSlice {
+	endpointIP string,
+	conditions discovery.EndpointConditions) *discovery.EndpointSlice {
 	addrType := discovery.AddressTypeIPv4
 	if isIPv6 {
 		addrType = discovery.AddressTypeIPv6
@@ -2384,11 +2385,9 @@ func generateEndpointSlice(svcName string,
 			Addresses: []string{
 				endpointIP,
 			},
-			Conditions: discovery.EndpointConditions{
-				Ready: ptr.To(true),
-			},
-			Hostname: nodeName,
-			NodeName: nodeName,
+			Conditions: conditions,
+			Hostname:   nodeName,
+			NodeName:   nodeName,
 		}}
 		endpointSlice.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p80"),
@@ -2397,6 +2396,16 @@ func generateEndpointSlice(svcName string,
 		}}
 	}
 	return endpointSlice
+}
+
+func generateEndpointSlice(svcName string,
+	suffix string,
+	isLocal bool,
+	isIPv6 bool,
+	endpointIP string) *discovery.EndpointSlice {
+	return generateEndpointSliceWithConditions(svcName, suffix, isLocal, isIPv6, endpointIP, discovery.EndpointConditions{
+		Ready: ptr.To(true),
+	})
 }
 
 func generateBGPPeer(ip string, asn, port, gracefulRestartTimeSeconds int32) v1alpha1.BGPPeer {
@@ -2757,4 +2766,392 @@ func TestDeleteHandlerTombstone(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestBGPEndpointReadinessAndSharedIP(t *testing.T) {
+	creationTime := metav1.Now()
+	sharedLBIP := "192.168.77.200"
+	sharedLBRoute := bgp.Route{Prefix: sharedLBIP + ipv4Suffix}
+	clusterIP1 := "10.96.10.11"
+	clusterIP2 := "10.96.10.12"
+	clusterIP3 := "10.96.10.13"
+
+	policy := generateBGPPolicy("test-policy", creationTime, nodeLabels1, 179, 65000, false, false, true, false, false, []v1alpha1.BGPPeer{ipv4Peer1}, nil)
+	clusterIPPolicy := generateBGPPolicy("test-cip-policy", creationTime, nodeLabels1, 179, 65000, true, false, false, false, false, []v1alpha1.BGPPeer{ipv4Peer1}, nil)
+
+	t.Run("Readiness", func(t *testing.T) {
+		tests := []struct {
+			name               string
+			svc                *corev1.Service
+			epsConditions      discovery.EndpointConditions
+			isLocal            bool
+			hasEndpoints       bool
+			expectedAdvertised bool
+			expectedRoute      bgp.Route
+			expectedMeta       RouteMetadata
+		}{
+			{
+				name:               "local endpoint ready",
+				svc:                generateService("svc-local-ready", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, true),
+				epsConditions:      discovery.EndpointConditions{Ready: ptr.To(true)},
+				isLocal:            true,
+				hasEndpoints:       true,
+				expectedAdvertised: true,
+				expectedRoute:      sharedLBRoute,
+				expectedMeta:       RouteMetadata{Type: ServiceLoadBalancerIP, K8sObjRef: getServiceName("svc-local-ready")},
+			},
+			{
+				name:               "local endpoint not ready and not serving",
+				svc:                generateService("svc-local-not-ready", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, true),
+				epsConditions:      discovery.EndpointConditions{Ready: ptr.To(false), Serving: ptr.To(false)},
+				isLocal:            true,
+				hasEndpoints:       true,
+				expectedAdvertised: false,
+			},
+			{
+				name:               "local endpoint terminating and serving",
+				svc:                generateService("svc-local-terminating", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, true),
+				epsConditions:      discovery.EndpointConditions{Ready: ptr.To(false), Serving: ptr.To(true), Terminating: ptr.To(true)},
+				isLocal:            true,
+				hasEndpoints:       true,
+				expectedAdvertised: true,
+				expectedRoute:      sharedLBRoute,
+				expectedMeta:       RouteMetadata{Type: ServiceLoadBalancerIP, K8sObjRef: getServiceName("svc-local-terminating")},
+			},
+			{
+				name:               "only a remote ready endpoint",
+				svc:                generateService("svc-remote-ready", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, true),
+				epsConditions:      discovery.EndpointConditions{Ready: ptr.To(true)},
+				isLocal:            false,
+				hasEndpoints:       true,
+				expectedAdvertised: false,
+			},
+			{
+				name:               "endpoint with nil ready condition",
+				svc:                generateService("svc-nil-ready", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, true),
+				epsConditions:      discovery.EndpointConditions{Ready: nil},
+				isLocal:            true,
+				hasEndpoints:       true,
+				expectedAdvertised: true,
+				expectedRoute:      sharedLBRoute,
+				expectedMeta:       RouteMetadata{Type: ServiceLoadBalancerIP, K8sObjRef: getServiceName("svc-nil-ready")},
+			},
+			{
+				name:               "ClusterIP internalTrafficPolicy Local not ready",
+				svc:                generateService("svc-cip-not-ready", corev1.ServiceTypeClusterIP, clusterIP1, "", "", true, false),
+				epsConditions:      discovery.EndpointConditions{Ready: ptr.To(false), Serving: ptr.To(false)},
+				isLocal:            true,
+				hasEndpoints:       true,
+				expectedAdvertised: false,
+			},
+			{
+				name:               "ClusterIP internalTrafficPolicy Local drain case",
+				svc:                generateService("svc-cip-drain", corev1.ServiceTypeClusterIP, clusterIP1, "", "", true, false),
+				epsConditions:      discovery.EndpointConditions{Ready: ptr.To(false), Serving: ptr.To(true), Terminating: ptr.To(true)},
+				isLocal:            true,
+				hasEndpoints:       true,
+				expectedAdvertised: true,
+				expectedRoute:      bgp.Route{Prefix: clusterIP1 + ipv4Suffix},
+				expectedMeta:       RouteMetadata{Type: ServiceClusterIP, K8sObjRef: getServiceName("svc-cip-drain")},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var objects []runtime.Object
+				objects = append(objects, node, tt.svc)
+				if tt.hasEndpoints {
+					eps := generateEndpointSliceWithConditions(tt.svc.Name, "eps", tt.isLocal, false, "10.10.0.10", tt.epsConditions)
+					objects = append(objects, eps)
+				}
+				effectivePolicy := policy
+				if tt.svc.Spec.Type == corev1.ServiceTypeClusterIP {
+					effectivePolicy = clusterIPPolicy
+				}
+				c := newFakeController(t, objects, []runtime.Object{effectivePolicy}, true, false)
+				stopCh := make(chan struct{})
+				defer close(stopCh)
+				ctx := context.Background()
+				c.startInformers(stopCh)
+				c.bgpPeerPasswords = bgpPeerPasswords
+
+				waitAndGetDummyEvent(t, c)
+				c.mockBGPServer.EXPECT().Start(gomock.Any())
+				c.mockBGPServer.EXPECT().AddPeer(gomock.Any(), ipv4Peer1Config)
+				if tt.expectedAdvertised {
+					c.mockBGPServer.EXPECT().AdvertiseRoutes(gomock.Any(), []bgp.Route{tt.expectedRoute})
+				}
+				require.NoError(t, c.syncBGPPolicy(ctx))
+				doneDummyEvent(t, c)
+
+				if tt.expectedAdvertised {
+					assert.Equal(t, tt.expectedMeta, c.bgpPolicyState.routes[tt.expectedRoute])
+				} else {
+					assert.Empty(t, c.bgpPolicyState.routes)
+				}
+			})
+		}
+	})
+
+	t.Run("Shared IP", func(t *testing.T) {
+		tests := []struct {
+			name               string
+			services           []*corev1.Service
+			endpointSlices     []*discovery.EndpointSlice
+			expectedAdvertised bool
+			expectedMeta       RouteMetadata
+		}{
+			{
+				name: "both Cluster",
+				services: []*corev1.Service{
+					generateService("svc-a", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, false),
+					generateService("svc-b", corev1.ServiceTypeLoadBalancer, clusterIP2, "", sharedLBIP, false, false),
+				},
+				endpointSlices:     nil,
+				expectedAdvertised: true,
+				expectedMeta: RouteMetadata{
+					Type:      ServiceLoadBalancerIP,
+					K8sObjRef: getServiceName("svc-a") + "," + getServiceName("svc-b"),
+				},
+			},
+			{
+				name: "both Local, both with a local serving endpoint",
+				services: []*corev1.Service{
+					generateService("svc-a", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, true),
+					generateService("svc-b", corev1.ServiceTypeLoadBalancer, clusterIP2, "", sharedLBIP, false, true),
+				},
+				endpointSlices: []*discovery.EndpointSlice{
+					generateEndpointSliceWithConditions("svc-a", "eps", true, false, "10.10.0.1", discovery.EndpointConditions{Ready: ptr.To(true)}),
+					generateEndpointSliceWithConditions("svc-b", "eps", true, false, "10.10.0.2", discovery.EndpointConditions{Ready: ptr.To(true)}),
+				},
+				expectedAdvertised: true,
+				expectedMeta: RouteMetadata{
+					Type:      ServiceLoadBalancerIP,
+					K8sObjRef: getServiceName("svc-a") + "," + getServiceName("svc-b"),
+				},
+			},
+			{
+				name: "both Local, one local and one remote endpoint",
+				services: []*corev1.Service{
+					generateService("svc-a", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, true),
+					generateService("svc-b", corev1.ServiceTypeLoadBalancer, clusterIP2, "", sharedLBIP, false, true),
+				},
+				endpointSlices: []*discovery.EndpointSlice{
+					generateEndpointSliceWithConditions("svc-a", "eps", true, false, "10.10.0.1", discovery.EndpointConditions{Ready: ptr.To(true)}),
+					generateEndpointSliceWithConditions("svc-b", "eps", false, false, "10.10.0.2", discovery.EndpointConditions{Ready: ptr.To(true)}),
+				},
+				expectedAdvertised: false,
+			},
+			{
+				name: "both Local, neither with a local endpoint",
+				services: []*corev1.Service{
+					generateService("svc-a", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, true),
+					generateService("svc-b", corev1.ServiceTypeLoadBalancer, clusterIP2, "", sharedLBIP, false, true),
+				},
+				endpointSlices: []*discovery.EndpointSlice{
+					generateEndpointSliceWithConditions("svc-a", "eps", false, false, "10.10.0.1", discovery.EndpointConditions{Ready: ptr.To(true)}),
+					generateEndpointSliceWithConditions("svc-b", "eps", false, false, "10.10.0.2", discovery.EndpointConditions{Ready: ptr.To(true)}),
+				},
+				expectedAdvertised: false,
+			},
+			{
+				name: "Cluster and Local, the Local one has a local endpoint",
+				services: []*corev1.Service{
+					generateService("svc-a", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, false),
+					generateService("svc-b", corev1.ServiceTypeLoadBalancer, clusterIP2, "", sharedLBIP, false, true),
+				},
+				endpointSlices: []*discovery.EndpointSlice{
+					generateEndpointSliceWithConditions("svc-b", "eps", true, false, "10.10.0.2", discovery.EndpointConditions{Ready: ptr.To(true)}),
+				},
+				expectedAdvertised: true,
+				expectedMeta: RouteMetadata{
+					Type:      ServiceLoadBalancerIP,
+					K8sObjRef: getServiceName("svc-a") + "," + getServiceName("svc-b"),
+				},
+			},
+			{
+				name: "Cluster and Local, the Local one has no local endpoint",
+				services: []*corev1.Service{
+					generateService("svc-a", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, false),
+					generateService("svc-b", corev1.ServiceTypeLoadBalancer, clusterIP2, "", sharedLBIP, false, true),
+				},
+				endpointSlices: []*discovery.EndpointSlice{
+					generateEndpointSliceWithConditions("svc-b", "eps", false, false, "10.10.0.2", discovery.EndpointConditions{Ready: ptr.To(true)}),
+				},
+				expectedAdvertised: false,
+			},
+			{
+				name: "three Services, two Local with local endpoints and one Local without",
+				services: []*corev1.Service{
+					generateService("svc-a", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, true),
+					generateService("svc-b", corev1.ServiceTypeLoadBalancer, clusterIP2, "", sharedLBIP, false, true),
+					generateService("svc-c", corev1.ServiceTypeLoadBalancer, clusterIP3, "", sharedLBIP, false, true),
+				},
+				endpointSlices: []*discovery.EndpointSlice{
+					generateEndpointSliceWithConditions("svc-a", "eps", true, false, "10.10.0.1", discovery.EndpointConditions{Ready: ptr.To(true)}),
+					generateEndpointSliceWithConditions("svc-b", "eps", true, false, "10.10.0.2", discovery.EndpointConditions{Ready: ptr.To(true)}),
+					generateEndpointSliceWithConditions("svc-c", "eps", false, false, "10.10.0.3", discovery.EndpointConditions{Ready: ptr.To(true)}),
+				},
+				expectedAdvertised: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var objects []runtime.Object
+				objects = append(objects, node)
+				for _, svc := range tt.services {
+					objects = append(objects, svc)
+				}
+				for _, eps := range tt.endpointSlices {
+					objects = append(objects, eps)
+				}
+				c := newFakeController(t, objects, []runtime.Object{policy}, true, false)
+				stopCh := make(chan struct{})
+				defer close(stopCh)
+				ctx := context.Background()
+				c.startInformers(stopCh)
+				c.bgpPeerPasswords = bgpPeerPasswords
+
+				waitAndGetDummyEvent(t, c)
+				c.mockBGPServer.EXPECT().Start(gomock.Any())
+				c.mockBGPServer.EXPECT().AddPeer(gomock.Any(), ipv4Peer1Config)
+				if tt.expectedAdvertised {
+					c.mockBGPServer.EXPECT().AdvertiseRoutes(gomock.Any(), []bgp.Route{sharedLBRoute})
+				}
+				require.NoError(t, c.syncBGPPolicy(ctx))
+				doneDummyEvent(t, c)
+
+				if tt.expectedAdvertised {
+					assert.Equal(t, tt.expectedMeta, c.bgpPolicyState.routes[sharedLBRoute])
+				} else {
+					assert.NotContains(t, c.bgpPolicyState.routes, sharedLBRoute)
+				}
+			})
+		}
+	})
+
+	t.Run("Determinism", func(t *testing.T) {
+		svcA := generateService("svc-a", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, false)
+		svcB := generateService("svc-b", corev1.ServiceTypeLoadBalancer, clusterIP2, "", sharedLBIP, false, false)
+
+		// Order 1: svcA then svcB
+		c1 := newFakeController(t, []runtime.Object{node, svcA, svcB}, []runtime.Object{policy}, true, false)
+		stopCh1 := make(chan struct{})
+		defer close(stopCh1)
+		ctx := context.Background()
+		c1.startInformers(stopCh1)
+		c1.bgpPeerPasswords = bgpPeerPasswords
+
+		waitAndGetDummyEvent(t, c1)
+		c1.mockBGPServer.EXPECT().Start(gomock.Any())
+		c1.mockBGPServer.EXPECT().AddPeer(gomock.Any(), ipv4Peer1Config)
+		c1.mockBGPServer.EXPECT().AdvertiseRoutes(gomock.Any(), []bgp.Route{sharedLBRoute})
+		require.NoError(t, c1.syncBGPPolicy(ctx))
+		doneDummyEvent(t, c1)
+		meta1 := c1.bgpPolicyState.routes[sharedLBRoute]
+
+		// Order 2: svcB then svcA
+		c2 := newFakeController(t, []runtime.Object{node, svcB, svcA}, []runtime.Object{policy}, true, false)
+		stopCh2 := make(chan struct{})
+		defer close(stopCh2)
+		c2.startInformers(stopCh2)
+		c2.bgpPeerPasswords = bgpPeerPasswords
+
+		waitAndGetDummyEvent(t, c2)
+		c2.mockBGPServer.EXPECT().Start(gomock.Any())
+		c2.mockBGPServer.EXPECT().AddPeer(gomock.Any(), ipv4Peer1Config)
+		c2.mockBGPServer.EXPECT().AdvertiseRoutes(gomock.Any(), []bgp.Route{sharedLBRoute})
+		require.NoError(t, c2.syncBGPPolicy(ctx))
+		doneDummyEvent(t, c2)
+		meta2 := c2.bgpPolicyState.routes[sharedLBRoute]
+
+		assert.Equal(t, meta1, meta2)
+		assert.Equal(t, getServiceName("svc-a")+","+getServiceName("svc-b"), meta1.K8sObjRef)
+	})
+
+	t.Run("Transitions", func(t *testing.T) {
+		t.Run("Local Service endpoint readiness flip", func(t *testing.T) {
+			svc := generateService("svc-flip", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, true)
+			c := newFakeController(t, []runtime.Object{node, svc}, []runtime.Object{policy}, true, false)
+			mockBGPServer := c.mockBGPServer
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			ctx := context.Background()
+			c.startInformers(stopCh)
+			c.bgpPeerPasswords = bgpPeerPasswords
+
+			waitAndGetDummyEvent(t, c)
+			mockBGPServer.EXPECT().Start(gomock.Any())
+			mockBGPServer.EXPECT().AddPeer(gomock.Any(), ipv4Peer1Config)
+			require.NoError(t, c.syncBGPPolicy(ctx))
+			doneDummyEvent(t, c)
+
+			// Add local ready endpoint
+			eps := generateEndpointSliceWithConditions(svc.Name, "eps", true, false, "10.10.0.1", discovery.EndpointConditions{Ready: ptr.To(true)})
+			_, err := c.client.DiscoveryV1().EndpointSlices(namespaceDefault).Create(context.TODO(), eps, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			waitAndGetDummyEvent(t, c)
+			mockBGPServer.EXPECT().AdvertiseRoutes(gomock.Any(), []bgp.Route{sharedLBRoute})
+			require.NoError(t, c.syncBGPPolicy(ctx))
+			doneDummyEvent(t, c)
+			assert.Contains(t, c.bgpPolicyState.routes, sharedLBRoute)
+
+			// Flip endpoint to not ready and not serving
+			eps = generateEndpointSliceWithConditions(svc.Name, "eps", true, false, "10.10.0.1", discovery.EndpointConditions{Ready: ptr.To(false), Serving: ptr.To(false)})
+			_, err = c.client.DiscoveryV1().EndpointSlices(namespaceDefault).Update(context.TODO(), eps, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
+			waitAndGetDummyEvent(t, c)
+			mockBGPServer.EXPECT().WithdrawRoutes(gomock.Any(), []bgp.Route{sharedLBRoute})
+			require.NoError(t, c.syncBGPPolicy(ctx))
+			doneDummyEvent(t, c)
+			assert.NotContains(t, c.bgpPolicyState.routes, sharedLBRoute)
+
+			// Flip back to ready
+			eps = generateEndpointSliceWithConditions(svc.Name, "eps", true, false, "10.10.0.1", discovery.EndpointConditions{Ready: ptr.To(true)})
+			_, err = c.client.DiscoveryV1().EndpointSlices(namespaceDefault).Update(context.TODO(), eps, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
+			waitAndGetDummyEvent(t, c)
+			mockBGPServer.EXPECT().AdvertiseRoutes(gomock.Any(), []bgp.Route{sharedLBRoute})
+			require.NoError(t, c.syncBGPPolicy(ctx))
+			doneDummyEvent(t, c)
+			assert.Contains(t, c.bgpPolicyState.routes, sharedLBRoute)
+		})
+
+		t.Run("Shared prefix second Local Service endpoint deleted", func(t *testing.T) {
+			svcA := generateService("svc-a", corev1.ServiceTypeLoadBalancer, clusterIP1, "", sharedLBIP, false, true)
+			svcB := generateService("svc-b", corev1.ServiceTypeLoadBalancer, clusterIP2, "", sharedLBIP, false, true)
+			epsA := generateEndpointSliceWithConditions("svc-a", "eps", true, false, "10.10.0.1", discovery.EndpointConditions{Ready: ptr.To(true)})
+			epsB := generateEndpointSliceWithConditions("svc-b", "eps", true, false, "10.10.0.2", discovery.EndpointConditions{Ready: ptr.To(true)})
+
+			c := newFakeController(t, []runtime.Object{node, svcA, svcB, epsA, epsB}, []runtime.Object{policy}, true, false)
+			mockBGPServer := c.mockBGPServer
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			ctx := context.Background()
+			c.startInformers(stopCh)
+			c.bgpPeerPasswords = bgpPeerPasswords
+
+			waitAndGetDummyEvent(t, c)
+			mockBGPServer.EXPECT().Start(gomock.Any())
+			mockBGPServer.EXPECT().AddPeer(gomock.Any(), ipv4Peer1Config)
+			mockBGPServer.EXPECT().AdvertiseRoutes(gomock.Any(), []bgp.Route{sharedLBRoute})
+			require.NoError(t, c.syncBGPPolicy(ctx))
+			doneDummyEvent(t, c)
+			assert.Contains(t, c.bgpPolicyState.routes, sharedLBRoute)
+
+			// Delete epsB (svcB has no local endpoints anymore)
+			err := c.client.DiscoveryV1().EndpointSlices(namespaceDefault).Delete(context.TODO(), epsB.Name, metav1.DeleteOptions{})
+			require.NoError(t, err)
+
+			waitAndGetDummyEvent(t, c)
+			mockBGPServer.EXPECT().WithdrawRoutes(gomock.Any(), []bgp.Route{sharedLBRoute})
+			require.NoError(t, c.syncBGPPolicy(ctx))
+			doneDummyEvent(t, c)
+			assert.NotContains(t, c.bgpPolicyState.routes, sharedLBRoute)
+		})
+	})
 }

--- a/pkg/agent/controller/serviceexternalip/controller.go
+++ b/pkg/agent/controller/serviceexternalip/controller.go
@@ -40,6 +40,7 @@ import (
 	"antrea.io/antrea/v2/pkg/agent/ipassigner/linkmonitor"
 	"antrea.io/antrea/v2/pkg/agent/memberlist"
 	"antrea.io/antrea/v2/pkg/agent/types"
+	"antrea.io/antrea/v2/pkg/agent/util/endpointslice"
 	"antrea.io/antrea/v2/pkg/querier"
 )
 
@@ -464,19 +465,7 @@ func (c *ServiceExternalIPController) nodesHasHealthyServiceEndpoint(service *co
 			if ep.NodeName == nil {
 				continue
 			}
-			// Check the ready condition first to respect the Service's publishNotReadyAddresses setting.
-			// The ready condition is true when:
-			// - publishNotReadyAddresses is true (all endpoints are considered ready), OR
-			// - the endpoint is serving AND not terminating
-			// If ready is true (or nil, which means true), we can use this endpoint.
-			if ep.Conditions.Ready == nil || *ep.Conditions.Ready {
-				nodes.Insert(*ep.NodeName)
-				continue
-			}
-			// If ready is false, fall back to checking the serving condition directly.
-			// This handles cases where the endpoint might still be serving but is marked not ready
-			// (e.g., during termination but still draining connections).
-			if ep.Conditions.Serving == nil || *ep.Conditions.Serving {
+			if endpointslice.CanServe(ep) {
 				nodes.Insert(*ep.NodeName)
 			}
 		}

--- a/pkg/agent/util/endpointslice/endpointslice.go
+++ b/pkg/agent/util/endpointslice/endpointslice.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpointslice
+
+import (
+	discoveryv1 "k8s.io/api/discovery/v1"
+)
+
+// CanServe reports whether AntreaProxy would send traffic to the endpoint. It is true for a ready
+// endpoint, and for an endpoint which is terminating while it is still serving, which is a Pod
+// draining its connections. It mirrors the rule AntreaProxy applies when it selects the Endpoints
+// of a Service, so that a Node does not advertise a Service IP its own datapath rejects. A nil
+// condition is read the way the EndpointSlice API defines it.
+func CanServe(ep discoveryv1.Endpoint) bool {
+	ready := ep.Conditions.Ready == nil || *ep.Conditions.Ready
+	serving := ep.Conditions.Serving == nil || *ep.Conditions.Serving
+	terminating := ep.Conditions.Terminating != nil && *ep.Conditions.Terminating
+	return ready || serving && terminating
+}

--- a/pkg/agent/util/endpointslice/endpointslice_test.go
+++ b/pkg/agent/util/endpointslice/endpointslice_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpointslice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestCanServe(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions discoveryv1.EndpointConditions
+		expected   bool
+	}{
+		{
+			name: "Ready nil, Serving nil",
+			conditions: discoveryv1.EndpointConditions{
+				Ready:   nil,
+				Serving: nil,
+			},
+			expected: true,
+		},
+		{
+			name: "Ready nil, Serving true",
+			conditions: discoveryv1.EndpointConditions{
+				Ready:   nil,
+				Serving: ptr.To(true),
+			},
+			expected: true,
+		},
+		{
+			name: "Ready nil, Serving false",
+			conditions: discoveryv1.EndpointConditions{
+				Ready:   nil,
+				Serving: ptr.To(false),
+			},
+			expected: true,
+		},
+		{
+			name: "Ready true, Serving nil",
+			conditions: discoveryv1.EndpointConditions{
+				Ready:   ptr.To(true),
+				Serving: nil,
+			},
+			expected: true,
+		},
+		{
+			name: "Ready true, Serving true",
+			conditions: discoveryv1.EndpointConditions{
+				Ready:   ptr.To(true),
+				Serving: ptr.To(true),
+			},
+			expected: true,
+		},
+		{
+			// Ready wins, as AntreaProxy takes every ready endpoint before it looks at anything else.
+			name: "Ready true, Serving false",
+			conditions: discoveryv1.EndpointConditions{
+				Ready:   ptr.To(true),
+				Serving: ptr.To(false),
+			},
+			expected: true,
+		},
+		{
+			// Serving is nil on a cluster which predates the condition, so it reads as true, but the
+			// endpoint is not terminating and AntreaProxy would not fall back to it.
+			name: "Ready false, Serving nil",
+			conditions: discoveryv1.EndpointConditions{
+				Ready:   ptr.To(false),
+				Serving: nil,
+			},
+			expected: false,
+		},
+		{
+			// Serving without Terminating contradicts the API, which defines Serving as readiness
+			// regardless of the terminating state. AntreaProxy only falls back to a terminating
+			// endpoint, so neither does this.
+			name: "Ready false, Serving true, not terminating",
+			conditions: discoveryv1.EndpointConditions{
+				Ready:   ptr.To(false),
+				Serving: ptr.To(true),
+			},
+			expected: false,
+		},
+		{
+			name: "Ready false, Serving true, Terminating true (drain state)",
+			conditions: discoveryv1.EndpointConditions{
+				Ready:       ptr.To(false),
+				Serving:     ptr.To(true),
+				Terminating: ptr.To(true),
+			},
+			expected: true,
+		},
+		{
+			name: "Ready false, Serving false",
+			conditions: discoveryv1.EndpointConditions{
+				Ready:   ptr.To(false),
+				Serving: ptr.To(false),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := discoveryv1.Endpoint{
+				Conditions: tt.conditions,
+			}
+			assert.Equal(t, tt.expected, CanServe(ep))
+		})
+	}
+}


### PR DESCRIPTION
Addresses items 2 and 3 of #8347. Item 1 of that issue, withdrawing routes for a `Cluster` policy
Service with no endpoints anywhere, is an API addition and will come in a separate PR.

## Endpoint readiness

`hasLocalEndpoints` returned true for any endpoint whose `NodeName` matched the Node, without ever
looking at `Ready`, `Serving` or `Terminating`. AntreaProxy on the same Node does look, and drops an
unready endpoint from the Service group. So a Node whose only local Pod failed its readiness probe
kept advertising a Service IP that its own datapath rejected, and the withdrawal that
`externalTrafficPolicy: Local` exists to perform never happened until the Pod object was deleted.

An endpoint now counts the way AntreaProxy selects one, which is ready, or terminating while still
serving so that a draining Pod keeps its route up. Choosing Endpoints is AntreaProxy's job, so this
restates its rule rather than inventing one, and the rule moves to `pkg/agent/util/endpointslice`
so the two cannot drift apart.

This also corrects the ServiceExternalIP controller, which had `ready || serving` and so accepted an
endpoint that was neither ready nor terminating. On a cluster which predates the `Serving` condition,
where a nil `Serving` reads as true, it claimed an external IP for a Node whose Pod was not ready.
AntreaProxy has never used such an endpoint.

## Advertising per prefix

Route computation was per Service, but the results went into a map keyed by prefix alone, so two
Services sharing an IP overwrote each other and the prefix was advertised if either one passed its
own check.

With two `externalTrafficPolicy: Local` Services sharing a LoadBalancer IP, a TCP one and a UDP one
as is common since a single Service could not mix protocols, and their Pods on different Nodes, both
Nodes advertised the IP. The router ECMPed across them and each protocol lost the share of its
traffic hashed to the Node without its backend. Which share depends on the hash, so it looked like
random flakiness.

The decision is now made once per prefix, after every contributing Service is known. For Services
sharing one IP:

- Both `Cluster`. Advertised from every selected Node, as before.
- Both `Local`. Advertised only from a Node where both have a serving endpoint on that Node.
- One `Cluster`, one `Local`. The `Local` one decides. A `Cluster` Service never blocks a prefix,
  because it forwards to a remote backend.

`RouteMetadata.K8sObjRef` used to name whichever Service the lister returned last, so
`antctl get bgproutes` attributed a shared prefix to an arbitrary Service that could change between
syncs. It now records every contributing Service in a stable order.

## Testing

`TestCanServe` covers every combination of the `Ready`, `Serving` and `Terminating` conditions,
including the nil cases and the two states where the endpoint is serving but not terminating, which
AntreaProxy does not use.

`TestBGPEndpointReadinessAndSharedIP` covers, against the mock BGP server and the resulting route
metadata:

- Readiness, for both `externalTrafficPolicy` and `internalTrafficPolicy`: a ready local endpoint, a
  local endpoint that is neither ready nor serving, a local endpoint terminating but still serving,
  only a remote ready endpoint, and an endpoint whose `Ready` condition is nil.
- Shared IPs: both `Cluster`, both `Local` with local endpoints, both `Local` with one local and one
  remote, both `Local` with neither local, `Cluster` and `Local` with and without a local endpoint,
  and three `Local` Services where one has no local endpoint.
- Determinism: the same two Services created in either order produce the same metadata.
- Transitions: a readiness flip withdraws the route and restores it, and losing the local endpoint
  of one Service withdraws a shared prefix the other Service could still serve.

Each of the four behaviours was checked by reverting it in the implementation and confirming the
tests fail: removing the sort, removing the readiness check, removing the per-prefix veto, and
dropping the terminating condition from `CanServe`.

## Not in this change

- The switch to withdraw routes for a `Cluster` policy Service with no endpoints anywhere, item 1 of
  the issue.
- Rejecting incompatible IP sharing at allocation time, the way MetalLB and Cilium do. That belongs
  to the ServiceExternalIP controller and only covers IPs Antrea allocates, so this rule is needed
  regardless.

