### PR TITLE
fix: prevent bundleStream DeepCopyObject panic

### DIFF
--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -376,7 +376,7 @@ func (b *bundleStream) GetObjectKind() schema.ObjectKind {
 }
 
 func (b *bundleStream) DeepCopyObject() runtime.Object {
-	panic("bundleStream does not have DeepCopyObject")
+	return &bundleStream{cache: b.cache}
 }
 
 func (b *bundleStream) InputStream(_ context.Context, _, _ string) (stream io.ReadCloser, flush bool, mimeType string, err error) {

--- a/pkg/apiserver/registry/system/supportbundle/rest_test.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest_test.go
@@ -389,3 +389,17 @@ func TestAgentStorageFailure(t *testing.T) {
 	assert.Equal(t, errors.NewNotFound(system.Resource("supportBundle"), modeController), err)
 	assert.False(t, deleted)
 }
+func TestBundleStreamDeepCopyObject(t *testing.T) {
+	stream := &bundleStream{
+		cache: &system.SupportBundle{
+			ObjectMeta: metav1.ObjectMeta{Name: modeController},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		copied := stream.DeepCopyObject()
+		copiedStream, ok := copied.(*bundleStream)
+		require.True(t, ok)
+		assert.Equal(t, stream.cache, copiedStream.cache)
+	})
+}


### PR DESCRIPTION
## Summary

* `bundleStream` implements `runtime.Object`, but its `DeepCopyObject()` method unconditionally called `panic()`.
* This meant any code path that attempted to treat `bundleStream` as a Kubernetes `runtime.Object` could crash instead of safely returning an object copy.
* We replaced the unconditional panic with a safe shallow-copy implementation that returns a new `bundleStream` while preserving its underlying `cache`.
* We added a regression test to reproduce the problematic `DeepCopyObject()` path and verify that it no longer panics and returns a valid `*bundleStream`.

## How the Issue Was Solved

1. Identified the root cause in `pkg/apiserver/registry/system/supportbundle/rest.go`, where `bundleStream.DeepCopyObject()` was explicitly panicking.
2. Added a regression test first to confirm the existing implementation failed because of the panic.
3. Implemented `DeepCopyObject()` using a shallow copy:

   ```go
   return &bundleStream{cache: b.cache}
   ```
4. Re-ran the regression test and confirmed that the panic was resolved.
5. Ran the complete support bundle package test suite to ensure the change did not introduce regressions.
6. Ran `git diff --check` to verify that the patch had no formatting or whitespace issues.

## Validation

* `go test ./pkg/apiserver/registry/system/supportbundle/...`
* `git diff --check`

Fixes antrea-io/antrea#8160
