### PR TITLE
feat(bgp): support uint32 ASNs for BGP peers and local ASN

### DIFF
--- a/pkg/agent/apis/types.go
+++ b/pkg/agent/apis/types.go
@@ -222,7 +222,7 @@ func (r ServiceExternalIPInfo) SortRows() bool {
 type BGPPolicyResponse struct {
 	BGPPolicyName           string   `json:"name,omitempty"`
 	RouterID                string   `json:"routerID,omitempty"`
-	LocalASN                int32    `json:"localASN,omitempty"`
+	LocalASN                uint32   `json:"localASN,omitempty"`
 	ListenPort              int32    `json:"listenPort,omitempty"`
 	ConfederationIdentifier int32    `json:"confederationIdentifier,omitempty"`
 	MemberASNs              []uint32 `json:"memberASNs,omitempty"`
@@ -239,9 +239,9 @@ func (r BGPPolicyResponse) GetTableRow(maxColumnLength int) []string {
 		confederationIdentifierStr = strconv.Itoa(int(r.ConfederationIdentifier))
 	}
 	for _, memberASN := range r.MemberASNs {
-		memberASNs = append(memberASNs, strconv.Itoa(int(memberASN)))
+		memberASNs = append(memberASNs, strconv.FormatUint(uint64(memberASN), 10))
 	}
-	return []string{r.BGPPolicyName, r.RouterID, strconv.Itoa(int(r.LocalASN)), strconv.Itoa(int(r.ListenPort)),
+	return []string{r.BGPPolicyName, r.RouterID, strconv.FormatUint(uint64(r.LocalASN), 10), strconv.Itoa(int(r.ListenPort)),
 		confederationIdentifierStr, printers.GenerateTableElementWithSummary(memberASNs, maxColumnLength)}
 }
 
@@ -252,7 +252,7 @@ func (r BGPPolicyResponse) SortRows() bool {
 // BGPPeerResponse describes the response struct of bgppeers command.
 type BGPPeerResponse struct {
 	Peer  string `json:"peer,omitempty"`
-	ASN   int32  `json:"asn,omitempty"`
+	ASN   uint32 `json:"asn,omitempty"`
 	State string `json:"state,omitempty"`
 }
 

--- a/pkg/agent/bgp/gobgp/gobgp.go
+++ b/pkg/agent/bgp/gobgp/gobgp.go
@@ -194,7 +194,7 @@ func convertGoBGPPeerToPeerStatus(peer *gobgpapi.Peer) *bgp.PeerStatus {
 	}
 	if conf := peer.GetConf(); conf != nil {
 		peerStatus.Address = conf.GetNeighborAddress()
-		peerStatus.ASN = int32(conf.GetPeerAsn())
+		peerStatus.ASN = conf.GetPeerAsn()
 	}
 	if ebgpMultiHop := peer.GetEbgpMultihop(); ebgpMultiHop != nil {
 		peerStatus.MultihopTTL = int32(ebgpMultiHop.GetMultihopTtl())
@@ -278,7 +278,7 @@ func convertPeerConfigToGoBGPPeer(peerConfig bgp.PeerConfig) (*gobgpapi.Peer, er
 	peer := &gobgpapi.Peer{
 		Conf: &gobgpapi.PeerConf{
 			NeighborAddress: peerConfig.Address,
-			PeerAsn:         uint32(peerConfig.ASN),
+			PeerAsn:         peerConfig.ASN,
 			AuthPassword:    peerConfig.Password,
 		},
 		AfiSafis: []*gobgpapi.AfiSafi{

--- a/pkg/agent/bgp/interface.go
+++ b/pkg/agent/bgp/interface.go
@@ -117,7 +117,7 @@ type PeerConfig struct {
 type PeerStatus struct {
 	Address                    string
 	Port                       int32
-	ASN                        int32
+	ASN                        uint32
 	MultihopTTL                int32
 	GracefulRestartTimeSeconds int32
 	SessionState               SessionState

--- a/pkg/agent/controller/bgp/controller.go
+++ b/pkg/agent/controller/bgp/controller.go
@@ -106,9 +106,9 @@ type bgpPolicyState struct {
 	// The port on which the local BGP server listens.
 	listenPort int32
 	// The AS number used by the local BGP server.
-	localASN int32
-	// The router ID used by the local BGP server.
-	routerID string
+	localASN uint32
+	listenPort int32
+	routerID  string
 	// The confederation config used by the local BGP server.
 	confederationConfig *confederationConfig
 	// routes stores all BGP routes advertised to BGP peers.
@@ -734,7 +734,7 @@ func (c *Controller) getPeerConfigs(peers []v1alpha1.BGPPeer) map[string]bgp.Pee
 	return peerConfigs
 }
 
-func generateBGPPeerKey(address string, asn int32) string {
+func generateBGPPeerKey(address string, asn uint32) string {
 	return fmt.Sprintf("%s-%d", address, asn)
 }
 

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -263,8 +263,9 @@ type BGPPolicySpec struct {
 	// will be effective and enforced; others serve as alternatives.
 	NodeSelector metav1.LabelSelector `json:"nodeSelector"`
 
-	// LocalASN is the AS number used by the BGP process. It accepts values in the range of 1-65535.
-	LocalASN int32 `json:"localASN"`
+	// LocalASN is the AS number used by the BGP process. It accepts values in the range of 1-4294967294.
+	// The value 4294967295 is reserved per RFC7300 and cannot be used.
+	LocalASN uint32 `json:"localASN"`
 
 	// ListenPort is the port on which the BGP process listens, and the default value is 179.
 	ListenPort *int32 `json:"listenPort,omitempty"`
@@ -297,7 +298,7 @@ type Confederation struct {
 	Identifier int32 `json:"identifier,omitempty"`
 
 	// MemberASNs lists the ASNs of other members in the confederation.
-	MemberASNs []int32 `json:"memberASNs,omitempty"`
+	MemberASNs []uint32 `json:"memberASNs,omitempty"`
 }
 
 type ServiceIPType string
@@ -335,7 +336,7 @@ type BGPPeer struct {
 	Port *int32 `json:"port,omitempty"`
 
 	// The AS number of the BGP peer.
-	ASN int32 `json:"asn"`
+	ASN uint32 `json:"asn"`
 
 	// The Time To Live (TTL) value used in BGP packets sent to the BGP peer. The range of the value is from 1 to 255,
 	// and the default value is 1.


### PR DESCRIPTION
## Summary

Updates the ASN field type from int32 to uint32 across BGPPeer, BGPPolicy, and related types to support the full 32-bit ASN range (1-4294967294) per RFC7300. The value 4294967295 is reserved and cannot be used. GoBGP already supports 32-bit ASNs, so this change aligns the Antrea BGP configuration with the underlying library.

## Changes

- : LocalASN, MemberASNs, and BGPPeer.ASN changed from int32 to uint32
- : localASN and generateBGPPeerKey updated to uint32
- : PeerStatus.ASN and GlobalConfig.ASN updated to uint32
- : PeerStatus.ASN and PeerAsn updated to uint32
- : BGPPolicyResponse and BGPPeerResponse ASN fields updated to uint32

Fixes #8311