### PR TITLE
fix secondary network interface recovery

### DIFF
--- a/pkg/agent/secondarynetwork/init_linux.go
+++ b/pkg/agent/secondarynetwork/init_linux.go
@@ -59,6 +59,7 @@ var (
 
 	// Funcs which will be overridden with mock funcs in tests.
 	interfaceByNameFn = net.InterfaceByName
+	renameInterfaceFn = util.RenameInterface
 	// func(bridge, ifName, ifOFPort, externalIDs, mtu) (bridgedName, alreadyExists, error)
 	prepareHostInterfaceConnectionFn = util.PrepareHostInterfaceConnection
 	restoreHostInterfaceConfigFn     = util.RestoreHostInterfaceConfiguration // func(brName, ifName string) error

--- a/pkg/agent/secondarynetwork/init_linux_test.go
+++ b/pkg/agent/secondarynetwork/init_linux_test.go
@@ -171,7 +171,7 @@ func TestConnectPhyInterfacesToOVSBridge(t *testing.T) {
 			ctrl := mock.NewController(t)
 			mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(ctrl)
 
-			mockInterfaceByName(t)
+			mockInterfaceByName(t, nil, []string{nonExistingInterface})
 			if tc.expectedCalls != nil {
 				tc.expectedCalls(mockOVSBridgeClient)
 			}
@@ -709,6 +709,19 @@ func TestReconcileBridge(t *testing.T) {
 			},
 		},
 		{
+			name:       "recovers stale renamed interface with no OVS ports",
+			prevCfg:    bridgeConfig(brOld, eth1),
+			desiredCfg: bridgeConfig(brOld, eth1),
+			expectedCalls: func(old, new *ovsconfigtest.MockOVSBridgeClient) {
+				old.EXPECT().GetPortList().Return([]ovsconfig.OVSPortData{}, nil)
+				old.EXPECT().GetOFPort(eth1+"~").Return(int32(0), client.ErrNotFound)
+				old.EXPECT().CreateUplinkPort(eth1+"~", int32(0), map[string]string{
+					interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaUplink,
+				}).Return("", nil)
+			},
+			wantPrepareCalls: []string{eth1},
+		},
+		{
 			name:       "bridge deleted (desired is nil)",
 			prevCfg:    &agenttypes.OVSBridgeConfig{BridgeName: brOld, PhysicalInterfaces: []agenttypes.PhysicalInterfaceConfig{{Name: eth1}}},
 			desiredCfg: nil,
@@ -949,7 +962,32 @@ func TestReconcileBridge(t *testing.T) {
 			oldMock := ovsconfigtest.NewMockOVSBridgeClient(ctrl)
 			newMock := ovsconfigtest.NewMockOVSBridgeClient(ctrl)
 
-			mockInterfaceByName(t)
+			var gotRenameFrom, gotRenameTo string
+			mockInterfaceByName(t, nil, []string{nonExistingInterface})
+			if tc.name == "recovers stale renamed interface with no OVS ports" {
+				origInterfaceByName := interfaceByNameFn
+				interfaceByNameFn = func(name string) (*net.Interface, error) {
+					if name == eth1 {
+						return nil, errors.New("interface not found")
+					}
+					if name == eth1+"~" {
+						return &net.Interface{Name: name}, nil
+					}
+					return origInterfaceByName(name)
+				}
+				t.Cleanup(func() {
+					interfaceByNameFn = origInterfaceByName
+				})
+				origRenameInterface := renameInterfaceFn
+				renameInterfaceFn = func(from, to string) error {
+					gotRenameFrom = from
+					gotRenameTo = to
+					return nil
+				}
+				t.Cleanup(func() {
+					renameInterfaceFn = origRenameInterface
+				})
+			}
 			mockNewOVSBridgeByName(t, map[string]ovsconfig.OVSBridgeClient{
 				brOld: oldMock,
 				brNew: newMock,
@@ -1022,6 +1060,10 @@ func TestReconcileBridge(t *testing.T) {
 				}
 				assert.Equal(t, tc.wantPrepareCalls, gotPrepareCalls,
 					"unexpected PrepareHostInterfaceConnection calls")
+				if tc.name == "recovers stale renamed interface with no OVS ports" {
+					assert.Equal(t, eth1+"~", gotRenameFrom)
+					assert.Equal(t, eth1, gotRenameTo)
+				}
 			}
 		})
 	}
@@ -1088,7 +1130,7 @@ func TestReconcileBridgeClearsStateBeforeCreatingReplacement(t *testing.T) {
 	ctrl := mock.NewController(t)
 	oldMock := ovsconfigtest.NewMockOVSBridgeClient(ctrl)
 	newMock := ovsconfigtest.NewMockOVSBridgeClient(ctrl)
-	mockInterfaceByName(t)
+	mockInterfaceByName(t, nil, []string{nonExistingInterface})
 
 	createErr := errors.New("create failed")
 
@@ -1202,7 +1244,7 @@ func TestSyncBridgeRetriesDesiredBridgeCreation(t *testing.T) {
 func TestSyncBridgeDeletesDiscoveredBridgeWhenUndesired(t *testing.T) {
 	ctrl := mock.NewController(t)
 	bridgeClient := ovsconfigtest.NewMockOVSBridgeClient(ctrl)
-	mockInterfaceByName(t)
+	mockInterfaceByName(t, nil, []string{nonExistingInterface})
 	mockNewOVSBridgeByName(t, map[string]ovsconfig.OVSBridgeClient{brOld: bridgeClient})
 	mockStartupSecondaryBridge(t, brOld)
 
@@ -1301,7 +1343,7 @@ func TestSyncBridgeReconcilesDiscoveredManagedBridge(t *testing.T) {
 	ctrl := mock.NewController(t)
 	oldMock := ovsconfigtest.NewMockOVSBridgeClient(ctrl)
 
-	mockInterfaceByName(t)
+	mockInterfaceByName(t, nil, []string{nonExistingInterface})
 	mockNewOVSBridgeByName(t, map[string]ovsconfig.OVSBridgeClient{
 		brOld: oldMock,
 	})
@@ -1391,15 +1433,24 @@ func TestSyncBridgeReconcilesStaticBridgeOnANCListError(t *testing.T) {
 	assert.Equal(t, 1, findCalls)
 }
 
-func mockInterfaceByName(t *testing.T) {
+func mockInterfaceByName(t *testing.T, existing []string, missing []string) {
 	t.Helper()
+
 	prevFunc := interfaceByNameFn
 	interfaceByNameFn = func(name string) (*net.Interface, error) {
-		if name == nonExistingInterface {
-			return nil, errors.New("interface not found")
+		for _, n := range existing {
+			if name == n {
+				return &net.Interface{Name: name}, nil
+			}
+		}
+		for _, n := range missing {
+			if name == n {
+				return nil, errors.New("interface not found")
+			}
 		}
 		return nil, nil
 	}
+
 	t.Cleanup(func() { interfaceByNameFn = prevFunc })
 }
 

--- a/pkg/agent/secondarynetwork/init_linux_test.go
+++ b/pkg/agent/secondarynetwork/init_linux_test.go
@@ -722,6 +722,19 @@ func TestReconcileBridge(t *testing.T) {
 			wantPrepareCalls: []string{eth1},
 		},
 		{
+			name:       "does not recover on unexpected interface lookup error",
+			prevCfg:    bridgeConfig(brOld, eth1),
+			desiredCfg: bridgeConfig(brOld, eth1),
+			expectedCalls: func(old, new *ovsconfigtest.MockOVSBridgeClient) {
+				old.EXPECT().GetPortList().Return([]ovsconfig.OVSPortData{}, nil)
+				old.EXPECT().GetOFPort(eth1+"~").Return(int32(0), client.ErrNotFound)
+				old.EXPECT().CreateUplinkPort(eth1+"~", int32(0), map[string]string{
+					interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaUplink,
+				}).Return("", nil)
+			},
+			wantPrepareCalls: []string{eth1},
+		},
+		{
 			name:       "bridge deleted (desired is nil)",
 			prevCfg:    &agenttypes.OVSBridgeConfig{BridgeName: brOld, PhysicalInterfaces: []agenttypes.PhysicalInterfaceConfig{{Name: eth1}}},
 			desiredCfg: nil,
@@ -968,7 +981,11 @@ func TestReconcileBridge(t *testing.T) {
 				origInterfaceByName := interfaceByNameFn
 				interfaceByNameFn = func(name string) (*net.Interface, error) {
 					if name == eth1 {
-						return nil, errors.New("interface not found")
+						return nil, &net.OpError{
+							Op:  "route",
+							Net: "ip+net",
+							Err: errors.New("no such network interface"),
+						}
 					}
 					if name == eth1+"~" {
 						return &net.Interface{Name: name}, nil
@@ -986,6 +1003,20 @@ func TestReconcileBridge(t *testing.T) {
 				}
 				t.Cleanup(func() {
 					renameInterfaceFn = origRenameInterface
+				})
+			} else if tc.name == "does not recover on unexpected interface lookup error" {
+				origInterfaceByName := interfaceByNameFn
+				interfaceByNameFn = func(name string) (*net.Interface, error) {
+					if name == eth1 {
+						return nil, errors.New("interface lookup failed")
+					}
+					if name == eth1+"~" {
+						return &net.Interface{Name: name}, nil
+					}
+					return origInterfaceByName(name)
+				}
+				t.Cleanup(func() {
+					interfaceByNameFn = origInterfaceByName
 				})
 			}
 			mockNewOVSBridgeByName(t, map[string]ovsconfig.OVSBridgeClient{
@@ -1063,6 +1094,9 @@ func TestReconcileBridge(t *testing.T) {
 				if tc.name == "recovers stale renamed interface with no OVS ports" {
 					assert.Equal(t, eth1+"~", gotRenameFrom)
 					assert.Equal(t, eth1, gotRenameTo)
+				} else if tc.name == "does not recover on unexpected interface lookup error" {
+					assert.Empty(t, gotRenameFrom)
+					assert.Empty(t, gotRenameTo)
 				}
 			}
 		})
@@ -1445,10 +1479,14 @@ func mockInterfaceByName(t *testing.T, existing []string, missing []string) {
 		}
 		for _, n := range missing {
 			if name == n {
-				return nil, errors.New("interface not found")
+				return nil, &net.OpError{
+					Op:  "route",
+					Net: "ip+net",
+					Err: errors.New("no such network interface"),
+				}
 			}
 		}
-		return nil, nil
+		return &net.Interface{Name: name}, nil
 	}
 
 	t.Cleanup(func() { interfaceByNameFn = prevFunc })

--- a/pkg/agent/secondarynetwork/ovs_bridge_linux.go
+++ b/pkg/agent/secondarynetwork/ovs_bridge_linux.go
@@ -20,6 +20,7 @@ package secondarynetwork
 import (
 	"errors"
 	"fmt"
+	"net"
 
 	"github.com/ovn-kubernetes/libovsdb/client"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -313,7 +314,7 @@ func prepareBridgePhysicalInterfaces(
 		// kernel interface was renamed but the OVS ports were never created.
 		if _, interfacePortExists := existingPorts[iface.Name]; !interfacePortExists {
 			if _, uplinkPortExists := existingPorts[bridgedName]; !uplinkPortExists {
-				if _, err := interfaceByNameFn(iface.Name); err != nil {
+				if _, err := interfaceByNameFn(iface.Name); err != nil && isInterfaceNotFoundError(err) {
 					if _, err := interfaceByNameFn(bridgedName); err == nil {
 						klog.InfoS("Recovering stale renamed host interface",
 							"bridge", desired.BridgeName,
@@ -387,6 +388,11 @@ func prepareBridgePhysicalInterfaces(
 	}
 
 	return desired.PhysicalInterfaces, nil
+}
+
+func isInterfaceNotFoundError(err error) bool {
+	var opErr *net.OpError
+	return errors.As(err, &opErr) && opErr.Err.Error() == "no such network interface"
 }
 
 // connectPhyInterfacesToOVSBridge connects each physical interface to the OVS

--- a/pkg/agent/secondarynetwork/ovs_bridge_linux.go
+++ b/pkg/agent/secondarynetwork/ovs_bridge_linux.go
@@ -309,6 +309,25 @@ func prepareBridgePhysicalInterfaces(
 	if len(desired.PhysicalInterfaces) == 1 {
 		iface := desired.PhysicalInterfaces[0]
 		bridgedName := util.GenerateUplinkInterfaceName(iface.Name)
+		// Recover from a partially completed host-interface setup where the
+		// kernel interface was renamed but the OVS ports were never created.
+		if _, interfacePortExists := existingPorts[iface.Name]; !interfacePortExists {
+			if _, uplinkPortExists := existingPorts[bridgedName]; !uplinkPortExists {
+				if _, err := interfaceByNameFn(iface.Name); err != nil {
+					if _, err := interfaceByNameFn(bridgedName); err == nil {
+						klog.InfoS("Recovering stale renamed host interface",
+							"bridge", desired.BridgeName,
+							"interface", iface.Name,
+							"uplink", bridgedName,
+						)
+						if err := renameInterfaceFn(bridgedName, iface.Name); err != nil {
+							return nil, fmt.Errorf("failed to restore host interface %s from %s: %w",
+								iface.Name, bridgedName, err)
+						}
+					}
+				}
+			}
+		}
 		if _, exists := existingPorts[bridgedName]; exists {
 			return []agenttypes.PhysicalInterfaceConfig{
 				{Name: bridgedName, AllowedVLANs: iface.AllowedVLANs},


### PR DESCRIPTION
## Summary
Fix recovery of a renamed host interface when reconciling a secondary OVS bridge.
## Problem
When a single physical interface is added to a secondary OVS bridge, Antrea first renames the host interface to its uplink name. For example, `eth1` is renamed to `eth1~`.
There is a window between that rename and the creation of the OVS ports. If reconciliation is interrupted during that window, the rename remains in the kernel but the OVS ports are never created.
On the next reconciliation, Antrea sees that `eth1` is missing and tries to prepare the host interface again, even though `eth1~` is still present. This leaves the interface stuck with the renamed name and reconciliation fails.
## Fix
Before calling `PrepareHostInterfaceConnection`, check for the partially completed state:
* `eth1` is not present in the OVS port list.
* `eth1~` is not present in the OVS port list.
* `eth1` does not exist as a kernel interface.
* `eth1~` does exist as a kernel interface.
When this state is found, rename `eth1~` back to `eth1` and let the existing preparation flow handle the setup from there.
The rename function is also exposed through `renameInterfaceFn` so the recovery path can be tested without actually renaming a host interface.

## Tests
Added a regression test for the case where the interface has already been renamed but no OVS ports were created. The test verifies that reconciliation restores the original interface name and continues creating the uplink port.
Ran:
* `go test ./pkg/agent/secondarynetwork -v`
* `go test ./pkg/agent/secondarynetwork`
* `git diff --check`
All passed.
## Notes
The recovery is limited to the single-interface case, where the uplink name can be derived from the configured interface name.
This follows the proposed direction from the issue, but I'm open to feedback on whether the recovery should live at this reconciliation layer or elsewhere in the host-interface setup flow.

Fixes #8297 
