### PR TITLE
Fix internal NetworkPolicyType constant mismatch for CNP

### DIFF
--- a/pkg/agent/flowexporter/connections/connections_test.go
+++ b/pkg/agent/flowexporter/connections/connections_test.go
@@ -21,11 +21,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"antrea.io/antrea/v2/pkg/agent/flowexporter/connection"
 	"antrea.io/antrea/v2/pkg/agent/flowexporter/utils"
 	"antrea.io/antrea/v2/pkg/agent/types"
+	"antrea.io/antrea/v2/pkg/apis/controlplane"
 	"antrea.io/antrea/v2/pkg/apis/controlplane/v1beta2"
 	queriertest "antrea.io/antrea/v2/pkg/querier/testing"
 	objectstoretest "antrea.io/antrea/v2/pkg/util/objectstore/testing"
@@ -300,4 +302,31 @@ func TestAddEgressNetworkPolicyMetadata(t *testing.T) {
 			assert.Equal(t, tt.expectedRuleAction, tt.conn.EgressNetworkPolicyRuleAction)
 		})
 	}
+}
+
+func TestAddNetworkPolicyMetadataForClusterNetworkPolicy(t *testing.T) {
+	internalRef := &controlplane.NetworkPolicyReference{
+		Type: controlplane.K8sClusterNetworkPolicy,
+		Name: "cnp-allow-web",
+		UID:  "uid-cnp-1",
+	}
+	policyRef := &v1beta2.NetworkPolicyReference{}
+	require.NoError(t, v1beta2.Convert_controlplane_NetworkPolicyReference_To_v1beta2_NetworkPolicyReference(internalRef, policyRef, nil))
+
+	mockCtrl := gomock.NewController(t)
+	mockQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(mockCtrl)
+	mockQuerier.EXPECT().GetRuleByFlowID(uint32(100)).Return(&types.PolicyRule{Name: "ingress-0", PolicyRef: policyRef}).AnyTimes()
+	mockQuerier.EXPECT().GetRuleByFlowID(uint32(200)).Return(&types.PolicyRule{Name: "egress-0", PolicyRef: policyRef}).AnyTimes()
+
+	cs := &connectionStore{networkPolicyQuerier: mockQuerier}
+
+	ingressConn := &connection.Connection{IngressRuleID: 100, Disposition: "Allow"}
+	cs.addIngressNetworkPolicyMetadata(ingressConn)
+	assert.Equal(t, "cnp-allow-web", ingressConn.IngressNetworkPolicyName)
+	assert.Equal(t, utils.PolicyTypeK8sClusterNetworkPolicy, ingressConn.IngressNetworkPolicyType)
+
+	egressConn := &connection.Connection{EgressRuleID: 200, Disposition: "Allow"}
+	cs.addEgressNetworkPolicyMetadata(egressConn)
+	assert.Equal(t, "cnp-allow-web", egressConn.EgressNetworkPolicyName)
+	assert.Equal(t, utils.PolicyTypeK8sClusterNetworkPolicy, egressConn.EgressNetworkPolicyType)
 }

