### PR TITLE
Reload OVS after updating port trunks

### DIFF
--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -82,6 +82,8 @@ type OVSBridgeClient interface {
 	SetInterfaceType(name, ifType string) error
 	SetPortExternalIDs(portName string, externalIDs map[string]string) error
 	GetPortExternalIDs(portName string) (map[string]string, error)
+	// SetPortTrunks updates the allowed VLANs and waits up to five seconds for
+	// ovs-vswitchd to acknowledge that it applied the configuration.
 	SetPortTrunks(portName string, vlanSpecs []string) error
 	SetInterfaceMAC(name string, mac net.HardwareAddr) error
 }

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ovn-kubernetes/libovsdb/model"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/v2/pkg/util/vlan"
@@ -78,13 +79,15 @@ const (
 	interfaceTable   = "Interface"
 
 	// ovs-vswitchd suppresses IDL change alerts for some Port columns, including trunks.
-	// Incrementing next_cfg explicitly asks ovs-vswitchd to reload the configuration.
+	// Incrementing next_cfg explicitly requests an ovs-vswitchd configuration reload.
 	// ovsConfigWaitTimeout is the total budget for the port lookup, OVSDB transaction,
 	// and ovs-vswitchd acknowledgement. It matches the timeout used for OFPort readiness.
-	ovsConfigWaitTimeout = 5 * time.Second
-	// ovsConfigWaitInterval is the interval at which cur_cfg is checked while waiting
-	// for ovs-vswitchd to acknowledge the configuration.
-	ovsConfigWaitInterval = 10 * time.Millisecond
+	ovsConfigWaitTimeout         = 5 * time.Second
+	ovsConfigWaitInitialInterval = 10 * time.Millisecond
+	ovsConfigWaitBackoffFactor   = 1.2
+	// The total duration of all backoff steps exceeds ovsConfigWaitTimeout, ensuring
+	// that the context deadline remains the overall bound for the operation.
+	ovsConfigWaitBackoffSteps = 30
 
 	// Openflow protocol version 1.0.
 	openflowProtoVersion10 = "OpenFlow10"
@@ -1250,7 +1253,7 @@ func (br *OVSBridge) SetPortTrunks(portName string, vlanSpecs []string) error {
 		klog.ErrorS(err, "Failed to construct update operation for Port", "port", portName)
 		return err
 	}
-	return br.transactAndWaitForConfig(ctx, ops, "set port trunks")
+	return br.transactAndWaitForReload(ctx, ops, "set port trunks")
 }
 
 func (br *OVSBridge) SetInterfaceMTU(name string, MTU int) error {
@@ -1436,11 +1439,11 @@ func (br *OVSBridge) transact(ctx context.Context, ops []ovsdb.Operation, action
 	return results, nil
 }
 
-// transactAndWaitForConfig executes the supplied operations, requests an ovs-vswitchd
+// transactAndWaitForReload executes the supplied operations, requests an ovs-vswitchd
 // configuration reload, and waits for ovs-vswitchd to acknowledge it. Some columns,
 // including Port.trunks, are omitted from OVS IDL change alerts and do not trigger a
 // reconfiguration on their own.
-func (br *OVSBridge) transactAndWaitForConfig(ctx context.Context, ops []ovsdb.Operation, action string) error {
+func (br *OVSBridge) transactAndWaitForReload(ctx context.Context, ops []ovsdb.Operation, action string) error {
 	ovs, err := br.getOpenvSwitch(ctx)
 	if err != nil {
 		return err
@@ -1483,27 +1486,27 @@ func (br *OVSBridge) transactAndWaitForConfig(ctx context.Context, ops []ovsdb.O
 }
 
 func (br *OVSBridge) waitForConfig(ctx context.Context, nextCfg int) error {
-	ticker := time.NewTicker(ovsConfigWaitInterval)
-	defer ticker.Stop()
-
 	curCfg := 0
-	for {
+	err := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
+		Duration: ovsConfigWaitInitialInterval,
+		Factor:   ovsConfigWaitBackoffFactor,
+		Steps:    ovsConfigWaitBackoffSteps,
+	}, func(ctx context.Context) (bool, error) {
 		ovs, err := br.getOpenvSwitch(ctx)
 		if err != nil {
-			return err
+			return false, err
 		}
 		curCfg = ovs.CurCfg
-		if curCfg >= nextCfg {
-			return nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("timed out waiting for OVS configuration %d to be applied (cur_cfg=%d): %w",
-				nextCfg, curCfg, ctx.Err())
-		case <-ticker.C:
-		}
+		return curCfg >= nextCfg, nil
+	})
+	if err == nil {
+		return nil
 	}
+	if wait.Interrupted(err) {
+		return fmt.Errorf("timed out waiting for OVS configuration %d to be applied (cur_cfg=%d): %w",
+			nextCfg, curCfg, err)
+	}
+	return err
 }
 
 // extractOVSDBInt converts an OVSDB integer from a raw or typed result. Raw

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -77,6 +77,15 @@ const (
 	portTable        = "Port"
 	interfaceTable   = "Interface"
 
+	// ovs-vswitchd suppresses IDL change alerts for some Port columns, including trunks.
+	// Incrementing next_cfg explicitly asks ovs-vswitchd to reload the configuration.
+	// ovsConfigWaitTimeout is the total budget for the port lookup, OVSDB transaction,
+	// and ovs-vswitchd acknowledgement. It matches the timeout used for OFPort readiness.
+	ovsConfigWaitTimeout = 5 * time.Second
+	// ovsConfigWaitInterval is the interval at which cur_cfg is checked while waiting
+	// for ovs-vswitchd to acknowledge the configuration.
+	ovsConfigWaitInterval = 10 * time.Millisecond
+
 	// Openflow protocol version 1.0.
 	openflowProtoVersion10 = "OpenFlow10"
 	// Openflow protocol version 1.5.
@@ -1219,9 +1228,12 @@ func (br *OVSBridge) GetPortExternalIDs(portName string) (map[string]string, err
 	return maps.Clone(port.ExternalIDs), nil
 }
 
+// SetPortTrunks updates the allowed VLANs on a port and waits for ovs-vswitchd
+// to acknowledge that it applied the configuration. It returns an error if the
+// complete operation does not finish within five seconds.
 func (br *OVSBridge) SetPortTrunks(portName string, vlanSpecs []string) error {
-	// TODO: use ctx from parent context
-	ctx := context.TODO()
+	ctx, cancel := context.WithTimeout(context.Background(), ovsConfigWaitTimeout)
+	defer cancel()
 
 	port, err := br.getPort(ctx, portName, "")
 	if err != nil {
@@ -1238,8 +1250,7 @@ func (br *OVSBridge) SetPortTrunks(portName string, vlanSpecs []string) error {
 		klog.ErrorS(err, "Failed to construct update operation for Port", "port", portName)
 		return err
 	}
-	_, err = br.transact(ctx, ops, "set port trunks")
-	return err
+	return br.transactAndWaitForConfig(ctx, ops, "set port trunks")
 }
 
 func (br *OVSBridge) SetInterfaceMTU(name string, MTU int) error {
@@ -1423,6 +1434,89 @@ func (br *OVSBridge) transact(ctx context.Context, ops []ovsdb.Operation, action
 		return nil, convertOVSDBErrors(opErrs, err)
 	}
 	return results, nil
+}
+
+// transactAndWaitForConfig executes the supplied operations, requests an ovs-vswitchd
+// configuration reload, and waits for ovs-vswitchd to acknowledge it. Some columns,
+// including Port.trunks, are omitted from OVS IDL change alerts and do not trigger a
+// reconfiguration on their own.
+func (br *OVSBridge) transactAndWaitForConfig(ctx context.Context, ops []ovsdb.Operation, action string) error {
+	ovs, err := br.getOpenvSwitch(ctx)
+	if err != nil {
+		return err
+	}
+
+	mOVS := &OpenvSwitch{}
+	reloadOps, err := br.ovsdb.Where(OVSWithUUID(ovs.UUID)).Mutate(mOVS, model.Mutation{
+		Field:   &mOVS.NextCfg,
+		Mutator: ovsdb.MutateOperationAdd,
+		Value:   1,
+	})
+	if err != nil {
+		klog.ErrorS(err, "Failed to construct OVS configuration reload operation", "bridge", br.name)
+		return err
+	}
+	ops = append(ops, reloadOps...)
+	ops = append(ops, newSelectOperation(openvSwitchTable, "_uuid", ovsdb.UUID{GoUUID: ovs.UUID}, "next_cfg"))
+
+	results, err := br.transact(ctx, ops, action)
+	if err != nil {
+		return err
+	}
+	if len(results) == 0 {
+		return fmt.Errorf("unexpected empty OVSDB transaction result after %s", action)
+	}
+	selectResult := results[len(results)-1]
+	if len(selectResult.Rows) == 0 {
+		return fmt.Errorf("unexpected OVSDB transaction result: no Open_vSwitch row returned after %s", action)
+	}
+	nextCfgRaw, ok := selectResult.Rows[0]["next_cfg"]
+	if !ok {
+		return fmt.Errorf("unexpected OVSDB transaction result: next_cfg not returned after %s", action)
+	}
+	nextCfg, ok := extractOVSDBInt(nextCfgRaw)
+	if !ok {
+		return fmt.Errorf("failed to parse next_cfg from OVSDB result after %s", action)
+	}
+
+	return br.waitForConfig(ctx, nextCfg)
+}
+
+func (br *OVSBridge) waitForConfig(ctx context.Context, nextCfg int) error {
+	ticker := time.NewTicker(ovsConfigWaitInterval)
+	defer ticker.Stop()
+
+	curCfg := 0
+	for {
+		ovs, err := br.getOpenvSwitch(ctx)
+		if err != nil {
+			return err
+		}
+		curCfg = ovs.CurCfg
+		if curCfg >= nextCfg {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for OVS configuration %d to be applied (cur_cfg=%d): %w",
+				nextCfg, curCfg, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// extractOVSDBInt converts an OVSDB integer from a raw or typed result. Raw
+// select results are decoded through encoding/json as float64, while typed
+// model values use int.
+func extractOVSDBInt(val interface{}) (int, bool) {
+	if floatVal, ok := extractOVSDBValue[float64](val); ok {
+		return int(floatVal), true
+	}
+	if intVal, ok := extractOVSDBValue[int](val); ok {
+		return intVal, true
+	}
+	return 0, false
 }
 
 // extractOVSDBValue is a generic helper function to parse typed fields from raw

--- a/pkg/ovs/ovsconfig/ovs_client_test.go
+++ b/pkg/ovs/ovsconfig/ovs_client_test.go
@@ -15,12 +15,27 @@
 package ovsconfig
 
 import (
+	"context"
+	"errors"
 	"net"
 	"testing"
+	"testing/synctest"
 
+	"github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 )
+
+type testOVSDBClient struct {
+	client.Client
+	listFn func(context.Context, any) error
+}
+
+func (c *testOVSDBClient) List(ctx context.Context, result any) error {
+	return c.listFn(ctx, result)
+}
 
 func TestBuildPortDataCommon(t *testing.T) {
 	macStr := "9a:23:45:23:22:41"
@@ -100,4 +115,115 @@ func TestBuildPortDataCommon(t *testing.T) {
 		})
 	}
 
+}
+
+func TestWaitForConfig(t *testing.T) {
+	testErr := errors.New("list failed")
+	tests := []struct {
+		name            string
+		curCfgs         []int
+		listErr         error
+		expectedErr     error
+		expectedErrText string
+		expectedCalls   int
+	}{
+		{
+			name:          "configuration already applied",
+			curCfgs:       []int{5},
+			expectedCalls: 1,
+		},
+		{
+			name:          "configuration applied after retry",
+			curCfgs:       []int{4, 5},
+			expectedCalls: 2,
+		},
+		{
+			name:          "OVSDB read fails",
+			listErr:       testErr,
+			expectedErr:   testErr,
+			expectedCalls: 1,
+		},
+		{
+			name:            "configuration wait times out",
+			curCfgs:         []int{4},
+			expectedErr:     context.DeadlineExceeded,
+			expectedErrText: "timed out waiting for OVS configuration 5 to be applied (cur_cfg=4)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				calls := 0
+				ovsdbClient := &testOVSDBClient{
+					listFn: func(_ context.Context, result any) error {
+						calls++
+						if tc.listErr != nil {
+							return tc.listErr
+						}
+						index := min(calls-1, len(tc.curCfgs)-1)
+						ovsList := result.(*[]OpenvSwitch)
+						*ovsList = []OpenvSwitch{{CurCfg: tc.curCfgs[index]}}
+						return nil
+					},
+				}
+				br := &OVSBridge{ovsdb: ovsdbClient}
+				ctx, cancel := context.WithTimeout(t.Context(), ovsConfigWaitTimeout)
+				defer cancel()
+
+				err := br.waitForConfig(ctx, 5)
+				if tc.expectedErr == nil {
+					require.NoError(t, err)
+				} else {
+					require.ErrorIs(t, err, tc.expectedErr)
+				}
+				if tc.expectedErrText != "" {
+					assert.ErrorContains(t, err, tc.expectedErrText)
+				}
+				if tc.expectedCalls > 0 {
+					assert.Equal(t, tc.expectedCalls, calls)
+				}
+			})
+		})
+	}
+}
+
+func TestExtractOVSDBInt(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         any
+		expectedValue int
+		expectedOK    bool
+	}{
+		{
+			name:          "raw JSON value",
+			value:         float64(5),
+			expectedValue: 5,
+			expectedOK:    true,
+		},
+		{
+			name:          "typed model value",
+			value:         5,
+			expectedValue: 5,
+			expectedOK:    true,
+		},
+		{
+			name:          "wrapped raw JSON value",
+			value:         ovsdb.OvsSet{GoSet: []any{float64(5)}},
+			expectedValue: 5,
+			expectedOK:    true,
+		},
+		{
+			name:  "invalid value",
+			value: "5",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, ok := extractOVSDBInt(tc.value)
+			assert.Equal(t, tc.expectedOK, ok)
+			assert.Equal(t, tc.expectedValue, actual)
+		})
+	}
 }

--- a/pkg/ovs/ovsconfig/ovs_schema.go
+++ b/pkg/ovs/ovsconfig/ovs_schema.go
@@ -43,6 +43,8 @@ type OpenvSwitch struct {
 	OvsVersion  *string           `ovsdb:"ovs_version"`
 	OtherConfig map[string]string `ovsdb:"other_config"`
 	Bridges     []string          `ovsdb:"bridges"`
+	CurCfg      int               `ovsdb:"cur_cfg"`
+	NextCfg     int               `ovsdb:"next_cfg"`
 }
 
 type Interface struct {

--- a/test/integration/ovs/ovs_client_test.go
+++ b/test/integration/ovs/ovs_client_test.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"antrea.io/antrea/v2/pkg/ovs/ovsconfig"
+	"antrea.io/antrea/v2/pkg/ovs/ovsctl"
 )
 
 const (
@@ -241,6 +243,84 @@ func TestOVSPortExternalIDs(t *testing.T) {
 	}, 2*time.Second, 50*time.Millisecond, "Partial port updates should not overwrite other mutable fields like Tag")
 
 	deleteAllPorts(t, data.br)
+}
+
+// TestOVSSetPortTrunks verifies that updating Port.trunks is applied to the
+// ovs-vswitchd runtime configuration before SetPortTrunks returns.
+func TestOVSSetPortTrunks(t *testing.T) {
+	data := &testData{}
+	data.setup(t)
+	defer data.teardown(t)
+
+	access15Name := "access15-" + uuid.Must(uuid.NewV4()).String()[:8]
+	access18Name := "access18-" + uuid.Must(uuid.NewV4()).String()[:8]
+	trunkName := "trunk-" + uuid.Must(uuid.NewV4()).String()[:8]
+	testCreatePort(t, data.br, access15Name, "internal", 0)
+	testCreatePort(t, data.br, access18Name, "internal", 0)
+	testCreatePort(t, data.br, trunkName, "internal", 0)
+
+	setPortTag := func(portName string, vlanID int) {
+		port := &ovsconfig.Port{Tag: &vlanID}
+		ops, err := data.ovsdb.Where(&ovsconfig.Port{Name: portName}).Update(port, &port.Tag)
+		require.NoError(t, err)
+		results, err := data.ovsdb.Transact(context.Background(), ops...)
+		require.NoError(t, err)
+		opErrs, err := ovsdb.CheckOperationResults(results, ops)
+		require.NoError(t, err, "Failed to set access VLAN: %v", opErrs)
+	}
+	setPortTag(access15Name, 15)
+	setPortTag(access18Name, 18)
+
+	// The first call also ensures that ovs-vswitchd has loaded the access port
+	// tags set directly above.
+	require.NoError(t, data.br.SetPortTrunks(trunkName, []string{"15"}))
+
+	ovsCtlClient := ovsctl.NewClient(data.br.GetBridgeName())
+	_, err := ovsCtlClient.RunOfctlCmd("add-flow", "priority=0,actions=NORMAL")
+	require.NoError(t, err)
+
+	traceDatapathActions := func(inPort string) string {
+		trace, err := ovsCtlClient.Trace(&ovsctl.TracingRequest{
+			InPort: inPort,
+			SrcMAC: mustParseMAC(t, "00:00:00:00:00:01"),
+			DstMAC: mustParseMAC(t, "ff:ff:ff:ff:ff:ff"),
+			Flow:   "arp",
+		})
+		require.NoError(t, err)
+		for _, line := range strings.Split(trace, "\n") {
+			if strings.HasPrefix(line, "Datapath actions:") {
+				actions := strings.TrimSpace(strings.TrimPrefix(line, "Datapath actions:"))
+				t.Logf("Datapath actions for %s: %s", inPort, actions)
+				return actions
+			}
+		}
+		t.Fatalf("Datapath actions not found in trace output:\n%s", trace)
+		return ""
+	}
+
+	assert.Contains(t, traceDatapathActions(access15Name), "push_vlan(vid=15,")
+	assert.Equal(t, "drop", traceDatapathActions(access18Name))
+
+	var before []ovsconfig.OpenvSwitch
+	require.NoError(t, data.ovsdb.List(context.Background(), &before))
+	require.Len(t, before, 1)
+
+	require.NoError(t, data.br.SetPortTrunks(trunkName, []string{"18"}))
+
+	var after []ovsconfig.OpenvSwitch
+	require.NoError(t, data.ovsdb.List(context.Background(), &after))
+	require.Len(t, after, 1)
+	assert.Greater(t, after[0].NextCfg, before[0].NextCfg)
+	assert.GreaterOrEqual(t, after[0].CurCfg, after[0].NextCfg)
+	assert.Equal(t, "drop", traceDatapathActions(access15Name))
+	assert.Contains(t, traceDatapathActions(access18Name), "push_vlan(vid=18,")
+}
+
+func mustParseMAC(t *testing.T, mac string) net.HardwareAddr {
+	t.Helper()
+	parsed, err := net.ParseMAC(mac)
+	require.NoError(t, err)
+	return parsed
 }
 
 // TestOVSDeletePortIdempotent verifies that calling DeletePort on a non-existent port does not


### PR DESCRIPTION
ovs-vswitchd suppresses IDL alerts for Port.trunks changes. A successful OVSDB transaction can therefore leave the runtime VLAN configuration stale.

Increment Open_vSwitch.next_cfg in the trunk update transaction and wait for cur_cfg to acknowledge the reload. Add integration coverage which verifies the effective VLAN forwarding with ofproto/trace.