--- a/pkg/apis/controlplane/helper.go
+++ b/pkg/apis/controlplane/helper.go
@@ -17,7 +17,7 @@ package controlplane
 import "fmt"
 
 func (r *NetworkPolicyReference) ToString() string {
-	if r.Type == AntreaClusterNetworkPolicy {
+	if r.Type == AntreaClusterNetworkPolicy || r.Type == K8sClusterNetworkPolicy {
 		return fmt.Sprintf("%s:%s", r.Type, r.Name)
 	}
 	return fmt.Sprintf("%s:%s/%s", r.Type, r.Namespace, r.Name)

--- a/pkg/apis/controlplane/helper_test.go
+++ b/pkg/apis/controlplane/helper_test.go
@@ -106,6 +106,15 @@ func TestNetworkPolicyReferenceToString(t *testing.T) {
 			},
 			out: "AntreaNetworkPolicy:nsA/annpA",
 		},
+		{
+			name: "cnp-ref",
+			inNPRef: &NetworkPolicyReference{
+				Type:      K8sClusterNetworkPolicy,
+				Namespace: "",
+				Name:      "cnpA",
+			},
+			out: "K8sClusterNetworkPolicy:cnpA",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/controlplane/types.go
+++ b/pkg/apis/controlplane/types.go
@@ -202,7 +202,7 @@ const (
 	AntreaNetworkPolicy        NetworkPolicyType = "AntreaNetworkPolicy"
 	AdminNetworkPolicy         NetworkPolicyType = "AdminNetworkPolicy"
 	BaselineAdminNetworkPolicy NetworkPolicyType = "BaselineAdminNetworkPolicy"
-	ClusterNetworkPolicy       NetworkPolicyType = "ClusterNetworkPolicy"
+	K8sClusterNetworkPolicy    NetworkPolicyType = "K8sClusterNetworkPolicy"
 )
 
 type NetworkPolicyReference struct {

--- a/pkg/controller/networkpolicy/clusternetworkpolicy.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy.go
@@ -53,7 +53,7 @@ var (
 
 func getCNPReference(cnp *v1alpha2.ClusterNetworkPolicy) *controlplane.NetworkPolicyReference {
 	return &controlplane.NetworkPolicyReference{
-		Type: controlplane.ClusterNetworkPolicy,
+		Type: controlplane.K8sClusterNetworkPolicy,
 		Name: cnp.Name,
 		UID:  cnp.UID,
 	}
@@ -398,7 +398,7 @@ func (n *NetworkPolicyController) processClusterNetworkPolicy(cnp *v1alpha2.Clus
 		Name:       internalNetworkPolicyKeyFunc(cnp),
 		Generation: cnp.Generation,
 		SourceRef: &controlplane.NetworkPolicyReference{
-			Type: controlplane.ClusterNetworkPolicy,
+			Type: controlplane.K8sClusterNetworkPolicy,
 			Name: cnp.Name,
 			UID:  cnp.UID,
 		},

--- a/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
@@ -96,7 +96,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-1",
 				Name: "uid-1",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-ingress-ns",
 					UID:  "uid-1",
 				},
@@ -153,7 +153,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-2",
 				Name: "uid-2",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-egress-ns",
 					UID:  "uid-2",
 				},
@@ -212,7 +212,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-3",
 				Name: "uid-3",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-ingress-pods",
 					UID:  "uid-3",
 				},
@@ -264,7 +264,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-4",
 				Name: "uid-4",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-egress-net",
 					UID:  "uid-4",
 				},
@@ -315,7 +315,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-nodes",
 				Name: "uid-nodes",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-egress-nodes",
 					UID:  "uid-nodes",
 				},
@@ -370,7 +370,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-fqdn",
 				Name: "uid-fqdn",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-egress-fqdn",
 					UID:  "uid-fqdn",
 				},
@@ -422,7 +422,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-fc1",
 				Name: "uid-fc1",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-unknown-egress-deny",
 					UID:  "uid-fc1",
 				},
@@ -473,7 +473,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-fc2",
 				Name: "uid-fc2",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-unknown-egress-pass",
 					UID:  "uid-fc2",
 				},
@@ -523,7 +523,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-fc3",
 				Name: "uid-fc3",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-unknown-egress-accept",
 					UID:  "uid-fc3",
 				},
@@ -572,7 +572,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-fc4",
 				Name: "uid-fc4",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-unknown-ingress-deny",
 					UID:  "uid-fc4",
 				},
@@ -622,7 +622,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-fc5",
 				Name: "uid-fc5",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-unknown-ingress-accept",
 					UID:  "uid-fc5",
 				},
@@ -673,7 +673,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-fc6",
 				Name: "uid-fc6",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-unknown-ingress-pass",
 					UID:  "uid-fc6",
 				},
@@ -729,7 +729,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 				UID:  "uid-5",
 				Name: "uid-5",
 				SourceRef: &controlplane.NetworkPolicyReference{
-					Type: controlplane.ClusterNetworkPolicy,
+					Type: controlplane.K8sClusterNetworkPolicy,
 					Name: "cnp-multi-in",
 					UID:  "uid-5",
 				},

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -1661,7 +1661,7 @@ func (n *NetworkPolicyController) syncInternalNetworkPolicy(key *controlplane.Ne
 			return nil
 		}
 		newInternalNetworkPolicy, newAppliedToGroups, newAddressGroups = n.processBaselineAdminNetworkPolicy(banp)
-	case controlplane.ClusterNetworkPolicy:
+	case controlplane.K8sClusterNetworkPolicy:
 		cnp, err := n.cnpLister.Get(key.Name)
 		if err != nil || cnp.UID != key.UID {
 			n.deleteInternalNetworkPolicy(internalNetworkPolicyName)


### PR DESCRIPTION
The internal controlplane NetworkPolicyType constant for upstream ClusterNetworkPolicy was "ClusterNetworkPolicy", while its v1beta2 counterpart was "K8sClusterNetworkPolicy". The two are converted with a plain string cast, so the mismatch meant agents never recognized traffic matched by a ClusterNetworkPolicy, and exported ingress/egressNetworkPolicyType as 0 (Unspecified) instead of 4 (K8sCNP) in flow records.

Other impacts other than flow exporter:
- SOURCE column of `antctl get networkpolicy`, Traceflow observations agent logs shows `ClusterNetworkPolicy:/<name>` instead of  `K8sClusterNetworkPolicy:<name>`.
-  `GET /networkpolicies?type=K8SCNP` on the agent will return no results.

Rename the internal constant to match v1beta2 and update its usages.